### PR TITLE
Add handling for BigInts for autoarguments and finishing

### DIFF
--- a/elrond-wasm/src/io/arg_loader_endpoint.rs
+++ b/elrond-wasm/src/io/arg_loader_endpoint.rs
@@ -11,9 +11,12 @@ where
 {
     // the compiler is smart enough to evaluate this match at compile time
     match T::TYPE_INFO {
+        TypeInfo::BigInt => {
+            let big_int_arg = api.get_argument_big_int(index);
+            let cast_big_int: T = unsafe { core::mem::transmute_copy(&big_int_arg) };
+            cast_big_int
+        },
         TypeInfo::BigUint => {
-            // self must be of type BigUint
-            // performing a forceful cast
             let big_uint_arg = api.get_argument_big_uint(index);
             let cast_big_uint: T = unsafe { core::mem::transmute_copy(&big_uint_arg) };
             cast_big_uint

--- a/elrond-wasm/src/io/finish.rs
+++ b/elrond-wasm/src/io/finish.rs
@@ -23,9 +23,11 @@ where
         // the compiler is smart enough to evaluate this match at compile time
         match T::TYPE_INFO {
             TypeInfo::Unit => {},
-			TypeInfo::BigUint => {
-                // self must be of type BigUint
-                // performing a forceful cast
+            TypeInfo::BigInt => {
+                let cast_big_int: &BigInt = unsafe { &*(self as *const T as *const BigInt) };
+                api.finish_big_int(cast_big_int);
+            },
+            TypeInfo::BigUint => {
                 let cast_big_uint: &BigUint = unsafe { &*(self as *const T as *const BigUint) };
                 api.finish_big_uint(cast_big_uint);
             },


### PR DESCRIPTION
Add cases for `BigInt` to `load_single_arg()` and to `EndpointResult::finish()`.