### PR TITLE
Wasm Shrink 3 

### DIFF
--- a/elrond-wasm-debug/src/ext_mock.rs
+++ b/elrond-wasm-debug/src/ext_mock.rs
@@ -131,15 +131,12 @@ impl TxOutput {
         }
     }
 
-    pub fn from_panic_string(panic_string: &str) -> Self {
-        let mut message = b"panic occurred: ".to_vec();
-        message.extend_from_slice(panic_string.as_bytes());
-
+    pub fn from_panic_string(_: &str) -> Self {
         TxOutput {
             contract_storage: HashMap::new(),
             result: TxResult {
                 result_status: 4,
-                result_message: message,
+                result_message: b"panic occurred".to_vec(),
                 result_values: Vec::new(),
             },
             send_balance_list: Vec::new(),

--- a/elrond-wasm-output/Cargo.toml
+++ b/elrond-wasm-output/Cargo.toml
@@ -14,7 +14,14 @@ keywords = ["elrond", "wasm", "webassembly", "blockchain", "contract"]
 categories = ["no-std", "wasm", "cryptography::cryptocurrencies", "development-tools::ffi"]
 
 [features]
-wasm-output-mode = [] # crate functionality can be turned off, but just for running the framework tests
+# crate functionality can be turned off
+# is only turned off when running the framework tests
+wasm-output-mode = [] 
+
+# only provide panic messages if so configured
+# they add a lot of bloat to the final bytecode,
+# so only use them if you really need to learn about a certain panic occuring at some point
+panic-message = [] 
 
 [dependencies]
 elrond-wasm-node = { version = "0.8.0", path = "../elrond-wasm-node" }

--- a/elrond-wasm-output/src/lib.rs
+++ b/elrond-wasm-output/src/lib.rs
@@ -57,18 +57,24 @@ fn alloc_error_handler(_layout: alloc::alloc::Layout) -> ! {
 //     },
 // }
 
-#[cfg(feature = "wasm-output-mode")]
+#[cfg(all(feature = "wasm-output-mode", feature = "panic-message"))]
 #[panic_handler]
-fn panic_fmt(info: &core::panic::PanicInfo) -> ! {
+fn panic_fmt(panic_info: &core::panic::PanicInfo) -> ! {
     use alloc::string::String;
     let panic_msg =
-        if let Some(s) = info.message() {
+        if let Some(s) = panic_info.message() {
             format!("panic occurred: {:?}", s)
         } else {
             String::from("unknown panic occurred")
         };
 
     elrond_wasm_node::ext_error::signal_error(panic_msg.as_bytes())
+}
+
+#[cfg(all(feature = "wasm-output-mode", not(feature = "panic-message")))]
+#[panic_handler]
+fn panic_fmt(_: &core::panic::PanicInfo) -> ! {
+    elrond_wasm_node::ext_error::signal_error(&b"panic occured"[..])
 }
 
 #[cfg(feature = "wasm-output-mode")]

--- a/elrond-wasm-output/src/lib.rs
+++ b/elrond-wasm-output/src/lib.rs
@@ -74,7 +74,7 @@ fn panic_fmt(panic_info: &core::panic::PanicInfo) -> ! {
 #[cfg(all(feature = "wasm-output-mode", not(feature = "panic-message")))]
 #[panic_handler]
 fn panic_fmt(_: &core::panic::PanicInfo) -> ! {
-    elrond_wasm_node::ext_error::signal_error(&b"panic occured"[..])
+    elrond_wasm_node::ext_error::signal_error(&b"panic occurred"[..])
 }
 
 #[cfg(feature = "wasm-output-mode")]

--- a/test-contracts/basic-features/mandos/panic.scen.json
+++ b/test-contracts/basic-features/mandos/panic.scen.json
@@ -33,7 +33,7 @@
             "expect": {
                 "out": [],
                 "status": "0x04",
-                "message": "str:panic occurred: example panic message",
+                "message": "str:panic occurred",
                 "logs": [],
                 "gas": "*",
                 "refund": "*"

--- a/test-contracts/basic-features/wasm/Cargo.toml
+++ b/test-contracts/basic-features/wasm/Cargo.toml
@@ -22,8 +22,6 @@ default-features = false
 [dependencies.elrond-wasm-output]
 version = "0.8.0"
 path = "../../../elrond-wasm-output"
-features = ["wasm-output-mode", "panic-message"]
-
-
+features = ["wasm-output-mode"]
 
 [workspace]

--- a/test-contracts/basic-features/wasm/Cargo.toml
+++ b/test-contracts/basic-features/wasm/Cargo.toml
@@ -14,8 +14,16 @@ lto = true
 debug = false
 panic = "abort"
 
-[dependencies]
-basic-features = { path = "..", features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.8.0", path = "../../../elrond-wasm-output", features=["wasm-output-mode"] }
+[dependencies.basic-features]
+path = ".."
+features = ["wasm-output-mode"]
+default-features = false
+
+[dependencies.elrond-wasm-output]
+version = "0.8.0"
+path = "../../../elrond-wasm-output"
+features = ["wasm-output-mode", "panic-message"]
+
+
 
 [workspace]


### PR DESCRIPTION
Panic messages are off by default. Can be activated in times of need.

This seems to help a lot with code size.