### PR TITLE
Make build script parametric

### DIFF
--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -4,8 +4,9 @@
 
 ### EXAMPLES ###
 
+export RUSTFLAGS=${RUSTFLAGS-'-C link-arg=-s'}
+
 cd examples/adder/wasm
-RUSTFLAGS='-C link-arg=-s' \
 cargo build --target=wasm32-unknown-unknown --release
 cd ..
 mkdir -p output
@@ -13,7 +14,6 @@ cp wasm/target/wasm32-unknown-unknown/release/adder_wasm.wasm output/adder.wasm
 cd ../..
 
 cd examples/crypto-bubbles/wasm
-RUSTFLAGS='-C link-arg=-s' \
 cargo build --target=wasm32-unknown-unknown --release
 cd ..
 mkdir -p output
@@ -21,7 +21,6 @@ cp wasm/target/wasm32-unknown-unknown/release/crypto_bubbles_wasm.wasm output/cr
 cd ../..
 
 cd examples/factorial/wasm
-RUSTFLAGS='-C link-arg=-s' \
 cargo build --target=wasm32-unknown-unknown --release
 cd ..
 mkdir -p output
@@ -29,7 +28,6 @@ cp wasm/target/wasm32-unknown-unknown/release/factorial_wasm.wasm output/factori
 cd ../..
 
 cd examples/simple-erc20/wasm
-RUSTFLAGS='-C link-arg=-s' \
 cargo build --target=wasm32-unknown-unknown --release
 cd ..
 mkdir -p output
@@ -40,7 +38,6 @@ cd ../..
 ### TEST CONTRACTS ###
 
 cd test-contracts/basic-features/wasm
-RUSTFLAGS='-C link-arg=-s' \
 cargo build --target=wasm32-unknown-unknown --release
 cd ..
 mkdir -p output
@@ -48,7 +45,6 @@ cp wasm/target/wasm32-unknown-unknown/release/basic_features_wasm.wasm output/fe
 cd ../..
 
 cd test-contracts/async-alice/wasm
-RUSTFLAGS='-C link-arg=-s' \
 cargo build --target=wasm32-unknown-unknown --release
 cd ..
 mkdir -p output
@@ -56,7 +52,6 @@ cp wasm/target/wasm32-unknown-unknown/release/async_alice_wasm.wasm output/alice
 cd ../..
 
 cd test-contracts/async-bob/wasm
-RUSTFLAGS='-C link-arg=-s' \
 cargo build --target=wasm32-unknown-unknown --release
 cd ..
 mkdir -p output


### PR DESCRIPTION
This update allows us to pass a `RUSTFLAGS` value to the build script without it being overridden. It defaults to the same value as before, which is that for an optimized build.