### PR TITLE
Adjust examples (for erdpy templates)

### DIFF
--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -10,10 +10,19 @@ path = "src/lib.rs"
 [features]
 wasm-output-mode = ["elrond-wasm-node"]
 
-[dependencies]
-elrond-wasm = { version = "0.7.1", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.7.1", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.7.1", path = "../../elrond-wasm-node", optional = true }
+[dependencies.elrond-wasm]
+version = "0.7.1"
+path = "../../elrond-wasm"
 
-[dev-dependencies]
-elrond-wasm-debug = { version = "0.7.1", path = "../../elrond-wasm-debug" }
+[dependencies.elrond-wasm-derive]
+version = "0.7.1"
+path = "../../elrond-wasm-derive"
+
+[dependencies.elrond-wasm-node]
+version = "0.7.1"
+path = "../../elrond-wasm-node"
+optional = true
+
+[dev-dependencies.elrond-wasm-debug]
+version = "0.7.1"
+path = "../../elrond-wasm-debug"

--- a/examples/adder/wasm/Cargo.toml
+++ b/examples/adder/wasm/Cargo.toml
@@ -14,8 +14,14 @@ lto = true
 debug = false
 panic = "abort"
 
-[dependencies]
-adder = { path = "..", features=["wasm-output-mode"]}
-elrond-wasm-output = { version = "0.7.1", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
+[dependencies.adder]
+path = ".."
+features = ["wasm-output-mode"]
+default-features = false
+
+[dependencies.elrond-wasm-output]
+version = "0.7.1"
+path = "../../../elrond-wasm-output"
+features = ["wasm-output-mode"]
 
 [workspace]

--- a/examples/adder/wasm/src/lib.rs
+++ b/examples/adder/wasm/src/lib.rs
@@ -1,4 +1,3 @@
-
 #![no_std]
 
 pub use adder::*;

--- a/examples/crypto-bubbles/Cargo.toml
+++ b/examples/crypto-bubbles/Cargo.toml
@@ -10,10 +10,19 @@ path = "src/lib.rs"
 [features]
 wasm-output-mode = ["elrond-wasm-node"]
 
-[dependencies]
-elrond-wasm = { version = "0.7.1", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.7.1", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.7.1", path = "../../elrond-wasm-node", optional = true }
+[dependencies.elrond-wasm]
+version = "0.7.1"
+path = "../../elrond-wasm"
 
-[dev-dependencies]
-elrond-wasm-debug = { version = "0.7.1", path = "../../elrond-wasm-debug" }
+[dependencies.elrond-wasm-derive]
+version = "0.7.1"
+path = "../../elrond-wasm-derive"
+
+[dependencies.elrond-wasm-node]
+version = "0.7.1"
+path = "../../elrond-wasm-node"
+optional = true
+
+[dev-dependencies.elrond-wasm-debug]
+version = "0.7.1"
+path = "../../elrond-wasm-debug"

--- a/examples/crypto-bubbles/wasm/Cargo.toml
+++ b/examples/crypto-bubbles/wasm/Cargo.toml
@@ -14,8 +14,14 @@ lto = true
 debug = false
 panic = "abort"
 
-[dependencies]
-crypto-bubbles = { path = "..", features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.7.1", path = "../../../elrond-wasm-output", features=["wasm-output-mode"] }
+[dependencies.crypto-bubbles]
+path = ".."
+features = ["wasm-output-mode"]
+default-features = false
+
+[dependencies.elrond-wasm-output]
+version = "0.7.1"
+path = "../../../elrond-wasm-output"
+features = ["wasm-output-mode"]
 
 [workspace]

--- a/examples/crypto-bubbles/wasm/src/lib.rs
+++ b/examples/crypto-bubbles/wasm/src/lib.rs
@@ -1,4 +1,3 @@
-
 #![no_std]
 
 pub use crypto_bubbles::*;

--- a/examples/factorial/Cargo.toml
+++ b/examples/factorial/Cargo.toml
@@ -10,10 +10,19 @@ path = "src/lib.rs"
 [features]
 wasm-output-mode = ["elrond-wasm-node"]
 
-[dependencies]
-elrond-wasm = { version = "0.7.1", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.7.1", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.7.1", path = "../../elrond-wasm-node", optional = true }
+[dependencies.elrond-wasm]
+version = "0.7.1"
+path = "../../elrond-wasm"
 
-[dev-dependencies]
-elrond-wasm-debug = { version = "0.7.1", path = "../../elrond-wasm-debug" }
+[dependencies.elrond-wasm-derive]
+version = "0.7.1"
+path = "../../elrond-wasm-derive"
+
+[dependencies.elrond-wasm-node]
+version = "0.7.1"
+path = "../../elrond-wasm-node"
+optional = true
+
+[dev-dependencies.elrond-wasm-debug]
+version = "0.7.1"
+path = "../../elrond-wasm-debug"

--- a/examples/factorial/wasm/Cargo.toml
+++ b/examples/factorial/wasm/Cargo.toml
@@ -14,8 +14,14 @@ lto = true
 debug = false
 panic = "abort"
 
-[dependencies]
-factorial = { path = "..", features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.7.1", path = "../../../elrond-wasm-output", features=["wasm-output-mode"] }
+[dependencies.factorial]
+path = ".."
+features = ["wasm-output-mode"]
+default-features = false
+
+[dependencies.elrond-wasm-output]
+version = "0.7.1"
+path = "../../../elrond-wasm-output"
+features = ["wasm-output-mode"]
 
 [workspace]

--- a/examples/factorial/wasm/src/lib.rs
+++ b/examples/factorial/wasm/src/lib.rs
@@ -1,4 +1,3 @@
-
 #![no_std]
 
 pub use factorial::*;

--- a/examples/simple-erc20/Cargo.toml
+++ b/examples/simple-erc20/Cargo.toml
@@ -10,10 +10,19 @@ path = "src/lib.rs"
 [features]
 wasm-output-mode = ["elrond-wasm-node"]
 
-[dependencies]
-elrond-wasm = { version = "0.7.1", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.7.1", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.7.1", path = "../../elrond-wasm-node", optional = true }
+[dependencies.elrond-wasm]
+version = "0.7.1"
+path = "../../elrond-wasm"
 
-[dev-dependencies]
-elrond-wasm-debug = { version = "0.7.1", path = "../../elrond-wasm-debug" }
+[dependencies.elrond-wasm-derive]
+version = "0.7.1"
+path = "../../elrond-wasm-derive"
+
+[dependencies.elrond-wasm-node]
+version = "0.7.1"
+path = "../../elrond-wasm-node"
+optional = true
+
+[dev-dependencies.elrond-wasm-debug]
+version = "0.7.1"
+path = "../../elrond-wasm-debug"

--- a/examples/simple-erc20/wasm/Cargo.toml
+++ b/examples/simple-erc20/wasm/Cargo.toml
@@ -14,8 +14,14 @@ lto = true
 debug = false
 panic = "abort"
 
-[dependencies]
-simple-erc20 = { path = "..", features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.7.1", path = "../../../elrond-wasm-output", features=["wasm-output-mode"] }
+[dependencies.simple-erc20]
+path = ".."
+features = ["wasm-output-mode"]
+default-features = false
+
+[dependencies.elrond-wasm-output]
+version = "0.7.1"
+path = "../../../elrond-wasm-output"
+features = ["wasm-output-mode"]
 
 [workspace]

--- a/examples/simple-erc20/wasm/src/lib.rs
+++ b/examples/simple-erc20/wasm/src/lib.rs
@@ -1,4 +1,3 @@
-
 #![no_std]
 
 pub use simple_erc20::*;


### PR DESCRIPTION
Make minor adjustments to all the contracts in `examples`, to improve their usage as templates for `erdpy contract new`.