### PR TITLE
Wasm shrink - "fast exit" serializer strategy

### DIFF
--- a/elrond-codec/Cargo.toml
+++ b/elrond-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-codec"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]

--- a/elrond-codec/src/lib.rs
+++ b/elrond-codec/src/lib.rs
@@ -91,8 +91,8 @@ pub mod test_struct {
     }
 
     impl TopDecode for Test {
-        fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-            top_decode_from_nested(input, f)
+        fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+            dep_decode_from_byte_slice(input.get_slice_u8())
         }
     }
 
@@ -148,8 +148,8 @@ pub mod test_struct {
     }
 
     impl TopDecode for E {
-        fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-            top_decode_from_nested(input, f)
+        fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+            dep_decode_from_byte_slice(input.get_slice_u8())
         }
     }
 
@@ -179,8 +179,8 @@ pub mod test_struct {
     }
 
     impl TopDecode for WrappedArray {
-        fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-            top_decode_from_nested(input, f)
+        fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+            dep_decode_from_byte_slice(input.get_slice_u8())
         }
     }
 }
@@ -199,7 +199,7 @@ pub mod tests {
         V: TopEncode + TopDecode + PartialEq + Debug + 'static,
     {
         let serialized_bytes = top_encode_to_vec(&element).unwrap();
-        let deserialized = V::top_decode(&serialized_bytes[..], |res| res.unwrap());
+        let deserialized = V::top_decode(&serialized_bytes[..]).unwrap();
         assert_eq!(deserialized, element);
     }
 
@@ -268,7 +268,7 @@ pub mod tests {
         assert_eq!(serialized_bytes, expected_bytes);
 
         // deserialize
-        let deserialized = <[i32; 16384]>::top_decode(&serialized_bytes[..], |res| res.unwrap());
+        let deserialized = <[i32; 16384]>::top_decode(&serialized_bytes[..]).unwrap();
         for i in 0..16384 {
             assert_eq!(deserialized[i], 7i32);
         }

--- a/elrond-codec/src/lib.rs
+++ b/elrond-codec/src/lib.rs
@@ -106,6 +106,10 @@ pub mod test_struct {
         fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
             top_decode_from_nested(input)
         }
+
+        fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+            top_decode_from_nested_or_exit(input, c, exit)
+        }
     }
 
     #[derive(PartialEq, Clone, Debug)]
@@ -180,6 +184,10 @@ pub mod test_struct {
         fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
             top_decode_from_nested(input)
         }
+
+        fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+            top_decode_from_nested_or_exit(input, c, exit)
+        }
     }
 
     #[derive(PartialEq, Debug, Clone, Copy)]
@@ -218,6 +226,10 @@ pub mod test_struct {
     impl TopDecode for WrappedArray {
         fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
             top_decode_from_nested(input)
+        }
+
+        fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+            top_decode_from_nested_or_exit(input, c, exit)
         }
     }
 }

--- a/elrond-codec/src/lib.rs
+++ b/elrond-codec/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(never_type)]
 
 extern crate alloc;
 

--- a/elrond-codec/src/lib.rs
+++ b/elrond-codec/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(never_type)]
 
 extern crate alloc;
 
@@ -91,8 +92,8 @@ pub mod test_struct {
     }
 
     impl TopDecode for Test {
-        fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-            dep_decode_from_byte_slice(input.get_slice_u8())
+        fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+            top_decode_from_nested(input)
         }
     }
 
@@ -148,8 +149,8 @@ pub mod test_struct {
     }
 
     impl TopDecode for E {
-        fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-            dep_decode_from_byte_slice(input.get_slice_u8())
+        fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+            top_decode_from_nested(input)
         }
     }
 
@@ -179,8 +180,8 @@ pub mod test_struct {
     }
 
     impl TopDecode for WrappedArray {
-        fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-            dep_decode_from_byte_slice(input.get_slice_u8())
+        fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+            top_decode_from_nested(input)
         }
     }
 }

--- a/elrond-codec/src/lib.rs
+++ b/elrond-codec/src/lib.rs
@@ -262,7 +262,7 @@ pub mod test_struct {
 pub mod tests {
     use super::*;
     use super::test_struct::*;
-    use crate::test_util::ser_deser_ok;
+    use crate::test_util::{ser_deser_ok, check_top_encode, check_top_decode};
     use core::fmt::Debug;
     use alloc::vec::Vec;
     use core::num::NonZeroUsize;
@@ -271,8 +271,8 @@ pub mod tests {
     where
         V: TopEncode + TopDecode + PartialEq + Debug + 'static,
     {
-        let serialized_bytes = top_encode_to_vec(&element).unwrap();
-        let deserialized = V::top_decode(&serialized_bytes[..]).unwrap();
+        let serialized_bytes = check_top_encode(&element);
+        let deserialized: V = check_top_decode::<V>(&serialized_bytes[..]);
         assert_eq!(deserialized, element);
     }
 
@@ -337,7 +337,7 @@ pub mod tests {
         }
 
         // serialize
-        let serialized_bytes = top_encode_to_vec(&arr).unwrap();
+        let serialized_bytes = check_top_encode(&arr);
         assert_eq!(serialized_bytes, expected_bytes);
 
         // deserialize

--- a/elrond-codec/src/lib.rs
+++ b/elrond-codec/src/lib.rs
@@ -81,11 +81,11 @@ pub mod test_struct {
     }
     
     impl NestedDecode for Test {
-        fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
             Ok(Test{
-                int: u16::dep_decode_to(input)?,
-                seq: Vec::<u8>::dep_decode_to(input)?,
-                another_byte: u8::dep_decode_to(input)?,
+                int: u16::dep_decode(input)?,
+                seq: Vec::<u8>::dep_decode(input)?,
+                another_byte: u8::dep_decode(input)?,
             })
         }
     }
@@ -136,12 +136,12 @@ pub mod test_struct {
     }
     
     impl NestedDecode for E {
-        fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-            match u32::dep_decode_to(input)? {
+        fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+            match u32::dep_decode(input)? {
                 0 => Ok(E::Unit),
-                1 => Ok(E::Newtype(u32::dep_decode_to(input)?)),
-                2 => Ok(E::Tuple(u32::dep_decode_to(input)?, u32::dep_decode_to(input)?)),
-                3 => Ok(E::Struct{ a: u32::dep_decode_to(input)? }),
+                1 => Ok(E::Newtype(u32::dep_decode(input)?)),
+                2 => Ok(E::Tuple(u32::dep_decode(input)?, u32::dep_decode(input)?)),
+                3 => Ok(E::Struct{ a: u32::dep_decode(input)? }),
                 _ => Err(DecodeError::INVALID_VALUE),
             }
         }
@@ -171,7 +171,7 @@ pub mod test_struct {
     }
     
     impl NestedDecode for WrappedArray {
-        fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
             let mut arr = [0u8; 5];
             input.read_into(&mut arr)?;
             Ok(WrappedArray(arr))

--- a/elrond-codec/src/nested_de.rs
+++ b/elrond-codec/src/nested_de.rs
@@ -338,7 +338,8 @@ impl NestedDecode for NonZeroUsize {
 #[cfg(test)]
 mod tests {
     use super::*;
-	use super::super::test_struct::*;
+    use super::super::test_struct::*;
+    use crate::test_util::check_dep_decode;
     use core::fmt::Debug;
 
     fn deser_ok<V>(element: V, bytes: &[u8])
@@ -346,7 +347,7 @@ mod tests {
         V: NestedDecode + PartialEq + Debug + 'static,
     {
         let input = bytes.to_vec();
-        let deserialized: V = V::dep_decode(&mut &input[..]).unwrap();
+        let deserialized: V = check_dep_decode::<V>(&input[..]);
         assert_eq!(deserialized, element);
     }
 

--- a/elrond-codec/src/nested_de.rs
+++ b/elrond-codec/src/nested_de.rs
@@ -61,7 +61,6 @@ impl NestedDecode for () {
     }
     
     fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(_: &mut I, _: ExitCtx, _: fn(ExitCtx, DecodeError) -> !) -> Self {
-        ()
     }
 }
 

--- a/elrond-codec/src/nested_de.rs
+++ b/elrond-codec/src/nested_de.rs
@@ -18,14 +18,7 @@ pub trait NestedDecode: Sized {
     /// Attempt to deserialise the value from input,
     /// using the format of an object nested inside another structure.
     /// In case of success returns the deserialized value and the number of bytes consumed during the operation.
-    fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: &mut I, f: F) -> R {
-        f(Self::dep_decode_to(input))
-    }
-
-    #[inline]
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        Self::dep_decode(input, |res| res)
-    }
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError>;
 }
 
 /// Convenience method, to avoid having to specify type when calling `dep_decode`.
@@ -34,33 +27,32 @@ pub trait NestedDecode: Sized {
 /// The input doesn't need to be mutable because we are not changing the underlying data.
 pub fn dep_decode_from_byte_slice<D: NestedDecode>(input: &[u8]) -> Result<D, DecodeError> {
     let mut_slice = &mut &*input;
-    let result = D::dep_decode_to(mut_slice)?;
+    let result = D::dep_decode(mut_slice);
     if !mut_slice.is_empty() {
         return Err(DecodeError::INPUT_TOO_LONG);
     }
-    Ok(result)
+    result
 }
 
 impl NestedDecode for () {
     const TYPE_INFO: TypeInfo = TypeInfo::Unit;
 
-	fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(_input: &mut I, f: F) -> R {
-		f(Ok(()))
+	fn dep_decode<I: NestedDecodeInput>(_: &mut I) -> Result<(), DecodeError> {
+		Ok(())
 	}
 }
 
 impl NestedDecode for u8 {
     const TYPE_INFO: TypeInfo = TypeInfo::U8;
     
-    fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: &mut I, f: F) -> R {
-        f(input.read_byte())
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        input.read_byte()
     }
 }
 
-impl<T: NestedDecode> NestedDecode for Vec<T> {
-    #[inline(never)]
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        let size = usize::dep_decode_to(input)?;
+impl<T: NestedDecode> NestedDecode for Vec<T> { 
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        let size = usize::dep_decode(input)?;
         match T::TYPE_INFO {
 			TypeInfo::U8 => {
                 let bytes = input.read_slice(size)?;
@@ -71,7 +63,7 @@ impl<T: NestedDecode> NestedDecode for Vec<T> {
 			_ => {
                 let mut result: Vec<T> = Vec::with_capacity(size);
 				for _ in 0..size {
-                    result.push(T::dep_decode_to(input)?);
+                    result.push(T::dep_decode(input)?);
                 }
                 Ok(result)
 			}
@@ -84,12 +76,10 @@ macro_rules! decode_num_unsigned {
         impl NestedDecode for $ty {
             const TYPE_INFO: TypeInfo = $type_info;
             
-            #[inline(never)]
-            fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: &mut I, f: F) -> R {
-                match input.read_slice($num_bytes) {
-                    Ok(bytes) => f(Ok(bytes_to_number(bytes, false) as $ty)),
-                    Err(e) => f(Err(e)),
-                }
+            fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+                let bytes = input.read_slice($num_bytes)?;
+                let num = bytes_to_number(bytes, false) as $ty;
+                Ok(num)
             }
         }
     }
@@ -105,12 +95,10 @@ macro_rules! decode_num_signed {
         impl NestedDecode for $ty {
             const TYPE_INFO: TypeInfo = $type_info;
             
-            #[inline(never)]
-            fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: &mut I, f: F) -> R {
-                match input.read_slice($num_bytes) {
-                    Ok(bytes) => f(Ok(bytes_to_number(bytes, true) as $ty)),
-                    Err(e) => f(Err(e)),
-                }
+            fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+                let bytes = input.read_slice($num_bytes)?;
+                let num = bytes_to_number(bytes, true) as $ty;
+                Ok(num)
             }
         }
     }
@@ -125,33 +113,28 @@ decode_num_signed!(i64, 8, TypeInfo::I64);
 impl NestedDecode for bool {
     const TYPE_INFO: TypeInfo = TypeInfo::Bool;
     
-    fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: &mut I, f: F) -> R {
-        f(match input.read_byte() {
-            Ok(0) => Ok(false),
-            Ok(1) => Ok(true),
-            Ok(_) => Err(DecodeError::INVALID_VALUE),
-            Err(e) => Err(e),
-        })
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        match input.read_byte()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(DecodeError::INVALID_VALUE),
+        }
     }
 }
 
 impl<T: NestedDecode> NestedDecode for Option<T> {
-    fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: &mut I, f: F) -> R {
-        match input.read_byte() {
-			Ok(0) => f(Ok(None)),
-			Ok(1) => T::dep_decode(input, |res| f(res.map(|obj| Some(obj)))),
-			Ok(_) => f(Err(DecodeError::INVALID_VALUE)),
-            Err(e) => f(Err(e)),
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        match input.read_byte()? {
+			0 => Ok(None),
+			1 => Ok(Some(T::dep_decode(input)?)),
+			_ => Err(DecodeError::INVALID_VALUE),
 		}
     }
 }
 
 impl<T: NestedDecode> NestedDecode for Box<T> {
-    fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: &mut I, f: F) -> R {
-        T::dep_decode(input, |rep| match rep {
-            Ok(obj) => f(Ok(Box::new(obj))),
-            Err(e) => f(Err(e)),
-        })
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        Ok(Box::new(T::dep_decode(input)?))
     }
 }
 
@@ -162,10 +145,10 @@ macro_rules! tuple_impls {
             where
                 $($name: NestedDecode,)+
             {
-                fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+                fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
                     let tuple = (
                         $(
-                            $name::dep_decode_to(input)?,
+                            $name::dep_decode(input)?,
                         )+
                     );
                     Ok(tuple)
@@ -198,18 +181,17 @@ macro_rules! array_impls {
     ($($n: tt,)+) => {
         $(
             impl<T: NestedDecode> NestedDecode for [T; $n] {
-                fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: &mut I, f: F) -> R {
-                    let mut array_vec = ArrayVec::<[T; $n]>::new();
+                fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+					let mut r = ArrayVec::new();
 					for _ in 0..$n {
-                        match T::dep_decode_to(input) {
-                            Ok(elem) => { array_vec.push(elem); }
-                            Err(e) => { return f(Err(e)); }
-                        }
+						r.push(T::dep_decode(input)?);
 					}
-					f(match array_vec.into_inner() {
+					let i = r.into_inner();
+
+					match i {
 						Ok(a) => Ok(a),
 						Err(_) => Err(DecodeError::ARRAY_DECODE_ERROR),
-					})
+					}
 				}
             }
         )+
@@ -244,11 +226,8 @@ fn decode_non_zero_usize(num: usize) -> Result<NonZeroUsize, DecodeError> {
 }
 
 impl NestedDecode for NonZeroUsize {
-    fn dep_decode<I: NestedDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: &mut I, f: F) -> R {
-        usize::dep_decode(input, |res| match res {
-            Ok(num) => f(decode_non_zero_usize(num)),
-            Err(e) => f(Err(e)),
-        })
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        decode_non_zero_usize(usize::dep_decode(input)?)
     }
 }
 
@@ -265,7 +244,7 @@ mod tests {
         V: NestedDecode + PartialEq + Debug + 'static,
     {
         let input = bytes.to_vec();
-        let deserialized: V = V::dep_decode_to(&mut &input[..]).unwrap();
+        let deserialized: V = V::dep_decode(&mut &input[..]).unwrap();
         assert_eq!(deserialized, element);
     }
 

--- a/elrond-codec/src/nested_de_input.rs
+++ b/elrond-codec/src/nested_de_input.rs
@@ -12,6 +12,8 @@ pub trait NestedDecodeInput {
 	/// Read the exact number of bytes required to fill the given buffer.
     fn read_into(&mut self, into: &mut [u8]) -> Result<(), DecodeError>;
 
+    /// Read the exact number of bytes required to fill the given buffer.
+    /// Exit early if there are not enough bytes to fill the result.
     fn read_into_or_exit<ExitCtx: Clone>(&mut self, into: &mut [u8], c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !);
 
 	/// Read a single byte from the input.
@@ -31,8 +33,11 @@ pub trait NestedDecodeInput {
     /// Read the exact number of bytes required to fill the given buffer.
     fn read_slice(&mut self, length: usize) -> Result<&[u8], DecodeError>;
 
+    /// Read the exact number of bytes required to fill the given buffer.
+    /// Exit directly if the input contains too few bytes.
     fn read_slice_or_exit<ExitCtx: Clone>(&mut self, length: usize, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> &[u8];
     
+    /// Clears the input buffer and returns all remaining bytes.
     fn flush(&mut self) -> &[u8];
 
 }

--- a/elrond-codec/src/nested_ser.rs
+++ b/elrond-codec/src/nested_ser.rs
@@ -87,7 +87,7 @@ impl<T: NestedEncode> NestedEncode for Vec<T> {
 
 // The main unsigned types need to be reversed before serializing.
 macro_rules! encode_num_unsigned {
-    ($num_type:ident, $size_in_bits:expr, $type_info:expr) => {
+    ($num_type:ty, $size_in_bits:expr, $type_info:expr) => {
 		impl NestedEncode for $num_type {
 			const TYPE_INFO: TypeInfo = $type_info;
 
@@ -116,7 +116,7 @@ impl NestedEncode for u8 {
 
 // Derive the implementation of the other types by casting.
 macro_rules! encode_num_mimic {
-    ($num_type:ident, $mimic_type:ident, $type_info:expr) => {
+    ($num_type:ty, $mimic_type:ident, $type_info:expr) => {
 		impl NestedEncode for $num_type {
 			const TYPE_INFO: TypeInfo = $type_info;
 

--- a/elrond-codec/src/nested_ser.rs
+++ b/elrond-codec/src/nested_ser.rs
@@ -58,7 +58,7 @@ macro_rules! dep_encode_from_no_err {
 }
 
 /// Convenience function for getting an object nested-encoded to a Vec<u8> directly.
-pub fn dep_encode_vec<T: NestedEncode>(obj: &T) -> Result<Vec<u8>, EncodeError> {
+pub fn dep_encode_to_vec<T: NestedEncode>(obj: &T) -> Result<Vec<u8>, EncodeError> {
 	let mut bytes = Vec::<u8>::new();
 	obj.dep_encode(&mut bytes)?;
 	Ok(bytes)
@@ -353,6 +353,7 @@ impl NestedEncode for NonZeroUsize {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::test_util::check_dep_encode;
 	use super::super::test_struct::*;
     use core::fmt::Debug;
 
@@ -360,8 +361,7 @@ mod tests {
     where
         V: NestedEncode + PartialEq + Debug + 'static,
     {
-		let bytes = dep_encode_vec(&element).unwrap();
-		// let bytes_or_exit = 
+		let bytes = check_dep_encode(&element);
 		assert_eq!(bytes.as_slice(), expected_bytes);
         
     }

--- a/elrond-codec/src/nested_ser.rs
+++ b/elrond-codec/src/nested_ser.rs
@@ -6,9 +6,16 @@ use crate::codec_err::EncodeError;
 use crate::TypeInfo;
 use crate::nested_ser_output::NestedEncodeOutput;
 
+/// Most types will be encoded without any possibility of error.
+/// The trait is used to provide these implementations.
+/// This is currently not a substitute for implementing a proper TopEncode. 
+pub trait NestedEncodeNoErr: Sized {
+	fn dep_encode_no_err<O: NestedEncodeOutput>(&self, dest: &mut O);
+}
+
 /// Trait that allows zero-copy write of value-references to slices in LE format.
 ///
-/// Implementations should override `using_top_encoded` for value types and `dep_encode_to` and `size_hint` for allocating types.
+/// Implementations should override `using_top_encoded` for value types and `dep_encode` and `size_hint` for allocating types.
 /// Wrapper types should override all methods.
 pub trait NestedEncode: Sized {
 	// !INTERNAL USE ONLY!
@@ -18,14 +25,42 @@ pub trait NestedEncode: Sized {
 
 	/// NestedEncode to output, using the format of an object nested inside another structure.
 	/// Does not provide compact version.
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError>;
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError>;
 
+	/// Version of `top_decode` that exits quickly in case of error.
+    /// Its purpose is to create smaller implementations
+    /// in cases where the application is supposed to exit directly on decode error.
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        match self.dep_encode(dest) {
+            Ok(v) => v,
+            Err(e) => exit(c, e)
+        }
+    }
+}
+
+macro_rules! dep_encode_from_no_err {
+    ($type:ty, $type_info:expr) => {
+		impl NestedEncode for $type {
+			const TYPE_INFO: TypeInfo = $type_info;
+		
+			#[inline]
+			fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+				self.dep_encode_no_err(dest);
+				Ok(())
+			}
+		
+			#[inline]
+			fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, _: ExitCtx, _: fn(ExitCtx, EncodeError) -> !) {
+				self.dep_encode_no_err(dest);
+			}
+		}
+    }
 }
 
 /// Convenience function for getting an object nested-encoded to a Vec<u8> directly.
-pub fn dep_encode_to_vec<T: NestedEncode>(obj: &T) -> Result<Vec<u8>, EncodeError> {
+pub fn dep_encode_vec<T: NestedEncode>(obj: &T) -> Result<Vec<u8>, EncodeError> {
 	let mut bytes = Vec::<u8>::new();
-	obj.dep_encode_to(&mut bytes)?;
+	obj.dep_encode(&mut bytes)?;
 	Ok(bytes)
 }
 
@@ -41,62 +76,100 @@ pub fn dep_encode_slice_contents<T: NestedEncode, O: NestedEncodeOutput>(slice: 
 		},
 		_ => {
 			for x in slice {
-				x.dep_encode_to(dest)?;
+				x.dep_encode(dest)?;
 			}
 		}
 	}
 	Ok(())
 }
 
-impl NestedEncode for () {
-    const TYPE_INFO: TypeInfo = TypeInfo::Unit;
-
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, _dest: &mut O) -> Result<(), EncodeError> {
-		Ok(())
+pub fn dep_encode_slice_contents_or_exit<T, O, ExitCtx>(slice: &[T], dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !)
+where
+	T: NestedEncode,
+	O: NestedEncodeOutput,
+	ExitCtx: Clone,
+{
+	match T::TYPE_INFO {
+		TypeInfo::U8 => {
+			// cast &[T] to &[u8]
+			let slice: &[u8] = unsafe { core::slice::from_raw_parts(slice.as_ptr() as *const u8, slice.len()) };
+			dest.write(slice);
+		},
+		_ => {
+			for x in slice {
+				x.dep_encode_or_exit(dest, c.clone(), exit);
+			}
+		}
 	}
 }
 
+impl NestedEncodeNoErr for () {
+	fn dep_encode_no_err<O: NestedEncodeOutput>(&self, _: &mut O) {
+	}
+}
+
+dep_encode_from_no_err!{(), TypeInfo::Unit}
+
 impl<T: NestedEncode> NestedEncode for &[T] {
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
 		// push size
-		self.len().dep_encode_to(dest)?;
+		self.len().dep_encode(dest)?;
 		// actual data
 		dep_encode_slice_contents(self, dest)
+	}
+
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		// push size
+		self.len().dep_encode_or_exit(dest, c.clone(), exit);
+		// actual data
+		dep_encode_slice_contents_or_exit(self, dest, c, exit);
 	}
 }
 
 impl<T: NestedEncode> NestedEncode for &T {
-	#[inline(never)]
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-		(*self).dep_encode_to(dest)
+	#[inline]
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+		(*self).dep_encode(dest)
+	}
+
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		(*self).dep_encode_or_exit(dest, c, exit);
 	}
 }
 
 impl NestedEncode for &str {
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-		self.as_bytes().dep_encode_to(dest)
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+		self.as_bytes().dep_encode(dest)
+	}
+
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.as_bytes().dep_encode_or_exit(dest, c, exit);
 	}
 }
 
 impl<T: NestedEncode> NestedEncode for Vec<T> {
-	#[inline(never)]
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-		self.as_slice().dep_encode_to(dest)
+	#[inline]
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+		self.as_slice().dep_encode(dest)
+	}
+
+	#[inline]
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.as_slice().dep_encode_or_exit(dest, c, exit);
 	}
 }
 
 // The main unsigned types need to be reversed before serializing.
 macro_rules! encode_num_unsigned {
     ($num_type:ty, $size_in_bits:expr, $type_info:expr) => {
-		impl NestedEncode for $num_type {
-			const TYPE_INFO: TypeInfo = $type_info;
-
+		impl NestedEncodeNoErr for $num_type {
 			#[inline(never)]
-            fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+            fn dep_encode_no_err<O: NestedEncodeOutput>(&self, dest: &mut O) {
 				dest.write(&self.to_be_bytes()[..]);
-				Ok(())
 			}
 		}
+
+		dep_encode_from_no_err!{$num_type, $type_info}
     }
 }
 
@@ -105,26 +178,25 @@ encode_num_unsigned!{u32, 32, TypeInfo::U32}
 encode_num_unsigned!{u16, 16, TypeInfo::U16}
 
 // No reversing needed for u8, because it is a single byte.
-impl NestedEncode for u8 {
-	const TYPE_INFO: TypeInfo = TypeInfo::U8;
-
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+impl NestedEncodeNoErr for u8 {
+	fn dep_encode_no_err<O: NestedEncodeOutput>(&self, dest: &mut O) {
 		dest.push_byte(*self as u8);
-		Ok(())
 	}
 }
+
+dep_encode_from_no_err!{u8, TypeInfo::U8}
 
 // Derive the implementation of the other types by casting.
 macro_rules! encode_num_mimic {
     ($num_type:ty, $mimic_type:ident, $type_info:expr) => {
-		impl NestedEncode for $num_type {
-			const TYPE_INFO: TypeInfo = $type_info;
-
+		impl NestedEncodeNoErr for $num_type {
 			#[inline]
-            fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-				(*self as $mimic_type).dep_encode_to(dest)
+            fn dep_encode_no_err<O: NestedEncodeOutput>(&self, dest: &mut O) {
+				(*self as $mimic_type).dep_encode_no_err(dest)
 			}
 		}
+
+		dep_encode_from_no_err!{$num_type, $type_info}
     }
 }
 
@@ -137,11 +209,11 @@ encode_num_mimic!{i8, u8, TypeInfo::I8}
 encode_num_mimic!{bool, u8, TypeInfo::Bool}
 
 impl<T: NestedEncode> NestedEncode for Option<T> {
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
 		match self {
 			Some(v) => {
 				dest.push_byte(1u8);
-				v.dep_encode_to(dest)
+				v.dep_encode(dest)
 			},
 			None => {
 				dest.push_byte(0u8);
@@ -149,19 +221,38 @@ impl<T: NestedEncode> NestedEncode for Option<T> {
 			}
 		}
 	}
+
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		match self {
+			Some(v) => {
+				dest.push_byte(1u8);
+				v.dep_encode_or_exit(dest, c, exit);
+			},
+			None => {
+				dest.push_byte(0u8);
+			}
+		}
+	}
 }
 
 impl<T: NestedEncode> NestedEncode for Box<T> {
 	#[inline(never)]
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-		self.as_ref().dep_encode_to(dest)
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+		self.as_ref().dep_encode(dest)
+	}
+
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.as_ref().dep_encode_or_exit(dest, c, exit);
 	}
 }
 
 impl<T: NestedEncode> NestedEncode for Box<[T]> {
-	#[inline(never)]
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-		self.as_ref().dep_encode_to(dest)
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+		self.as_ref().dep_encode(dest)
+	}
+
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.as_ref().dep_encode_or_exit(dest, c, exit);
 	}
 }
 
@@ -172,12 +263,17 @@ macro_rules! tuple_impls {
             where
                 $($name: NestedEncode,)+
             {
-				#[inline(never)]
-				fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+				fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
 					$(
-                        self.$n.dep_encode_to(dest)?;
+                        self.$n.dep_encode(dest)?;
                     )+
 					Ok(())
+				}
+
+				fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+					$(
+                        self.$n.dep_encode_or_exit(dest, c.clone(), exit);
+                    )+
 				}
             }
         )+
@@ -208,10 +304,15 @@ macro_rules! array_impls {
         $(
             impl<T: NestedEncode> NestedEncode for [T; $n] {
 				#[inline]
-				fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+				fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
 					dep_encode_slice_contents(&self[..], dest)
 				}
-            }
+
+				#[inline]
+				fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+					dep_encode_slice_contents_or_exit(&self[..], dest, c, exit);
+				}
+			}
         )+
     }
 }
@@ -236,9 +337,14 @@ array_impls!(
 );
 
 impl NestedEncode for NonZeroUsize {
-	#[inline(never)]
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-		self.get().dep_encode_to(dest)
+	#[inline]
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+		self.get().dep_encode(dest)
+	}
+
+	#[inline]
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.get().dep_encode_or_exit(dest, c, exit);
 	}
 }
 
@@ -254,7 +360,8 @@ mod tests {
     where
         V: NestedEncode + PartialEq + Debug + 'static,
     {
-		let bytes = dep_encode_to_vec(&element).unwrap();
+		let bytes = dep_encode_vec(&element).unwrap();
+		// let bytes_or_exit = 
 		assert_eq!(bytes.as_slice(), expected_bytes);
         
     }

--- a/elrond-codec/src/test_util.rs
+++ b/elrond-codec/src/test_util.rs
@@ -1,15 +1,93 @@
 use crate::*;
 use core::fmt::Debug;
+use alloc::vec::Vec;
+
+/// Calls `top_encode_or_exit` and panics if an encoding error occurs.
+/// Do not use in smart contracts!
+pub fn top_encode_to_vec_or_panic<T: TopEncode>(obj: &T) -> Vec<u8> {
+	let mut bytes = Vec::<u8>::new();
+	obj.top_encode_or_exit(&mut bytes, (), encode_panic_exit);
+	bytes
+}
+
+/// Calls `dep_encode_or_exit` and panics if an encoding error occurs.
+/// Do not use in smart contracts!
+pub fn dep_encode_to_vec_or_panic<T: NestedEncode>(obj: &T) -> Vec<u8> {
+	let mut bytes = Vec::<u8>::new();
+	obj.dep_encode_or_exit(&mut bytes, (), encode_panic_exit);
+	bytes
+}
+
+fn encode_panic_exit(_: (), en_err: EncodeError) -> ! {
+    panic!("encode panicked: {}", core::str::from_utf8(en_err.message_bytes()).unwrap())
+}
+
+/// Calls both the fast exit and the regular top-encode,
+/// compares that the outputs are equal, then returns the result.
+/// To be used in serialization tests.
+pub fn check_top_encode<T: TopEncode>(obj: &T) -> Vec<u8> {
+    let fast_exit_bytes = top_encode_to_vec_or_panic(obj);
+    let result_bytes = top_encode_to_vec(obj).unwrap();
+    assert_eq!(fast_exit_bytes, result_bytes);
+    fast_exit_bytes
+}
+
+/// Calls both the fast exit and the regular dep-encode,
+/// compares that the outputs are equal, then returns the result.
+/// To be used in serialization tests.
+pub fn check_dep_encode<T: NestedEncode>(obj: &T) -> Vec<u8> {
+    let fast_exit_bytes = dep_encode_to_vec_or_panic(obj);
+    let result_bytes = dep_encode_to_vec(obj).unwrap();
+    assert_eq!(fast_exit_bytes, result_bytes);
+    fast_exit_bytes
+}
+
+/// Calls `top_decode_or_exit` and panics if an encoding error occurs.
+/// Do not use in smart contracts!
+pub fn top_decode_from_byte_slice_or_panic<T: TopDecode>(input: &[u8]) -> T {
+    T::top_decode_or_exit(input, (), decode_panic_exit)
+}
+
+/// Calls `dep_decode_or_exit` and panics if an encoding error occurs.
+/// Do not use in smart contracts!
+pub fn dep_decode_from_byte_slice_or_panic<T: NestedDecode>(input: &[u8]) -> T {
+    dep_decode_from_byte_slice_or_exit(input, (), decode_panic_exit)
+}
+
+fn decode_panic_exit(_: (), de_err: DecodeError) -> ! {
+    panic!("decode panicked: {}", core::str::from_utf8(de_err.message_bytes()).unwrap())
+}
+
+/// Calls both the fast exit and the regular top-decode,
+/// compares that the outputs are equal, then returns the result.
+/// To be used in serialization tests.
+pub fn check_top_decode<T: TopDecode + PartialEq + Debug>(bytes: &[u8]) -> T {
+    let fast_exit_obj = top_decode_from_byte_slice_or_panic(bytes);
+    let result_obj = T::top_decode(bytes).unwrap();
+    assert_eq!(fast_exit_obj, result_obj);
+    fast_exit_obj
+}
+
+/// Calls both the fast exit and the regular dep-decode,
+/// compares that the outputs are equal, then returns the result.
+/// To be used in serialization tests.
+pub fn check_dep_decode<T: NestedDecode + PartialEq + Debug>(bytes: &[u8]) -> T {
+    let fast_exit_obj = dep_decode_from_byte_slice_or_panic(bytes);
+    let result_obj = dep_decode_from_byte_slice::<T>(bytes).unwrap();
+    assert_eq!(fast_exit_obj, result_obj);
+    fast_exit_obj
+}
+
 
 pub fn ser_deser_ok<V>(element: V, expected_bytes: &[u8])
 where
     V: TopEncode + TopDecode + PartialEq + Debug,
 {
     // serialize
-    let serialized_bytes = top_encode_to_vec(&element).unwrap();
+    let serialized_bytes = check_top_encode(&element);
     assert_eq!(serialized_bytes.as_slice(), expected_bytes);
 
     // deserialize
-    let deserialized: V = V::top_decode(&serialized_bytes[..]).unwrap();
+    let deserialized: V = check_top_decode::<V>(&serialized_bytes[..]);
     assert_eq!(deserialized, element);
 }

--- a/elrond-codec/src/test_util.rs
+++ b/elrond-codec/src/test_util.rs
@@ -10,6 +10,6 @@ where
     assert_eq!(serialized_bytes.as_slice(), expected_bytes);
 
     // deserialize
-    let deserialized: V = V::top_decode(&serialized_bytes[..], |res| res.unwrap());
+    let deserialized: V = V::top_decode(&serialized_bytes[..]).unwrap();
     assert_eq!(deserialized, element);
 }

--- a/elrond-codec/src/top_de.rs
+++ b/elrond-codec/src/top_de.rs
@@ -92,7 +92,6 @@ impl TopDecode for () {
     }
     
     fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(_: I, _: ExitCtx, _: fn(ExitCtx, DecodeError) -> !) -> Self {
-        ()
     }
 }
 

--- a/elrond-codec/src/top_de.rs
+++ b/elrond-codec/src/top_de.rs
@@ -53,6 +53,7 @@ pub trait TopDecode: Sized {
     }
 }
 
+/// Top-decodes the result using the NestedDecode implementation.
 pub fn top_decode_from_nested<T, I>(input: I) -> Result<T, DecodeError>
 where
     I: TopDecodeInput,
@@ -67,6 +68,8 @@ where
     Ok(result)
 }
 
+/// Top-decodes the result using the NestedDecode implementation.
+/// Uses the fast-exit mechanism in case of error.
 pub fn top_decode_from_nested_or_exit<T, I, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> T
 where
     I: TopDecodeInput,
@@ -403,14 +406,15 @@ impl TopDecode for NonZeroUsize {
 #[cfg(test)]
 mod tests {
     use super::*;
-	use super::super::test_struct::*;
+    use super::super::test_struct::*;
+    use crate::test_util::check_top_decode;
     use core::fmt::Debug;
 
     fn deser_ok<V>(element: V, bytes: &[u8])
     where
         V: TopDecode + PartialEq + Debug + 'static,
     {
-        let deserialized: V = V::top_decode(bytes).unwrap();
+        let deserialized: V = check_top_decode::<V>(&bytes[..]);
         assert_eq!(deserialized, element);
     }
 

--- a/elrond-codec/src/top_de.rs
+++ b/elrond-codec/src/top_de.rs
@@ -48,16 +48,11 @@ where
 {
     let bytes = input.into_boxed_slice_u8();
     let mut_slice = &mut &*bytes;
-    match D::dep_decode_to(mut_slice) {
-        Ok(result) => {
-            if mut_slice.is_empty() {
-                f(Ok(result))
-            } else {
-                f(Err(DecodeError::INPUT_TOO_LONG))
-            }
-        },
-        Err(e) => f(Err(e)),
+    let result = D::dep_decode(mut_slice);
+    if !mut_slice.is_empty() {
+        return f(Err(DecodeError::INPUT_TOO_LONG));
     }
+    f(result)
 }
 
 impl TopDecode for () {
@@ -103,7 +98,7 @@ impl<T: NestedDecode> TopDecode for Vec<T> {
             let mut_slice = &mut &*bytes;
             let mut result: Vec<T> = Vec::new();
             while !mut_slice.is_empty() {
-                match T::dep_decode_to(mut_slice) {
+                match T::dep_decode(mut_slice) {
                     Ok(t) => { result.push(t); }
                     Err(e) => { return f(Err(e)); }
                 }

--- a/elrond-codec/src/top_ser.rs
+++ b/elrond-codec/src/top_ser.rs
@@ -81,12 +81,6 @@ pub fn top_encode_to_vec<T: TopEncode>(obj: &T) -> Result<Vec<u8>, EncodeError> 
 	Ok(bytes)
 }
 
-// pub fn top_encode_to_vec_or_panic<T: TopEncode>(obj: &T) -> Result<Vec<u8>, EncodeError> {
-// 	let mut bytes = Vec::<u8>::new();
-// 	obj.top_encode(&mut bytes)?;
-// 	Ok(bytes)
-// }
-
 impl TopEncodeNoErr for () {
 	#[inline]
 	fn top_encode_no_err<O: TopEncodeOutput>(&self, output: O) {
@@ -381,6 +375,7 @@ impl TopEncode for NonZeroUsize {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::test_util::check_top_encode;
 	use super::super::test_struct::*;
     use core::fmt::Debug;
 
@@ -388,7 +383,7 @@ mod tests {
     where
         V: TopEncode + PartialEq + Debug + 'static,
     {
-		let bytes = top_encode_to_vec(&element).unwrap();
+		let bytes = check_top_encode(&element);
 		assert_eq!(bytes.as_slice(), expected_bytes);
     }
 

--- a/elrond-wasm-debug/Cargo.toml
+++ b/elrond-wasm-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-debug"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -14,7 +14,7 @@ keywords = ["elrond", "blockchain", "contract", "debug"]
 categories = ["cryptography::cryptocurrencies", "development-tools::debugging"]
 
 [dependencies]
-elrond-wasm = { version = "0.9.0", path = "../elrond-wasm" }
+elrond-wasm = { version = "0.9.1", path = "../elrond-wasm" }
 mandos = { version = "0.2.0", path = "../mandos" }
 num-bigint = "0.3"
 num-traits = "0.2"

--- a/elrond-wasm-debug/Cargo.toml
+++ b/elrond-wasm-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-debug"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -14,8 +14,8 @@ keywords = ["elrond", "blockchain", "contract", "debug"]
 categories = ["cryptography::cryptocurrencies", "development-tools::debugging"]
 
 [dependencies]
-elrond-wasm = { version = "0.8.0", path = "../elrond-wasm" }
-mandos = { version = "0.1.3", path = "../mandos" }
+elrond-wasm = { version = "0.9.0", path = "../elrond-wasm" }
+mandos = { version = "0.2.0", path = "../mandos" }
 num-bigint = "0.3"
 num-traits = "0.2"
 hex = "0.4"

--- a/elrond-wasm-debug/src/big_int_mock.rs
+++ b/elrond-wasm-debug/src/big_int_mock.rs
@@ -171,8 +171,8 @@ impl NestedDecode for RustBigInt {
 }
 
 impl TopDecode for RustBigInt {
-	fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        f(Ok(RustBigInt::from_signed_bytes_be(&*input.into_boxed_slice_u8())))
+	fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+        Ok(RustBigInt::from_signed_bytes_be(input.get_slice_u8()))
     }
 }
 

--- a/elrond-wasm-debug/src/big_int_mock.rs
+++ b/elrond-wasm-debug/src/big_int_mock.rs
@@ -148,9 +148,9 @@ use elrond_wasm::elrond_codec::*;
 impl NestedEncode for RustBigInt {
     const TYPE_INFO: TypeInfo = TypeInfo::BigInt;
 
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         let bytes = self.to_signed_bytes_be();
-        bytes.as_slice().dep_encode_to(dest)
+        bytes.as_slice().dep_encode(dest)
     }
 }
 

--- a/elrond-wasm-debug/src/big_int_mock.rs
+++ b/elrond-wasm-debug/src/big_int_mock.rs
@@ -175,6 +175,12 @@ impl NestedDecode for RustBigInt {
         let bytes = input.read_slice(size)?;
         Ok(RustBigInt::from_signed_bytes_be(bytes))
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        let size = usize::dep_decode_or_exit(input, c.clone(), exit);
+        let bytes = input.read_slice_or_exit(size, c, exit);
+        RustBigInt::from_signed_bytes_be(bytes)
+    }
 }
 
 impl TopDecode for RustBigInt {

--- a/elrond-wasm-debug/src/big_int_mock.rs
+++ b/elrond-wasm-debug/src/big_int_mock.rs
@@ -181,6 +181,10 @@ impl TopDecode for RustBigInt {
 	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         Ok(RustBigInt::from_signed_bytes_be(&*input.into_boxed_slice_u8()))
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, _: ExitCtx, _: fn(ExitCtx, DecodeError) -> !) -> Self {
+        RustBigInt::from_signed_bytes_be(&*input.into_boxed_slice_u8())
+    }
 }
 
 impl elrond_wasm::BigIntApi<RustBigUint> for RustBigInt {

--- a/elrond-wasm-debug/src/big_int_mock.rs
+++ b/elrond-wasm-debug/src/big_int_mock.rs
@@ -163,8 +163,8 @@ impl TopEncode for RustBigInt {
 impl NestedDecode for RustBigInt {
     const TYPE_INFO: TypeInfo = TypeInfo::BigInt;
 
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        let size = usize::dep_decode_to(input)?;
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        let size = usize::dep_decode(input)?;
         let bytes = input.read_slice(size)?;
         Ok(RustBigInt::from_signed_bytes_be(bytes))
     }

--- a/elrond-wasm-debug/src/big_int_mock.rs
+++ b/elrond-wasm-debug/src/big_int_mock.rs
@@ -171,8 +171,8 @@ impl NestedDecode for RustBigInt {
 }
 
 impl TopDecode for RustBigInt {
-	fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-        Ok(RustBigInt::from_signed_bytes_be(input.get_slice_u8()))
+	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Ok(RustBigInt::from_signed_bytes_be(&*input.into_boxed_slice_u8()))
     }
 }
 

--- a/elrond-wasm-debug/src/big_int_mock.rs
+++ b/elrond-wasm-debug/src/big_int_mock.rs
@@ -149,14 +149,21 @@ impl NestedEncode for RustBigInt {
     const TYPE_INFO: TypeInfo = TypeInfo::BigInt;
 
     fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-        let bytes = self.to_signed_bytes_be();
-        bytes.as_slice().dep_encode(dest)
+        self.to_signed_bytes_be().as_slice().dep_encode(dest)
     }
+
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_signed_bytes_be().as_slice().dep_encode_or_exit(dest, c, exit);
+	}
 }
 
 impl TopEncode for RustBigInt {
 	fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
 		self.to_signed_bytes_be().top_encode(output)
+    }
+
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_signed_bytes_be().top_encode_or_exit(output, c, exit)
 	}
 }
 

--- a/elrond-wasm-debug/src/big_uint_mock.rs
+++ b/elrond-wasm-debug/src/big_uint_mock.rs
@@ -247,8 +247,8 @@ impl TopEncode for RustBigUint {
 impl NestedDecode for RustBigUint {
     const TYPE_INFO: TypeInfo = TypeInfo::BigUint;
 
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        let size = usize::dep_decode_to(input)?;
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        let size = usize::dep_decode(input)?;
         let bytes = input.read_slice(size)?;
         Ok(RustBigUint::from_bytes_be(bytes))
     }

--- a/elrond-wasm-debug/src/big_uint_mock.rs
+++ b/elrond-wasm-debug/src/big_uint_mock.rs
@@ -259,6 +259,12 @@ impl NestedDecode for RustBigUint {
         let bytes = input.read_slice(size)?;
         Ok(RustBigUint::from_bytes_be(bytes))
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        let size = usize::dep_decode_or_exit(input, c.clone(), exit);
+        let bytes = input.read_slice_or_exit(size, c, exit);
+        RustBigUint::from_bytes_be(bytes)
+    }
 }
 
 impl TopDecode for RustBigUint {

--- a/elrond-wasm-debug/src/big_uint_mock.rs
+++ b/elrond-wasm-debug/src/big_uint_mock.rs
@@ -233,14 +233,21 @@ impl NestedEncode for RustBigUint {
     const TYPE_INFO: TypeInfo = TypeInfo::BigUint;
     
     fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-        let bytes = self.to_bytes_be();
-        bytes.as_slice().dep_encode(dest)
+        self.to_bytes_be().as_slice().dep_encode(dest)
     }
+
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_bytes_be().as_slice().dep_encode_or_exit(dest, c, exit);
+	}
 }
 
 impl TopEncode for RustBigUint {
 	fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
 		self.to_bytes_be().top_encode(output)
+    }
+
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_bytes_be().top_encode_or_exit(output, c, exit)
 	}
 }
 

--- a/elrond-wasm-debug/src/big_uint_mock.rs
+++ b/elrond-wasm-debug/src/big_uint_mock.rs
@@ -232,9 +232,9 @@ use elrond_wasm::elrond_codec::*;
 impl NestedEncode for RustBigUint {
     const TYPE_INFO: TypeInfo = TypeInfo::BigUint;
     
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         let bytes = self.to_bytes_be();
-        bytes.as_slice().dep_encode_to(dest)
+        bytes.as_slice().dep_encode(dest)
     }
 }
 

--- a/elrond-wasm-debug/src/big_uint_mock.rs
+++ b/elrond-wasm-debug/src/big_uint_mock.rs
@@ -255,8 +255,8 @@ impl NestedDecode for RustBigUint {
 }
 
 impl TopDecode for RustBigUint {
-	fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        f(Ok(RustBigUint::from_bytes_be(&*input.into_boxed_slice_u8())))
+	fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+        Ok(RustBigUint::from_bytes_be(input.get_slice_u8()))
     }
 }
 

--- a/elrond-wasm-debug/src/big_uint_mock.rs
+++ b/elrond-wasm-debug/src/big_uint_mock.rs
@@ -265,6 +265,10 @@ impl TopDecode for RustBigUint {
 	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         Ok(RustBigUint::from_bytes_be(&*input.into_boxed_slice_u8()))
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, _: ExitCtx, _: fn(ExitCtx, DecodeError) -> !) -> Self {
+        RustBigUint::from_bytes_be(&*input.into_boxed_slice_u8())
+    }
 }
 
 impl elrond_wasm::BigUintApi for RustBigUint {

--- a/elrond-wasm-debug/src/big_uint_mock.rs
+++ b/elrond-wasm-debug/src/big_uint_mock.rs
@@ -255,8 +255,8 @@ impl NestedDecode for RustBigUint {
 }
 
 impl TopDecode for RustBigUint {
-	fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-        Ok(RustBigUint::from_bytes_be(input.get_slice_u8()))
+	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Ok(RustBigUint::from_bytes_be(&*input.into_boxed_slice_u8()))
     }
 }
 

--- a/elrond-wasm-debug/src/lib.rs
+++ b/elrond-wasm-debug/src/lib.rs
@@ -41,7 +41,7 @@ mod elrond_codec_tests {
         assert_eq!(serialized_bytes.as_slice(), expected_bytes);
 
         // deserialize
-        let deserialized: V = V::top_decode(&serialized_bytes[..], |res| res.unwrap());
+        let deserialized: V = V::top_decode(&serialized_bytes[..]).unwrap();
         assert_eq!(deserialized, element);
     }
 

--- a/elrond-wasm-debug/src/lib.rs
+++ b/elrond-wasm-debug/src/lib.rs
@@ -30,6 +30,7 @@ pub use std::collections::HashMap;
 mod elrond_codec_tests {
     use super::*;
     use elrond_wasm::elrond_codec::*;
+    use elrond_wasm::elrond_codec::test_util::{check_top_encode, check_top_decode};
     use core::fmt::Debug;
 
     pub fn ser_deser_ok<V>(element: V, expected_bytes: &[u8])
@@ -37,11 +38,11 @@ mod elrond_codec_tests {
         V: TopEncode + TopDecode + PartialEq + Debug + 'static,
     {
         // serialize
-        let serialized_bytes = top_encode_to_vec(&element).unwrap();
+        let serialized_bytes = check_top_encode(&element);
         assert_eq!(serialized_bytes.as_slice(), expected_bytes);
 
         // deserialize
-        let deserialized: V = V::top_decode(&serialized_bytes[..]).unwrap();
+        let deserialized: V = check_top_decode::<V>(&serialized_bytes[..]);
         assert_eq!(deserialized, element);
     }
 

--- a/elrond-wasm-derive/Cargo.toml
+++ b/elrond-wasm-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-derive"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]

--- a/elrond-wasm-derive/Cargo.toml
+++ b/elrond-wasm-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-derive"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]

--- a/elrond-wasm-derive/src/contract_gen_storage.rs
+++ b/elrond-wasm-derive/src/contract_gen_storage.rs
@@ -27,7 +27,7 @@ fn generate_key_snippet(key_args: &[MethodArg], identifier: String) -> proc_macr
         let key_appends: Vec<proc_macro2::TokenStream> = key_args.iter().map(|arg| {
             let arg_pat = &arg.pat;
             quote! {
-                if let Result::Err(encode_error) = #arg_pat.dep_encode_to(&mut key) {
+                if let Result::Err(encode_error) = #arg_pat.dep_encode(&mut key) {
                     self.api.signal_error(encode_error.message_bytes());
                 }
             }

--- a/elrond-wasm-node/Cargo.toml
+++ b/elrond-wasm-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-node"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -17,4 +17,4 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies", "development-t
 small-int-ei = []
 
 [dependencies]
-elrond-wasm = { version = "0.9.0", path = "../elrond-wasm" }
+elrond-wasm = { version = "0.9.1", path = "../elrond-wasm" }

--- a/elrond-wasm-node/Cargo.toml
+++ b/elrond-wasm-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-node"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -17,4 +17,4 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies", "development-t
 small-int-ei = []
 
 [dependencies]
-elrond-wasm = { version = "0.8.0", path = "../elrond-wasm" }
+elrond-wasm = { version = "0.9.0", path = "../elrond-wasm" }

--- a/elrond-wasm-node/src/big_int.rs
+++ b/elrond-wasm-node/src/big_int.rs
@@ -232,10 +232,8 @@ impl NestedDecode for ArwenBigInt {
 }
 
 impl TopDecode for ArwenBigInt {
-    const TYPE_INFO: TypeInfo = TypeInfo::BigUint;
-    
-	fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        f(Ok(ArwenBigInt::from_signed_bytes_be(&*input.into_boxed_slice_u8())))
+	fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+        Ok(ArwenBigInt::from_signed_bytes_be(input.get_slice_u8()))
     }
 }
 

--- a/elrond-wasm-node/src/big_int.rs
+++ b/elrond-wasm-node/src/big_int.rs
@@ -232,8 +232,8 @@ impl NestedDecode for ArwenBigInt {
 }
 
 impl TopDecode for ArwenBigInt {
-	fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-        Ok(ArwenBigInt::from_signed_bytes_be(input.get_slice_u8()))
+	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Ok(ArwenBigInt::from_signed_bytes_be(&*input.into_boxed_slice_u8()))
     }
 }
 

--- a/elrond-wasm-node/src/big_int.rs
+++ b/elrond-wasm-node/src/big_int.rs
@@ -224,8 +224,8 @@ impl TopEncode for ArwenBigInt {
 impl NestedDecode for ArwenBigInt {
     const TYPE_INFO: TypeInfo = TypeInfo::BigInt;
 
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        let size = usize::dep_decode_to(input)?;
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        let size = usize::dep_decode(input)?;
         let bytes = input.read_slice(size)?;
         Ok(ArwenBigInt::from_signed_bytes_be(bytes))
     }

--- a/elrond-wasm-node/src/big_int.rs
+++ b/elrond-wasm-node/src/big_int.rs
@@ -237,6 +237,12 @@ impl NestedDecode for ArwenBigInt {
         let bytes = input.read_slice(size)?;
         Ok(ArwenBigInt::from_signed_bytes_be(bytes))
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        let size = usize::dep_decode_or_exit(input, c.clone(), exit);
+        let bytes = input.read_slice_or_exit(size, c, exit);
+        ArwenBigInt::from_signed_bytes_be(bytes)
+    }
 }
 
 impl TopDecode for ArwenBigInt {

--- a/elrond-wasm-node/src/big_int.rs
+++ b/elrond-wasm-node/src/big_int.rs
@@ -206,9 +206,12 @@ impl NestedEncode for ArwenBigInt {
     
     fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         // TODO: vector allocation can be avoided by writing directly to dest
-        let bytes = self.to_signed_bytes_be();
-        bytes.as_slice().dep_encode(dest)
+        self.to_signed_bytes_be().as_slice().dep_encode(dest)
     }
+
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_signed_bytes_be().as_slice().dep_encode_or_exit(dest, c, exit);
+	}
 }
 
 impl TopEncode for ArwenBigInt {
@@ -218,6 +221,11 @@ impl TopEncode for ArwenBigInt {
 	fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
         output.set_big_int_handle_or_bytes(self.handle, || self.to_signed_bytes_be());
         Ok(())
+    }
+    
+    #[inline]
+	fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, _: ExitCtx, _: fn(ExitCtx, EncodeError) -> !) {
+		output.set_big_int_handle_or_bytes(self.handle, || self.to_signed_bytes_be());
 	}
 }
 

--- a/elrond-wasm-node/src/big_int.rs
+++ b/elrond-wasm-node/src/big_int.rs
@@ -204,10 +204,10 @@ use elrond_wasm::elrond_codec::*;
 impl NestedEncode for ArwenBigInt {
     const TYPE_INFO: TypeInfo = TypeInfo::BigInt;
     
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         // TODO: vector allocation can be avoided by writing directly to dest
         let bytes = self.to_signed_bytes_be();
-        bytes.as_slice().dep_encode_to(dest)
+        bytes.as_slice().dep_encode(dest)
     }
 }
 

--- a/elrond-wasm-node/src/big_int.rs
+++ b/elrond-wasm-node/src/big_int.rs
@@ -243,6 +243,10 @@ impl TopDecode for ArwenBigInt {
 	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         Ok(ArwenBigInt::from_signed_bytes_be(&*input.into_boxed_slice_u8()))
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, _: ExitCtx, _: fn(ExitCtx, DecodeError) -> !) -> Self {
+        ArwenBigInt::from_signed_bytes_be(&*input.into_boxed_slice_u8())
+    }
 }
 
 impl BigIntApi<ArwenBigUint> for ArwenBigInt {

--- a/elrond-wasm-node/src/big_uint.rs
+++ b/elrond-wasm-node/src/big_uint.rs
@@ -292,6 +292,10 @@ impl TopDecode for ArwenBigUint {
 	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         Ok(ArwenBigUint::from_bytes_be(&*input.into_boxed_slice_u8()))
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, _: ExitCtx, _: fn(ExitCtx, DecodeError) -> !) -> Self {
+        ArwenBigUint::from_bytes_be(&*input.into_boxed_slice_u8())
+    }
 }
 
 impl BigUintApi for ArwenBigUint {

--- a/elrond-wasm-node/src/big_uint.rs
+++ b/elrond-wasm-node/src/big_uint.rs
@@ -273,8 +273,8 @@ impl TopEncode for ArwenBigUint {
 impl NestedDecode for ArwenBigUint {
     const TYPE_INFO: TypeInfo = TypeInfo::BigUint;
 
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        let size = usize::dep_decode_to(input)?;
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        let size = usize::dep_decode(input)?;
         let bytes = input.read_slice(size)?;
         Ok(ArwenBigUint::from_bytes_be(bytes))
     }

--- a/elrond-wasm-node/src/big_uint.rs
+++ b/elrond-wasm-node/src/big_uint.rs
@@ -274,7 +274,7 @@ impl TopEncode for ArwenBigUint {
     
     #[inline]
 	fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, _: ExitCtx, _: fn(ExitCtx, EncodeError) -> !) {
-		output.set_big_int_handle_or_bytes(self.handle, || self.to_bytes_be());
+		output.set_big_uint_handle_or_bytes(self.handle, || self.to_bytes_be());
 	}
 }
 

--- a/elrond-wasm-node/src/big_uint.rs
+++ b/elrond-wasm-node/src/big_uint.rs
@@ -281,8 +281,8 @@ impl NestedDecode for ArwenBigUint {
 }
 
 impl TopDecode for ArwenBigUint {
-	fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-        Ok(ArwenBigUint::from_bytes_be(input.get_slice_u8()))
+	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Ok(ArwenBigUint::from_bytes_be(&*input.into_boxed_slice_u8()))
     }
 }
 

--- a/elrond-wasm-node/src/big_uint.rs
+++ b/elrond-wasm-node/src/big_uint.rs
@@ -253,10 +253,10 @@ use elrond_wasm::elrond_codec::*;
 impl NestedEncode for ArwenBigUint {
     const TYPE_INFO: TypeInfo = TypeInfo::BigUint;
     
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         // TODO: vector allocation can be avoided by writing directly to dest
         let bytes = self.to_bytes_be();
-        bytes.as_slice().dep_encode_to(dest)
+        bytes.as_slice().dep_encode(dest)
     }
 }
 

--- a/elrond-wasm-node/src/big_uint.rs
+++ b/elrond-wasm-node/src/big_uint.rs
@@ -286,6 +286,12 @@ impl NestedDecode for ArwenBigUint {
         let bytes = input.read_slice(size)?;
         Ok(ArwenBigUint::from_bytes_be(bytes))
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        let size = usize::dep_decode_or_exit(input, c.clone(), exit);
+        let bytes = input.read_slice_or_exit(size, c, exit);
+        ArwenBigUint::from_bytes_be(bytes)
+    }
 }
 
 impl TopDecode for ArwenBigUint {

--- a/elrond-wasm-node/src/big_uint.rs
+++ b/elrond-wasm-node/src/big_uint.rs
@@ -255,9 +255,12 @@ impl NestedEncode for ArwenBigUint {
     
     fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         // TODO: vector allocation can be avoided by writing directly to dest
-        let bytes = self.to_bytes_be();
-        bytes.as_slice().dep_encode(dest)
+        self.to_bytes_be().as_slice().dep_encode(dest)
     }
+
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_bytes_be().as_slice().dep_encode_or_exit(dest, c, exit);
+	}
 }
 
 impl TopEncode for ArwenBigUint {
@@ -267,6 +270,11 @@ impl TopEncode for ArwenBigUint {
 	fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
         output.set_big_uint_handle_or_bytes(self.handle, || self.to_bytes_be());
         Ok(())
+    }
+    
+    #[inline]
+	fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, _: ExitCtx, _: fn(ExitCtx, EncodeError) -> !) {
+		output.set_big_int_handle_or_bytes(self.handle, || self.to_bytes_be());
 	}
 }
 

--- a/elrond-wasm-node/src/big_uint.rs
+++ b/elrond-wasm-node/src/big_uint.rs
@@ -281,10 +281,8 @@ impl NestedDecode for ArwenBigUint {
 }
 
 impl TopDecode for ArwenBigUint {
-    const TYPE_INFO: TypeInfo = TypeInfo::BigUint;
-    
-	fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        f(Ok(ArwenBigUint::from_bytes_be(&*input.into_boxed_slice_u8())))
+	fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+        Ok(ArwenBigUint::from_bytes_be(input.get_slice_u8()))
     }
 }
 

--- a/elrond-wasm-output/Cargo.toml
+++ b/elrond-wasm-output/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-output"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -24,5 +24,5 @@ wasm-output-mode = []
 panic-message = [] 
 
 [dependencies]
-elrond-wasm-node = { version = "0.8.0", path = "../elrond-wasm-node" }
+elrond-wasm-node = { version = "0.9.0", path = "../elrond-wasm-node" }
 wee_alloc = "0.4"

--- a/elrond-wasm-output/Cargo.toml
+++ b/elrond-wasm-output/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-output"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -24,5 +24,5 @@ wasm-output-mode = []
 panic-message = [] 
 
 [dependencies]
-elrond-wasm-node = { version = "0.9.0", path = "../elrond-wasm-node" }
+elrond-wasm-node = { version = "0.9.1", path = "../elrond-wasm-node" }
 wee_alloc = "0.4"

--- a/elrond-wasm-serde/Cargo.toml
+++ b/elrond-wasm-serde/Cargo.toml
@@ -18,3 +18,4 @@ wee_alloc = "0.4"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 [workspace]
+members = ["."]

--- a/elrond-wasm/Cargo.toml
+++ b/elrond-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]

--- a/elrond-wasm/Cargo.toml
+++ b/elrond-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -14,6 +14,6 @@ keywords = ["elrond", "wasm", "webassembly", "blockchain", "contract"]
 categories = ["no-std", "wasm", "cryptography::cryptocurrencies", "development-tools"]
 
 [dependencies]
-elrond-codec = { version = "0.2.0", path = "../elrond-codec" }
+elrond-codec = { version = "0.3.0", path = "../elrond-codec" }
 wee_alloc = "0.4"
 arrayvec = { version = "0.5.1", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }

--- a/elrond-wasm/src/io/dyn_arg.rs
+++ b/elrond-wasm/src/io/dyn_arg.rs
@@ -35,12 +35,19 @@ where
         }
 
         let arg_input = loader.next_arg_input();
-        match T::top_decode(arg_input) {
-            Ok(v) => v,
-            Err(de_err) => loader.signal_arg_de_error(arg_id, de_err),
-        }
-        // T::top_decode_or_exit(
-        //     arg_input,
-        //     &|de_err| loader.signal_arg_de_error(arg_id, de_err))
+        T::top_decode_or_exit(
+            arg_input,
+            &(&*loader, arg_id),
+            dyn_load_exit)
     }
+}
+
+#[inline(always)]
+fn dyn_load_exit<I, D>(ctx: &(&D, ArgId), de_err: DecodeError) -> !
+where
+    I: TopDecodeInput,
+    D: DynArgInput<I>,
+{
+    let (loader, arg_id) = ctx;
+    loader.signal_arg_de_error(*arg_id, de_err)
 }

--- a/elrond-wasm/src/io/dyn_arg.rs
+++ b/elrond-wasm/src/io/dyn_arg.rs
@@ -35,9 +35,12 @@ where
         }
 
         let arg_input = loader.next_arg_input();
-        match T::top_decode(arg_input, |res| res) {
+        match T::top_decode(arg_input) {
             Ok(v) => v,
             Err(de_err) => loader.signal_arg_de_error(arg_id, de_err),
         }
+        // T::top_decode_or_exit(
+        //     arg_input,
+        //     &|de_err| loader.signal_arg_de_error(arg_id, de_err))
     }
 }

--- a/elrond-wasm/src/io/finish.rs
+++ b/elrond-wasm/src/io/finish.rs
@@ -82,9 +82,20 @@ where
     A: ContractHookApi<BigInt, BigUint> + ContractIOApi<BigInt, BigUint> + 'static
 {
     fn finish(&self, api: A) {
-        let res = self.top_encode(ApiOutput::new(api.clone()));
-        if let Err(encode_err_message) = res {
-            api.signal_error(encode_err_message.message_bytes());
-        }
+        self.top_encode_or_exit(
+            ApiOutput::new(api.clone()),
+            api.clone(),
+            finish_exit
+        );
     }
+}
+
+#[inline(always)]
+fn finish_exit<A, BigInt, BigUint>(api: A, en_err: EncodeError) -> !
+where
+    BigUint: BigUintApi + 'static,
+    BigInt: BigIntApi<BigUint> + 'static,
+    A: ContractHookApi<BigInt, BigUint> + ContractIOApi<BigInt, BigUint> + 'static
+{
+    api.signal_error(en_err.message_bytes())
 }

--- a/elrond-wasm/src/io/macro_helpers.rs
+++ b/elrond-wasm/src/io/macro_helpers.rs
@@ -26,10 +26,13 @@ where
             cast_big_uint
         },
         _ => {
-            match T::top_decode(ArgDecodeInput::new(api.clone(), index), |res| res) {
+            match T::top_decode(ArgDecodeInput::new(api.clone(), index)) {
                 Ok(v) => v,
                 Err(de_err) => ApiSignalError::new(api).signal_arg_de_error(arg_id, de_err),
             }
+            // T::top_decode_or_exit(
+            //     ArgDecodeInput::new(api.clone(), index),
+            //     &|de_err| ApiSignalError::new(api.clone()).signal_arg_de_error(arg_id, de_err))
         }
     }
 }

--- a/elrond-wasm/src/io/macro_helpers.rs
+++ b/elrond-wasm/src/io/macro_helpers.rs
@@ -26,15 +26,23 @@ where
             cast_big_uint
         },
         _ => {
-            match T::top_decode(ArgDecodeInput::new(api.clone(), index)) {
-                Ok(v) => v,
-                Err(de_err) => ApiSignalError::new(api).signal_arg_de_error(arg_id, de_err),
-            }
-            // T::top_decode_or_exit(
-            //     ArgDecodeInput::new(api.clone(), index),
-            //     &|de_err| ApiSignalError::new(api.clone()).signal_arg_de_error(arg_id, de_err))
+            T::top_decode_or_exit(
+                ArgDecodeInput::new(api.clone(), index),
+                (api, arg_id),
+                load_single_arg_exit)
         }
     }
+}
+
+#[inline(always)]
+fn load_single_arg_exit<A, BigInt, BigUint>(ctx: (A, ArgId), de_err: DecodeError) -> !
+where
+    BigUint: BigUintApi + 'static,
+    BigInt: BigIntApi<BigUint> + 'static,
+    A: ContractIOApi<BigInt, BigUint> + 'static
+{
+    let (api, arg_id) = ctx;
+    ApiSignalError::new(api).signal_arg_de_error(arg_id, de_err)
 }
 
 /// It's easier to generate code from macros using this function, instead of the DynArg method.

--- a/elrond-wasm/src/storage/storage_get.rs
+++ b/elrond-wasm/src/storage/storage_get.rs
@@ -85,7 +85,7 @@ where
             cast_big_uint
         },
         _ => {
-            match T::top_decode(StorageGetInput::new(api.clone(), key), |res| res) {
+            match T::top_decode(StorageGetInput::new(api, key)) {
                 Ok(v) => v,
                 Err(de_err) => storage_get_error(api, de_err),
             }

--- a/elrond-wasm/src/storage/storage_get.rs
+++ b/elrond-wasm/src/storage/storage_get.rs
@@ -2,19 +2,6 @@ use crate::*;
 use elrond_codec::*;
 use core::marker::PhantomData;
 
-fn storage_get_error<A, BigInt, BigUint>(api: A, de_err: DecodeError) -> !
-where
-    BigInt: NestedEncode + 'static,
-    BigUint: NestedEncode + 'static,
-    A: ContractHookApi<BigInt, BigUint> + ContractIOApi<BigInt, BigUint> + 'static
-{
-    let mut decode_err_message: Vec<u8> = Vec::new();
-    decode_err_message.extend_from_slice(err_msg::STORAGE_DECODE_ERROR);
-    decode_err_message.extend_from_slice(de_err.message_bytes());
-    api.signal_error(decode_err_message.as_slice())
-}
-
-
 struct StorageGetInput<'k, A, BigInt, BigUint>
 where
     BigInt: NestedEncode + 'static,
@@ -85,13 +72,23 @@ where
             cast_big_uint
         },
         _ => {
-            match T::top_decode(StorageGetInput::new(api.clone(), key)) {
-                Ok(v) => v,
-                Err(de_err) => storage_get_error(api, de_err),
-            }
-            // T::top_decode_or_exit(
-            //     StorageGetInput::new(api.clone(), key),
-            //     &|de_err| storage_get_error(api.clone(), de_err))
+            T::top_decode_or_exit(
+                StorageGetInput::new(api.clone(), key),
+                api,
+                storage_get_exit)
         }
     }
+}
+
+#[inline(always)]
+fn storage_get_exit<A, BigInt, BigUint>(api: A, de_err: DecodeError) -> !
+where
+    BigInt: NestedEncode + 'static,
+    BigUint: NestedEncode + 'static,
+    A: ContractHookApi<BigInt, BigUint> + ContractIOApi<BigInt, BigUint> + 'static
+{
+    let mut decode_err_message: Vec<u8> = Vec::new();
+    decode_err_message.extend_from_slice(err_msg::STORAGE_DECODE_ERROR);
+    decode_err_message.extend_from_slice(de_err.message_bytes());
+    api.signal_error(decode_err_message.as_slice())
 }

--- a/elrond-wasm/src/storage/storage_get.rs
+++ b/elrond-wasm/src/storage/storage_get.rs
@@ -85,10 +85,13 @@ where
             cast_big_uint
         },
         _ => {
-            match T::top_decode(StorageGetInput::new(api, key)) {
+            match T::top_decode(StorageGetInput::new(api.clone(), key)) {
                 Ok(v) => v,
                 Err(de_err) => storage_get_error(api, de_err),
             }
+            // T::top_decode_or_exit(
+            //     StorageGetInput::new(api.clone(), key),
+            //     &|de_err| storage_get_error(api.clone(), de_err))
         }
     }
 }

--- a/elrond-wasm/src/types/h256.rs
+++ b/elrond-wasm/src/types/h256.rs
@@ -132,6 +132,10 @@ impl NestedEncode for H256 {
         dest.write(&self.0[..]);
         Ok(())
     }
+
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, _: ExitCtx, _: fn(ExitCtx, EncodeError) -> !) {
+		dest.write(&self.0[..]);
+	}
 }
 
 impl TopEncode for H256 {
@@ -139,6 +143,10 @@ impl TopEncode for H256 {
         output.set_slice_u8(&self.0[..]);
         Ok(())
     }
+
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, _: ExitCtx, _: fn(ExitCtx, EncodeError) -> !) {
+		output.set_slice_u8(&self.0[..]);
+	}
 }
 
 impl NestedDecode for H256 {

--- a/elrond-wasm/src/types/h256.rs
+++ b/elrond-wasm/src/types/h256.rs
@@ -157,6 +157,12 @@ impl NestedDecode for H256 {
         input.read_into(res.as_mut())?;
         Ok(res)
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        let mut res = H256::zero();
+        input.read_into_or_exit(res.as_mut(), c, exit);
+        res
+    }
 }
 
 impl TopDecode for H256 {

--- a/elrond-wasm/src/types/h256.rs
+++ b/elrond-wasm/src/types/h256.rs
@@ -189,7 +189,7 @@ impl TopDecode for H256 {
 mod esd_light_tests {
     use super::*;
     use alloc::vec::Vec;
-    use elrond_codec::test_util::ser_deser_ok;
+    use elrond_codec::test_util::{ser_deser_ok, check_top_encode};
 
     #[test]
     fn test_address() {
@@ -212,7 +212,7 @@ mod esd_light_tests {
         let expected_bytes: &[u8] = &[4u8; 32*3];
 
         let tuple = (&addr, &&&addr, addr.clone());
-        let serialized_bytes = top_encode_to_vec(&tuple).unwrap();
+        let serialized_bytes = check_top_encode(&tuple);
         assert_eq!(serialized_bytes.as_slice(), expected_bytes);
     }
 }

--- a/elrond-wasm/src/types/h256.rs
+++ b/elrond-wasm/src/types/h256.rs
@@ -151,7 +151,7 @@ impl NestedDecode for H256 {
 
 impl TopDecode for H256 {
 	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
-        match Box::<[u8; 32]>::top_decode(input) {
+        match <[u8; 32]>::top_decode_boxed(input) {
             Ok(array_box) => Ok(H256(array_box)),
             Err(_) => Err(DecodeError::from(&b"bad H256 length"[..])),
         }

--- a/elrond-wasm/src/types/h256.rs
+++ b/elrond-wasm/src/types/h256.rs
@@ -128,7 +128,7 @@ impl H256 {
 use elrond_codec::*;
 
 impl NestedEncode for H256 {
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         dest.write(&self.0[..]);
         Ok(())
     }

--- a/elrond-wasm/src/types/h256.rs
+++ b/elrond-wasm/src/types/h256.rs
@@ -142,7 +142,7 @@ impl TopEncode for H256 {
 }
 
 impl NestedDecode for H256 {
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
         let mut res = H256::zero();
         input.read_into(res.as_mut())?;
         Ok(res)

--- a/elrond-wasm/src/types/h256.rs
+++ b/elrond-wasm/src/types/h256.rs
@@ -150,11 +150,11 @@ impl NestedDecode for H256 {
 }
 
 impl TopDecode for H256 {
-	fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        Box::<[u8; 32]>::top_decode(input, |res| match res {
-            Ok(array_box) => f(Ok(H256(array_box))),
-            Err(_) => f(Err(DecodeError::from(&b"bad H256 length"[..]))),
-        })
+	fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        match Box::<[u8; 32]>::top_decode(input) {
+            Ok(array_box) => Ok(H256(array_box)),
+            Err(_) => Err(DecodeError::from(&b"bad H256 length"[..])),
+        }
     }
 }
 

--- a/elrond-wasm/src/types/queue.rs
+++ b/elrond-wasm/src/types/queue.rs
@@ -100,9 +100,9 @@ impl<T: NestedEncode> TopEncode for Queue<T> {
 /// Deserializes like a Vec.
 impl<T: NestedDecode> NestedDecode for Queue<T> {
     #[inline]
-	fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+	fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
         Ok(Queue {
-            vec: Vec::<T>::dep_decode_to(input)?,
+            vec: Vec::<T>::dep_decode(input)?,
             start: 0,
         })
     }

--- a/elrond-wasm/src/types/queue.rs
+++ b/elrond-wasm/src/types/queue.rs
@@ -86,8 +86,8 @@ impl<T> Queue<T> {
 /// Serializes identically to a Vec, entries before start index are ignored.
 impl<T: NestedEncode> NestedEncode for Queue<T> {
 	#[inline]
-	fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-        self.as_slice().dep_encode_to(dest)
+	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+        self.as_slice().dep_encode(dest)
 	}
 }
 

--- a/elrond-wasm/src/types/queue.rs
+++ b/elrond-wasm/src/types/queue.rs
@@ -96,9 +96,15 @@ impl<T: NestedEncode> NestedEncode for Queue<T> {
 }
 
 impl<T: NestedEncode> TopEncode for Queue<T> {
+    #[inline]
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
         self.as_slice().top_encode(output)
     }
+
+    #[inline]
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.as_slice().top_encode_or_exit(output, c, exit)
+	}
 }
 
 /// Deserializes like a Vec.

--- a/elrond-wasm/src/types/queue.rs
+++ b/elrond-wasm/src/types/queue.rs
@@ -126,4 +126,11 @@ impl<T: NestedDecode> TopDecode for Queue<T> {
             start: 0,
         })
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        Queue {
+            vec: Vec::<T>::top_decode_or_exit(input, c, exit),
+            start: 0,
+        }
+    }
 }

--- a/elrond-wasm/src/types/queue.rs
+++ b/elrond-wasm/src/types/queue.rs
@@ -116,6 +116,14 @@ impl<T: NestedDecode> NestedDecode for Queue<T> {
             start: 0,
         })
     }
+
+    #[inline]
+	fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        Queue {
+            vec: Vec::<T>::dep_decode_or_exit(input, c, exit),
+            start: 0,
+        }
+    }
 }
 
 /// Deserializes like a Vec.

--- a/elrond-wasm/src/types/queue.rs
+++ b/elrond-wasm/src/types/queue.rs
@@ -110,13 +110,10 @@ impl<T: NestedDecode> NestedDecode for Queue<T> {
 
 /// Deserializes like a Vec.
 impl<T: NestedDecode> TopDecode for Queue<T> {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        Vec::<T>::top_decode(input, |res| match res {
-            Ok(vec) => f(Ok(Queue {
-                vec,
-                start: 0,
-            })),
-            Err(e) => f(Err(e)),
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Ok(Queue {
+            vec: Vec::<T>::top_decode(input)?,
+            start: 0,
         })
     }
 }

--- a/elrond-wasm/src/types/queue.rs
+++ b/elrond-wasm/src/types/queue.rs
@@ -88,7 +88,11 @@ impl<T: NestedEncode> NestedEncode for Queue<T> {
 	#[inline]
 	fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         self.as_slice().dep_encode(dest)
-	}
+    }
+    
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        self.as_slice().dep_encode_or_exit(dest, c, exit);
+    }
 }
 
 impl<T: NestedEncode> TopEncode for Queue<T> {

--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -11,18 +11,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-debug"

--- a/examples/adder/Cargo.toml
+++ b/examples/adder/Cargo.toml
@@ -11,18 +11,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-debug"

--- a/examples/adder/debug/Cargo.toml
+++ b/examples/adder/debug/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 adder = { path = ".." }
-elrond-wasm = { version = "0.9.0", path = "../../../elrond-wasm" }
-elrond-wasm-debug = { version = "0.9.0", path = "../../../elrond-wasm-debug" }
+elrond-wasm = { version = "0.9.1", path = "../../../elrond-wasm" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../../elrond-wasm-debug" }

--- a/examples/adder/debug/Cargo.toml
+++ b/examples/adder/debug/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 adder = { path = ".." }
-elrond-wasm = { version = "0.8.0", path = "../../../elrond-wasm" }
-elrond-wasm-debug = { version = "0.8.0", path = "../../../elrond-wasm-debug" }
+elrond-wasm = { version = "0.9.0", path = "../../../elrond-wasm" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../../elrond-wasm-debug" }

--- a/examples/adder/wasm/Cargo.toml
+++ b/examples/adder/wasm/Cargo.toml
@@ -25,3 +25,4 @@ path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 
 [workspace]
+members = ["."]

--- a/examples/adder/wasm/Cargo.toml
+++ b/examples/adder/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/examples/adder/wasm/Cargo.toml
+++ b/examples/adder/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/examples/crowdfunding-egld/Cargo.toml
+++ b/examples/crowdfunding-egld/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.1", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.1", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.1", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../elrond-wasm-debug" }

--- a/examples/crowdfunding-egld/Cargo.toml
+++ b/examples/crowdfunding-egld/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.8.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.8.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.8.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.8.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }

--- a/examples/crowdfunding-egld/src/lib.rs
+++ b/examples/crowdfunding-egld/src/lib.rs
@@ -141,4 +141,13 @@ impl TopDecode for Status {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         Status::from_u8(u8::top_decode(input)?)
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        match u8::top_decode_or_exit(input, c.clone(), exit) {
+            0 => Status::FundingPeriod,
+            1 => Status::Successful,
+            2 => Status::Failed,
+            _ => exit(c, DecodeError::INVALID_VALUE),
+        }
+    }
 }

--- a/examples/crowdfunding-egld/src/lib.rs
+++ b/examples/crowdfunding-egld/src/lib.rs
@@ -131,6 +131,10 @@ impl TopEncode for Status {
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
         self.to_u8().top_encode(output)
     }
+    
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_u8().top_encode_or_exit(output, c, exit)
+	}
 }
 
 impl TopDecode for Status {

--- a/examples/crowdfunding-egld/src/lib.rs
+++ b/examples/crowdfunding-egld/src/lib.rs
@@ -134,10 +134,7 @@ impl TopEncode for Status {
 }
 
 impl TopDecode for Status {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        u8::top_decode(input, |res| match res {
-            core::result::Result::Ok(num) => f(Status::from_u8(num)),
-            core::result::Result::Err(e) => f(core::result::Result::Err(e)),
-        })
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Status::from_u8(u8::top_decode(input)?)
     }
 }

--- a/examples/crowdfunding-egld/wasm/Cargo.toml
+++ b/examples/crowdfunding-egld/wasm/Cargo.toml
@@ -16,6 +16,6 @@ panic = "abort"
 
 [dependencies]
 crowdfunding = { path = "..", features=["wasm-output-mode"]}
-elrond-wasm-output = { version = "0.8.0", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
+elrond-wasm-output = { version = "0.9.0", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
 
 [workspace]

--- a/examples/crowdfunding-egld/wasm/Cargo.toml
+++ b/examples/crowdfunding-egld/wasm/Cargo.toml
@@ -19,3 +19,4 @@ crowdfunding = { path = "..", features=["wasm-output-mode"]}
 elrond-wasm-output = { version = "0.9.0", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
 
 [workspace]
+members = ["."]

--- a/examples/crowdfunding-egld/wasm/Cargo.toml
+++ b/examples/crowdfunding-egld/wasm/Cargo.toml
@@ -16,7 +16,7 @@ panic = "abort"
 
 [dependencies]
 crowdfunding = { path = "..", features=["wasm-output-mode"]}
-elrond-wasm-output = { version = "0.9.0", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
+elrond-wasm-output = { version = "0.9.1", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
 
 [workspace]
 members = ["."]

--- a/examples/crowdfunding-erc20/Cargo.toml
+++ b/examples/crowdfunding-erc20/Cargo.toml
@@ -11,10 +11,10 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.1", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.1", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.1", path = "../../elrond-wasm-node", optional = true }
 simple-erc20 = { path = "../simple-erc20" }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../elrond-wasm-debug" }

--- a/examples/crowdfunding-erc20/Cargo.toml
+++ b/examples/crowdfunding-erc20/Cargo.toml
@@ -11,10 +11,10 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.8.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.8.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.8.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
 simple-erc20 = { path = "../simple-erc20" }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.8.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }

--- a/examples/crowdfunding-erc20/src/lib.rs
+++ b/examples/crowdfunding-erc20/src/lib.rs
@@ -201,6 +201,10 @@ impl Status {
 impl TopEncode for Status {
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
         self.to_u8().top_encode(output)
+    }
+    
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_u8().top_encode_or_exit(output, c, exit)
 	}
 }
 

--- a/examples/crowdfunding-erc20/src/lib.rs
+++ b/examples/crowdfunding-erc20/src/lib.rs
@@ -205,10 +205,7 @@ impl TopEncode for Status {
 }
 
 impl TopDecode for Status {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        u8::top_decode(input, |res| match res {
-            core::result::Result::Ok(num) => f(Status::from_u8(num)),
-            core::result::Result::Err(e) => f(core::result::Result::Err(e)),
-        })
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Status::from_u8(u8::top_decode(input)?)
     }
 }

--- a/examples/crowdfunding-erc20/src/lib.rs
+++ b/examples/crowdfunding-erc20/src/lib.rs
@@ -212,4 +212,13 @@ impl TopDecode for Status {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         Status::from_u8(u8::top_decode(input)?)
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        match u8::top_decode_or_exit(input, c.clone(), exit) {
+            0 => Status::FundingPeriod,
+            1 => Status::Successful,
+            2 => Status::Failed,
+            _ => exit(c, DecodeError::INVALID_VALUE),
+        }
+    }
 }

--- a/examples/crowdfunding-erc20/wasm/Cargo.toml
+++ b/examples/crowdfunding-erc20/wasm/Cargo.toml
@@ -16,6 +16,6 @@ panic = "abort"
 
 [dependencies]
 crowdfunding-erc20 = { path = "..", features=["wasm-output-mode"]}
-elrond-wasm-output = { version = "0.8.0", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
+elrond-wasm-output = { version = "0.9.0", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
 
 [workspace]

--- a/examples/crowdfunding-erc20/wasm/Cargo.toml
+++ b/examples/crowdfunding-erc20/wasm/Cargo.toml
@@ -19,3 +19,4 @@ crowdfunding-erc20 = { path = "..", features=["wasm-output-mode"]}
 elrond-wasm-output = { version = "0.9.0", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
 
 [workspace]
+members = ["."]

--- a/examples/crowdfunding-erc20/wasm/Cargo.toml
+++ b/examples/crowdfunding-erc20/wasm/Cargo.toml
@@ -16,7 +16,7 @@ panic = "abort"
 
 [dependencies]
 crowdfunding-erc20 = { path = "..", features=["wasm-output-mode"]}
-elrond-wasm-output = { version = "0.9.0", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
+elrond-wasm-output = { version = "0.9.1", path = "../../../elrond-wasm-output", features=["wasm-output-mode"]}
 
 [workspace]
 members = ["."]

--- a/examples/crypto-bubbles/Cargo.toml
+++ b/examples/crypto-bubbles/Cargo.toml
@@ -11,18 +11,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-debug"

--- a/examples/crypto-bubbles/Cargo.toml
+++ b/examples/crypto-bubbles/Cargo.toml
@@ -11,18 +11,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-debug"

--- a/examples/crypto-bubbles/wasm/Cargo.toml
+++ b/examples/crypto-bubbles/wasm/Cargo.toml
@@ -25,3 +25,4 @@ path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 
 [workspace]
+members = ["."]

--- a/examples/crypto-bubbles/wasm/Cargo.toml
+++ b/examples/crypto-bubbles/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/examples/crypto-bubbles/wasm/Cargo.toml
+++ b/examples/crypto-bubbles/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/examples/factorial/Cargo.toml
+++ b/examples/factorial/Cargo.toml
@@ -11,18 +11,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-debug"

--- a/examples/factorial/Cargo.toml
+++ b/examples/factorial/Cargo.toml
@@ -11,18 +11,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-debug"

--- a/examples/factorial/wasm/Cargo.toml
+++ b/examples/factorial/wasm/Cargo.toml
@@ -25,3 +25,4 @@ path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 
 [workspace]
+members = ["."]

--- a/examples/factorial/wasm/Cargo.toml
+++ b/examples/factorial/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/examples/factorial/wasm/Cargo.toml
+++ b/examples/factorial/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/examples/lottery-erc20/Cargo.toml
+++ b/examples/lottery-erc20/Cargo.toml
@@ -11,15 +11,15 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-node"
 optional = true
 
@@ -27,5 +27,5 @@ optional = true
 path = "../simple-erc20"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-debug"

--- a/examples/lottery-erc20/Cargo.toml
+++ b/examples/lottery-erc20/Cargo.toml
@@ -11,15 +11,15 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-node"
 optional = true
 
@@ -27,5 +27,5 @@ optional = true
 path = "../simple-erc20"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-debug"

--- a/examples/lottery-erc20/src/lottery_info.rs
+++ b/examples/lottery-erc20/src/lottery_info.rs
@@ -14,25 +14,30 @@ pub struct LotteryInfo<BigUint:BigUintApi> {
 }
 
 impl<BigUint:BigUintApi> NestedEncode for LotteryInfo<BigUint> {
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-        self.ticket_price.dep_encode_to(dest)?;
-        self.tickets_left.dep_encode_to(dest)?;
-        self.deadline.dep_encode_to(dest)?;
-        self.max_entries_per_user.dep_encode_to(dest)?;
-        self.prize_distribution.dep_encode_to(dest)?;
-        self.whitelist.dep_encode_to(dest)?;
-        self.current_ticket_number.dep_encode_to(dest)?;
-        self.prize_pool.dep_encode_to(dest)?;
-        self.queued_tickets.dep_encode_to(dest)?;
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+        self.ticket_price.dep_encode(dest)?;
+        self.tickets_left.dep_encode(dest)?;
+        self.deadline.dep_encode(dest)?;
+        self.max_entries_per_user.dep_encode(dest)?;
+        self.prize_distribution.dep_encode(dest)?;
+        self.whitelist.dep_encode(dest)?;
+        self.current_ticket_number.dep_encode(dest)?;
+        self.prize_pool.dep_encode(dest)?;
+        self.queued_tickets.dep_encode(dest)?;
 
         Ok(())
     }
 }
 
 impl<BigUint:BigUintApi> TopEncode for LotteryInfo<BigUint> {
+    #[inline]
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
-        output.set_slice_u8(dep_encode_to_vec(self)?.as_slice());
-        Ok(())
+        top_encode_from_nested(self, output)
+    }
+
+    #[inline]
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        top_encode_from_nested_or_exit(self, output, c, exit);
     }
 }
 

--- a/examples/lottery-erc20/src/lottery_info.rs
+++ b/examples/lottery-erc20/src/lottery_info.rs
@@ -27,6 +27,18 @@ impl<BigUint:BigUintApi> NestedEncode for LotteryInfo<BigUint> {
 
         Ok(())
     }
+
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        self.ticket_price.dep_encode_or_exit(dest, c.clone(), exit);
+        self.tickets_left.dep_encode_or_exit(dest, c.clone(), exit);
+        self.deadline.dep_encode_or_exit(dest, c.clone(), exit);
+        self.max_entries_per_user.dep_encode_or_exit(dest, c.clone(), exit);
+        self.prize_distribution.dep_encode_or_exit(dest, c.clone(), exit);
+        self.whitelist.dep_encode_or_exit(dest, c.clone(), exit);
+        self.current_ticket_number.dep_encode_or_exit(dest, c.clone(), exit);
+        self.prize_pool.dep_encode_or_exit(dest, c.clone(), exit);
+        self.queued_tickets.dep_encode_or_exit(dest, c.clone(), exit);
+    }
 }
 
 impl<BigUint:BigUintApi> TopEncode for LotteryInfo<BigUint> {

--- a/examples/lottery-erc20/src/lottery_info.rs
+++ b/examples/lottery-erc20/src/lottery_info.rs
@@ -68,6 +68,20 @@ impl<BigUint:BigUintApi> NestedDecode for LotteryInfo<BigUint> {
             queued_tickets: u32::dep_decode(input)?,
         })
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        LotteryInfo {
+            ticket_price: BigUint::dep_decode_or_exit(input, c.clone(), exit),
+            tickets_left: u32::dep_decode_or_exit(input, c.clone(), exit),
+            deadline: u64::dep_decode_or_exit(input, c.clone(), exit),
+            max_entries_per_user: u32::dep_decode_or_exit(input, c.clone(), exit),
+            prize_distribution: Vec::<u8>::dep_decode_or_exit(input, c.clone(), exit),
+            whitelist: Vec::<Address>::dep_decode_or_exit(input, c.clone(), exit),
+            current_ticket_number: u32::dep_decode_or_exit(input, c.clone(), exit),
+            prize_pool: BigUint::dep_decode_or_exit(input, c.clone(), exit),
+            queued_tickets: u32::dep_decode_or_exit(input, c.clone(), exit),
+        }
+    }
 }
 
 impl<BigUint:BigUintApi> TopDecode for LotteryInfo<BigUint> {

--- a/examples/lottery-erc20/src/lottery_info.rs
+++ b/examples/lottery-erc20/src/lottery_info.rs
@@ -74,4 +74,8 @@ impl<BigUint:BigUintApi> TopDecode for LotteryInfo<BigUint> {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         top_decode_from_nested(input)
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        top_decode_from_nested_or_exit(input, c, exit)
+    }
 }

--- a/examples/lottery-erc20/src/lottery_info.rs
+++ b/examples/lottery-erc20/src/lottery_info.rs
@@ -38,23 +38,23 @@ impl<BigUint:BigUintApi> TopEncode for LotteryInfo<BigUint> {
 
 
 impl<BigUint:BigUintApi> NestedDecode for LotteryInfo<BigUint> {
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
         Ok(LotteryInfo {
-            ticket_price: BigUint::dep_decode_to(input)?,
-            tickets_left: u32::dep_decode_to(input)?,
-            deadline: u64::dep_decode_to(input)?,
-            max_entries_per_user: u32::dep_decode_to(input)?,
-            prize_distribution: Vec::<u8>::dep_decode_to(input)?,
-            whitelist: Vec::<Address>::dep_decode_to(input)?,
-            current_ticket_number: u32::dep_decode_to(input)?,
-            prize_pool: BigUint::dep_decode_to(input)?,
-            queued_tickets: u32::dep_decode_to(input)?,
+            ticket_price: BigUint::dep_decode(input)?,
+            tickets_left: u32::dep_decode(input)?,
+            deadline: u64::dep_decode(input)?,
+            max_entries_per_user: u32::dep_decode(input)?,
+            prize_distribution: Vec::<u8>::dep_decode(input)?,
+            whitelist: Vec::<Address>::dep_decode(input)?,
+            current_ticket_number: u32::dep_decode(input)?,
+            prize_pool: BigUint::dep_decode(input)?,
+            queued_tickets: u32::dep_decode(input)?,
         })
     }
 }
 
 impl<BigUint:BigUintApi> TopDecode for LotteryInfo<BigUint> {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        top_decode_from_nested(input, f)
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        top_decode_from_nested(input)
     }
 }

--- a/examples/lottery-erc20/src/status.rs
+++ b/examples/lottery-erc20/src/status.rs
@@ -43,4 +43,15 @@ impl TopDecode for Status {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         Status::from_u8(u8::top_decode(input)?)
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        match u8::top_decode_or_exit(input, c.clone(), exit) {
+            0 => Status::Inactive,
+            1 => Status::Running,
+            2 => Status::Ended,
+            3 => Status::DistributingPrizes,
+            _ => exit(c, DecodeError::INVALID_VALUE),
+        }
+    }
+
 }

--- a/examples/lottery-erc20/src/status.rs
+++ b/examples/lottery-erc20/src/status.rs
@@ -33,6 +33,10 @@ impl TopEncode for Status {
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
         self.to_u8().top_encode(output)
     }
+
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_u8().top_encode_or_exit(output, c, exit)
+	}
 }
 
 impl TopDecode for Status {

--- a/examples/lottery-erc20/src/status.rs
+++ b/examples/lottery-erc20/src/status.rs
@@ -36,10 +36,7 @@ impl TopEncode for Status {
 }
 
 impl TopDecode for Status {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        u8::top_decode(input, |res| match res {
-            core::result::Result::Ok(num) => f(Status::from_u8(num)),
-            core::result::Result::Err(e) => f(core::result::Result::Err(e)),
-        })
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Status::from_u8(u8::top_decode(input)?)
     }
 }

--- a/examples/lottery-erc20/wasm/Cargo.toml
+++ b/examples/lottery-erc20/wasm/Cargo.toml
@@ -23,5 +23,5 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.9.0"
+version = "0.9.1"
 features = [ "wasm-output-mode",]

--- a/examples/lottery-erc20/wasm/Cargo.toml
+++ b/examples/lottery-erc20/wasm/Cargo.toml
@@ -22,5 +22,5 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.8.0"
+version = "0.9.0"
 features = [ "wasm-output-mode",]

--- a/examples/lottery-erc20/wasm/Cargo.toml
+++ b/examples/lottery-erc20/wasm/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 crate-type = [ "cdylib",]
 
 [workspace]
+members = ["."]
 
 [profile.release]
 codegen-units = 1

--- a/examples/lottery/Cargo.toml
+++ b/examples/lottery/Cargo.toml
@@ -11,18 +11,18 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-debug"

--- a/examples/lottery/Cargo.toml
+++ b/examples/lottery/Cargo.toml
@@ -11,18 +11,18 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-debug"

--- a/examples/lottery/src/lottery_info.rs
+++ b/examples/lottery/src/lottery_info.rs
@@ -70,4 +70,8 @@ impl<BigUint:BigUintApi> TopDecode for LotteryInfo<BigUint> {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         top_decode_from_nested(input)
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        top_decode_from_nested_or_exit(input, c, exit)
+    }
 }

--- a/examples/lottery/src/lottery_info.rs
+++ b/examples/lottery/src/lottery_info.rs
@@ -64,6 +64,19 @@ impl<BigUint:BigUintApi> NestedDecode for LotteryInfo<BigUint> {
             prize_pool: BigUint::dep_decode(input)?,
         })
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        LotteryInfo {
+            ticket_price: BigUint::dep_decode_or_exit(input, c.clone(), exit),
+            tickets_left: u32::dep_decode_or_exit(input, c.clone(), exit),
+            deadline: u64::dep_decode_or_exit(input, c.clone(), exit),
+            max_entries_per_user: u32::dep_decode_or_exit(input, c.clone(), exit),
+            prize_distribution: Vec::<u8>::dep_decode_or_exit(input, c.clone(), exit),
+            whitelist: Vec::<Address>::dep_decode_or_exit(input, c.clone(), exit),
+            current_ticket_number: u32::dep_decode_or_exit(input, c.clone(), exit),
+            prize_pool: BigUint::dep_decode_or_exit(input, c.clone(), exit),
+        }
+    }
 }
 
 impl<BigUint:BigUintApi> TopDecode for LotteryInfo<BigUint> {

--- a/examples/lottery/src/lottery_info.rs
+++ b/examples/lottery/src/lottery_info.rs
@@ -36,22 +36,22 @@ impl<BigUint:BigUintApi> TopEncode for LotteryInfo<BigUint> {
 
 
 impl<BigUint:BigUintApi> NestedDecode for LotteryInfo<BigUint> {
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
         Ok(LotteryInfo {
-            ticket_price: BigUint::dep_decode_to(input)?,
-            tickets_left: u32::dep_decode_to(input)?,
-            deadline: u64::dep_decode_to(input)?,
-            max_entries_per_user: u32::dep_decode_to(input)?,
-            prize_distribution: Vec::<u8>::dep_decode_to(input)?,
-            whitelist: Vec::<Address>::dep_decode_to(input)?,
-            current_ticket_number: u32::dep_decode_to(input)?,
-            prize_pool: BigUint::dep_decode_to(input)?,
+            ticket_price: BigUint::dep_decode(input)?,
+            tickets_left: u32::dep_decode(input)?,
+            deadline: u64::dep_decode(input)?,
+            max_entries_per_user: u32::dep_decode(input)?,
+            prize_distribution: Vec::<u8>::dep_decode(input)?,
+            whitelist: Vec::<Address>::dep_decode(input)?,
+            current_ticket_number: u32::dep_decode(input)?,
+            prize_pool: BigUint::dep_decode(input)?,
         })
     }
 }
 
 impl<BigUint:BigUintApi> TopDecode for LotteryInfo<BigUint> {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        top_decode_from_nested(input, f)
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        top_decode_from_nested(input)
     }
 }

--- a/examples/lottery/src/lottery_info.rs
+++ b/examples/lottery/src/lottery_info.rs
@@ -13,24 +13,29 @@ pub struct LotteryInfo<BigUint:BigUintApi> {
 }
 
 impl<BigUint:BigUintApi> NestedEncode for LotteryInfo<BigUint> {
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-        self.ticket_price.dep_encode_to(dest)?;
-        self.tickets_left.dep_encode_to(dest)?;
-        self.deadline.dep_encode_to(dest)?;
-        self.max_entries_per_user.dep_encode_to(dest)?;
-        self.prize_distribution.dep_encode_to(dest)?;
-        self.whitelist.dep_encode_to(dest)?;
-        self.current_ticket_number.dep_encode_to(dest)?;
-        self.prize_pool.dep_encode_to(dest)?;
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+        self.ticket_price.dep_encode(dest)?;
+        self.tickets_left.dep_encode(dest)?;
+        self.deadline.dep_encode(dest)?;
+        self.max_entries_per_user.dep_encode(dest)?;
+        self.prize_distribution.dep_encode(dest)?;
+        self.whitelist.dep_encode(dest)?;
+        self.current_ticket_number.dep_encode(dest)?;
+        self.prize_pool.dep_encode(dest)?;
 
         Ok(())
     }
 }
 
 impl<BigUint:BigUintApi> TopEncode for LotteryInfo<BigUint> {
+    #[inline]
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
-        output.set_slice_u8(dep_encode_to_vec(self)?.as_slice());
-        Ok(())
+        top_encode_from_nested(self, output)
+    }
+
+    #[inline]
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        top_encode_from_nested_or_exit(self, output, c, exit);
     }
 }
 

--- a/examples/lottery/src/lottery_info.rs
+++ b/examples/lottery/src/lottery_info.rs
@@ -25,6 +25,17 @@ impl<BigUint:BigUintApi> NestedEncode for LotteryInfo<BigUint> {
 
         Ok(())
     }
+
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        self.ticket_price.dep_encode_or_exit(dest, c.clone(), exit);
+        self.tickets_left.dep_encode_or_exit(dest, c.clone(), exit);
+        self.deadline.dep_encode_or_exit(dest, c.clone(), exit);
+        self.max_entries_per_user.dep_encode_or_exit(dest, c.clone(), exit);
+        self.prize_distribution.dep_encode_or_exit(dest, c.clone(), exit);
+        self.whitelist.dep_encode_or_exit(dest, c.clone(), exit);
+        self.current_ticket_number.dep_encode_or_exit(dest, c.clone(), exit);
+        self.prize_pool.dep_encode_or_exit(dest, c.clone(), exit);
+    }
 }
 
 impl<BigUint:BigUintApi> TopEncode for LotteryInfo<BigUint> {

--- a/examples/lottery/src/status.rs
+++ b/examples/lottery/src/status.rs
@@ -30,6 +30,10 @@ impl TopEncode for Status {
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
         self.to_u8().top_encode(output)
     }
+
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.to_u8().top_encode_or_exit(output, c, exit)
+	}
 }
 
 impl TopDecode for Status {

--- a/examples/lottery/src/status.rs
+++ b/examples/lottery/src/status.rs
@@ -40,4 +40,13 @@ impl TopDecode for Status {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         Status::from_u8(u8::top_decode(input)?)
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        match u8::top_decode_or_exit(input, c.clone(), exit) {
+            0 => Status::Inactive,
+            1 => Status::Running,
+            2 => Status::Ended,
+            _ => exit(c, DecodeError::INVALID_VALUE),
+        }
+    }
 }

--- a/examples/lottery/src/status.rs
+++ b/examples/lottery/src/status.rs
@@ -33,10 +33,7 @@ impl TopEncode for Status {
 }
 
 impl TopDecode for Status {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        u8::top_decode(input, |res| match res {
-            core::result::Result::Ok(num) => f(Status::from_u8(num)),
-            core::result::Result::Err(e) => f(core::result::Result::Err(e)),
-        })
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Status::from_u8(u8::top_decode(input)?)
     }
 }

--- a/examples/lottery/wasm/Cargo.toml
+++ b/examples/lottery/wasm/Cargo.toml
@@ -23,5 +23,5 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.9.0"
+version = "0.9.1"
 features = [ "wasm-output-mode",]

--- a/examples/lottery/wasm/Cargo.toml
+++ b/examples/lottery/wasm/Cargo.toml
@@ -22,5 +22,5 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.8.0"
+version = "0.9.0"
 features = [ "wasm-output-mode",]

--- a/examples/lottery/wasm/Cargo.toml
+++ b/examples/lottery/wasm/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 crate-type = [ "cdylib",]
 
 [workspace]
+members = ["."]
 
 [profile.release]
 codegen-units = 1

--- a/examples/simple-erc20/Cargo.toml
+++ b/examples/simple-erc20/Cargo.toml
@@ -11,20 +11,20 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../elrond-wasm-debug"
 
 [dependencies]

--- a/examples/simple-erc20/Cargo.toml
+++ b/examples/simple-erc20/Cargo.toml
@@ -11,20 +11,20 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../elrond-wasm-debug"
 
 [dependencies]

--- a/examples/simple-erc20/wasm/Cargo.toml
+++ b/examples/simple-erc20/wasm/Cargo.toml
@@ -25,3 +25,4 @@ path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 
 [workspace]
+members = ["."]

--- a/examples/simple-erc20/wasm/Cargo.toml
+++ b/examples/simple-erc20/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/examples/simple-erc20/wasm/Cargo.toml
+++ b/examples/simple-erc20/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/mandos/Cargo.toml
+++ b/mandos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mandos"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]

--- a/modules/elrond-wasm-module-features/Cargo.toml
+++ b/modules/elrond-wasm-module-features/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-module-features"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -17,9 +17,9 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies"]
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.8.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.8.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.8.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.8.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }

--- a/modules/elrond-wasm-module-features/Cargo.toml
+++ b/modules/elrond-wasm-module-features/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-module-features"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -17,9 +17,9 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies"]
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.1", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.1", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.1", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../elrond-wasm-debug" }

--- a/modules/elrond-wasm-module-features/src/lib.rs
+++ b/modules/elrond-wasm-module-features/src/lib.rs
@@ -55,7 +55,7 @@ pub struct FeatureName<'a>(&'a [u8]);
 use elrond_wasm::elrond_codec::*;
 impl<'a> NestedEncode for FeatureName<'a> {
     #[inline]
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         dest.write(&self.0[..]);
         Result::Ok(())
     }

--- a/modules/elrond-wasm-module-features/src/lib.rs
+++ b/modules/elrond-wasm-module-features/src/lib.rs
@@ -59,6 +59,11 @@ impl<'a> NestedEncode for FeatureName<'a> {
         dest.write(&self.0[..]);
         Result::Ok(())
     }
+
+    #[inline]
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, _: ExitCtx, _: fn(ExitCtx, EncodeError) -> !) {
+        dest.write(&self.0[..]);
+    }
 }
 
 /// Expands to a snippet that returns with error if a feature is not enabled.

--- a/modules/elrond-wasm-module-pause/Cargo.toml
+++ b/modules/elrond-wasm-module-pause/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-module-pause"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -17,9 +17,9 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies"]
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.1", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.1", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.1", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../elrond-wasm-debug" }

--- a/modules/elrond-wasm-module-pause/Cargo.toml
+++ b/modules/elrond-wasm-module-pause/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-module-pause"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network<contact@elrond.com>"]
@@ -17,9 +17,9 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies"]
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.8.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.8.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.8.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.8.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }

--- a/test-contracts/async/Cargo.toml
+++ b/test-contracts/async/Cargo.toml
@@ -14,9 +14,9 @@ wasm-output-mode = ["elrond-wasm-node"]
 async-alice = { path = "async-alice" }
 async-bob = { path = "async-bob" }
 
-elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.1", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.1", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.1", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../elrond-wasm-debug" }

--- a/test-contracts/async/Cargo.toml
+++ b/test-contracts/async/Cargo.toml
@@ -14,9 +14,9 @@ wasm-output-mode = ["elrond-wasm-node"]
 async-alice = { path = "async-alice" }
 async-bob = { path = "async-bob" }
 
-elrond-wasm = { version = "0.8.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.8.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.8.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.8.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }

--- a/test-contracts/async/async-alice/Cargo.toml
+++ b/test-contracts/async/async-alice/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.8.0", path = "../../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.8.0", path = "../../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.8.0", path = "../../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.0", path = "../../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.0", path = "../../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.0", path = "../../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.8.0", path = "../../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../../elrond-wasm-debug" }

--- a/test-contracts/async/async-alice/Cargo.toml
+++ b/test-contracts/async/async-alice/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.9.0", path = "../../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.9.0", path = "../../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.9.0", path = "../../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.1", path = "../../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.1", path = "../../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.1", path = "../../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.9.0", path = "../../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../../elrond-wasm-debug" }

--- a/test-contracts/async/async-alice/wasm/Cargo.toml
+++ b/test-contracts/async/async-alice/wasm/Cargo.toml
@@ -19,3 +19,4 @@ async-alice = { path = "..", features=["wasm-output-mode"] }
 elrond-wasm-output = { version = "0.9.0", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
 
 [workspace]
+members = ["."]

--- a/test-contracts/async/async-alice/wasm/Cargo.toml
+++ b/test-contracts/async/async-alice/wasm/Cargo.toml
@@ -16,7 +16,7 @@ panic = "abort"
 
 [dependencies]
 async-alice = { path = "..", features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.9.0", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
+elrond-wasm-output = { version = "0.9.1", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
 
 [workspace]
 members = ["."]

--- a/test-contracts/async/async-alice/wasm/Cargo.toml
+++ b/test-contracts/async/async-alice/wasm/Cargo.toml
@@ -16,6 +16,6 @@ panic = "abort"
 
 [dependencies]
 async-alice = { path = "..", features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.8.0", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
+elrond-wasm-output = { version = "0.9.0", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
 
 [workspace]

--- a/test-contracts/async/async-bob/Cargo.toml
+++ b/test-contracts/async/async-bob/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.8.0", path = "../../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.8.0", path = "../../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.8.0", path = "../../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.0", path = "../../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.0", path = "../../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.0", path = "../../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.8.0", path = "../../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../../elrond-wasm-debug" }

--- a/test-contracts/async/async-bob/Cargo.toml
+++ b/test-contracts/async/async-bob/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.9.0", path = "../../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.9.0", path = "../../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.9.0", path = "../../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.1", path = "../../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.1", path = "../../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.1", path = "../../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.9.0", path = "../../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../../elrond-wasm-debug" }

--- a/test-contracts/async/async-bob/wasm/Cargo.toml
+++ b/test-contracts/async/async-bob/wasm/Cargo.toml
@@ -19,3 +19,4 @@ async-bob = { path = "..", features=["wasm-output-mode"] }
 elrond-wasm-output = { version = "0.9.0", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
 
 [workspace]
+members = ["."]

--- a/test-contracts/async/async-bob/wasm/Cargo.toml
+++ b/test-contracts/async/async-bob/wasm/Cargo.toml
@@ -16,7 +16,7 @@ panic = "abort"
 
 [dependencies]
 async-bob = { path = "..", features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.9.0", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
+elrond-wasm-output = { version = "0.9.1", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
 
 [workspace]
 members = ["."]

--- a/test-contracts/async/async-bob/wasm/Cargo.toml
+++ b/test-contracts/async/async-bob/wasm/Cargo.toml
@@ -16,6 +16,6 @@ panic = "abort"
 
 [dependencies]
 async-bob = { path = "..", features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.8.0", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
+elrond-wasm-output = { version = "0.9.0", path = "../../../../elrond-wasm-output", features=["wasm-output-mode"] }
 
 [workspace]

--- a/test-contracts/basic-features/Cargo.toml
+++ b/test-contracts/basic-features/Cargo.toml
@@ -11,10 +11,10 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.8.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.8.0", path = "../../elrond-wasm-derive" }
-# elrond-wasm-node = { version = "0.8.0", path = "../../elrond-wasm-node", optional = true } # <- no small int api used
-elrond-wasm-node = { version = "0.8.0", path = "../../elrond-wasm-node", optional = true, features = ["small-int-ei"] }
+elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
+# elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true } # <- no small int api used
+elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true, features = ["small-int-ei"] }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.8.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }

--- a/test-contracts/basic-features/Cargo.toml
+++ b/test-contracts/basic-features/Cargo.toml
@@ -11,10 +11,10 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies]
-elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
-# elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true } # <- no small int api used
-elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true, features = ["small-int-ei"] }
+elrond-wasm = { version = "0.9.1", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.1", path = "../../elrond-wasm-derive" }
+# elrond-wasm-node = { version = "0.9.1", path = "../../elrond-wasm-node", optional = true } # <- no small int api used
+elrond-wasm-node = { version = "0.9.1", path = "../../elrond-wasm-node", optional = true, features = ["small-int-ei"] }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../elrond-wasm-debug" }

--- a/test-contracts/basic-features/mandos/echo_big_int.scen.json
+++ b/test-contracts/basic-features/mandos/echo_big_int.scen.json
@@ -1,0 +1,253 @@
+{
+    "name": "echo_big_int",
+    "steps": [
+        {
+            "step": "setState",
+            "accounts": {
+                "address:features_contract": {
+                    "nonce": "0",
+                    "balance": "0x100",
+                    "storage": {},
+                    "code": "file:../output/features.wasm"
+                },
+                "address:an_account": {
+                    "nonce": "0",
+                    "balance": "0x900abc",
+                    "storage": {},
+                    "code": ""
+                }
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "1",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_int",
+                "arguments": [
+                    "0"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    ""
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "2",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_int",
+                "arguments": [
+                    "5"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "5"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "3",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_int",
+                "arguments": [
+                    "-3"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "0xfd"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "4",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_int",
+                "arguments": [
+                    "0x010000000000000000"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "0x010000000000000000"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "5",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_int",
+                "arguments": [
+                    "0xffffffffffffffff"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "0xff"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "6",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_int",
+                "arguments": [
+                    "0x7fffffffffffffff"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "0x7fffffffffffffff"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "7",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_int",
+                "arguments": [
+                    "+9223372036854775808"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "+9223372036854775808"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "8",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_int",
+                "arguments": [
+                    "-9223372036854775809"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "-9223372036854775809"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "9-zero",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_int",
+                "arguments": [
+                    "0x00"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [ "0" ],
+                "status": "0",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:features_contract": {
+                    "nonce": "*",
+                    "balance": "*",
+                    "storage": {},
+                    "code": "file:../output/features.wasm"
+                },
+                "address:an_account": {
+                    "nonce": "*",
+                    "balance": "*",
+                    "storage": {},
+                    "code": ""
+                }
+            }
+        }
+    ]
+}

--- a/test-contracts/basic-features/mandos/echo_big_uint.scen.json
+++ b/test-contracts/basic-features/mandos/echo_big_uint.scen.json
@@ -1,0 +1,159 @@
+{
+    "name": "echo_big_uint",
+    "steps": [
+        {
+            "step": "setState",
+            "accounts": {
+                "address:features_contract": {
+                    "nonce": "0",
+                    "balance": "0x100",
+                    "storage": {},
+                    "code": "file:../output/features.wasm"
+                },
+                "address:an_account": {
+                    "nonce": "0",
+                    "balance": "0x900abc",
+                    "storage": {},
+                    "code": ""
+                }
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "1",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_uint",
+                "arguments": [
+                    "0"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    ""
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "2",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_uint",
+                "arguments": [
+                    "5"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "5"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "3",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_uint",
+                "arguments": [
+                    "0xc8"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "0xc8"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "4",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_uint",
+                "arguments": [
+                    "0xffffffffffffffff"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "0xffffffffffffffff"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "5",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_big_uint",
+                "arguments": [
+                    "0x010000000000000000"
+                ],
+                "gasLimit": "0x100000",
+                "gasPrice": "0x01"
+            },
+            "expect": {
+                "out": [
+                    "0x010000000000000000"
+                ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:features_contract": {
+                    "nonce": "0",
+                    "balance": "0x100",
+                    "storage": {},
+                    "code": "file:../output/features.wasm"
+                },
+                "address:an_account": {
+                    "nonce": "*",
+                    "balance": "*",
+                    "storage": {},
+                    "code": ""
+                }
+            }
+        }
+    ]
+}

--- a/test-contracts/basic-features/src/large_boxed_byte_array.rs
+++ b/test-contracts/basic-features/src/large_boxed_byte_array.rs
@@ -28,7 +28,7 @@ impl NestedDecode for LargeBoxedByteArray {
 
 impl TopDecode for LargeBoxedByteArray {
     #[inline]
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        Box::<[u8; ARRAY_SIZE]>::top_decode(input, |res| f(res.map(|v| LargeBoxedByteArray(v))))
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        Ok(LargeBoxedByteArray(Box::<[u8; ARRAY_SIZE]>::top_decode(input)?))
     }
 }

--- a/test-contracts/basic-features/src/large_boxed_byte_array.rs
+++ b/test-contracts/basic-features/src/large_boxed_byte_array.rs
@@ -34,6 +34,10 @@ impl NestedDecode for LargeBoxedByteArray {
     fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
         Ok(LargeBoxedByteArray(Box::<[u8; ARRAY_SIZE]>::dep_decode(input)?))
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        LargeBoxedByteArray(Box::<[u8; ARRAY_SIZE]>::dep_decode_or_exit(input, c, exit))
+    }
 }
 
 impl TopDecode for LargeBoxedByteArray {

--- a/test-contracts/basic-features/src/large_boxed_byte_array.rs
+++ b/test-contracts/basic-features/src/large_boxed_byte_array.rs
@@ -7,8 +7,8 @@ pub struct LargeBoxedByteArray(Box<[u8; ARRAY_SIZE]>);
 
 impl NestedEncode for LargeBoxedByteArray {
     #[inline]
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-        self.0.dep_encode_to(dest)
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+        self.0.dep_encode(dest)
     }
 }
 

--- a/test-contracts/basic-features/src/large_boxed_byte_array.rs
+++ b/test-contracts/basic-features/src/large_boxed_byte_array.rs
@@ -41,4 +41,9 @@ impl TopDecode for LargeBoxedByteArray {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         Ok(LargeBoxedByteArray(Box::<[u8; ARRAY_SIZE]>::top_decode(input)?))
     }
+
+    #[inline]
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        LargeBoxedByteArray(Box::<[u8; ARRAY_SIZE]>::top_decode_or_exit(input, c, exit))
+    }
 }

--- a/test-contracts/basic-features/src/large_boxed_byte_array.rs
+++ b/test-contracts/basic-features/src/large_boxed_byte_array.rs
@@ -21,8 +21,8 @@ impl TopEncode for LargeBoxedByteArray {
 
 impl NestedDecode for LargeBoxedByteArray {
     #[inline]
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        Ok(LargeBoxedByteArray(Box::<[u8; ARRAY_SIZE]>::dep_decode_to(input)?))
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        Ok(LargeBoxedByteArray(Box::<[u8; ARRAY_SIZE]>::dep_decode(input)?))
     }
 }
 

--- a/test-contracts/basic-features/src/large_boxed_byte_array.rs
+++ b/test-contracts/basic-features/src/large_boxed_byte_array.rs
@@ -10,6 +10,11 @@ impl NestedEncode for LargeBoxedByteArray {
     fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         self.0.dep_encode(dest)
     }
+
+    #[inline]
+	fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.0.dep_encode_or_exit(dest, c, exit);
+	}
 }
 
 impl TopEncode for LargeBoxedByteArray {
@@ -17,6 +22,11 @@ impl TopEncode for LargeBoxedByteArray {
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
         self.0.top_encode(output)
     }
+
+    #[inline]
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+		self.0.top_encode_or_exit(output, c, exit);
+	}
 }
 
 impl NestedDecode for LargeBoxedByteArray {

--- a/test-contracts/basic-features/src/ser_ex1.rs
+++ b/test-contracts/basic-features/src/ser_ex1.rs
@@ -57,4 +57,8 @@ impl TopDecode for SerExample1 {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         top_decode_from_nested(input)
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        top_decode_from_nested_or_exit(input, c, exit)
+    }
 }

--- a/test-contracts/basic-features/src/ser_ex1.rs
+++ b/test-contracts/basic-features/src/ser_ex1.rs
@@ -11,20 +11,25 @@ pub struct SerExample1 {
 }
 
 impl NestedEncode for SerExample1 {
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-        self.int.dep_encode_to(dest)?;
-        self.seq.dep_encode_to(dest)?;
-        self.another_byte.dep_encode_to(dest)?;
-        self.uint_32.dep_encode_to(dest)?;
-        self.uint_64.dep_encode_to(dest)?;
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+        self.int.dep_encode(dest)?;
+        self.seq.dep_encode(dest)?;
+        self.another_byte.dep_encode(dest)?;
+        self.uint_32.dep_encode(dest)?;
+        self.uint_64.dep_encode(dest)?;
         Ok(())
     }
 }
 
 impl TopEncode for SerExample1 {
+    #[inline]
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
-        output.set_slice_u8(dep_encode_to_vec(self)?.as_slice());
-        Ok(())
+        top_encode_from_nested(self, output)
+    }
+
+    #[inline]
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        top_encode_from_nested_or_exit(self, output, c, exit);
     }
 }
 

--- a/test-contracts/basic-features/src/ser_ex1.rs
+++ b/test-contracts/basic-features/src/ser_ex1.rs
@@ -41,7 +41,7 @@ impl NestedDecode for SerExample1 {
 }
 
 impl TopDecode for SerExample1 {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        top_decode_from_nested(input, f)
+    fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+        dep_decode_from_byte_slice(input.get_slice_u8())
     }
 }

--- a/test-contracts/basic-features/src/ser_ex1.rs
+++ b/test-contracts/basic-features/src/ser_ex1.rs
@@ -19,6 +19,14 @@ impl NestedEncode for SerExample1 {
         self.uint_64.dep_encode(dest)?;
         Ok(())
     }
+
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        self.int.dep_encode_or_exit(dest, c.clone(), exit);
+        self.seq.dep_encode_or_exit(dest, c.clone(), exit);
+        self.another_byte.dep_encode_or_exit(dest, c.clone(), exit);
+        self.uint_32.dep_encode_or_exit(dest, c.clone(), exit);
+        self.uint_64.dep_encode_or_exit(dest, c.clone(), exit);
+    }
 }
 
 impl TopEncode for SerExample1 {

--- a/test-contracts/basic-features/src/ser_ex1.rs
+++ b/test-contracts/basic-features/src/ser_ex1.rs
@@ -29,13 +29,13 @@ impl TopEncode for SerExample1 {
 }
 
 impl NestedDecode for SerExample1 {
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
         Ok(SerExample1{
-            int: u16::dep_decode_to(input)?,
-            seq: Vec::<u8>::dep_decode_to(input)?,
-            another_byte: u8::dep_decode_to(input)?,
-            uint_32: u32::dep_decode_to(input)?,
-            uint_64: u64::dep_decode_to(input)?,
+            int: u16::dep_decode(input)?,
+            seq: Vec::<u8>::dep_decode(input)?,
+            another_byte: u8::dep_decode(input)?,
+            uint_32: u32::dep_decode(input)?,
+            uint_64: u64::dep_decode(input)?,
         })
     }
 }

--- a/test-contracts/basic-features/src/ser_ex1.rs
+++ b/test-contracts/basic-features/src/ser_ex1.rs
@@ -41,7 +41,7 @@ impl NestedDecode for SerExample1 {
 }
 
 impl TopDecode for SerExample1 {
-    fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-        dep_decode_from_byte_slice(input.get_slice_u8())
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        top_decode_from_nested(input)
     }
 }

--- a/test-contracts/basic-features/src/ser_ex1.rs
+++ b/test-contracts/basic-features/src/ser_ex1.rs
@@ -51,6 +51,16 @@ impl NestedDecode for SerExample1 {
             uint_64: u64::dep_decode(input)?,
         })
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        SerExample1{
+            int: u16::dep_decode_or_exit(input, c.clone(), exit),
+            seq: Vec::<u8>::dep_decode_or_exit(input, c.clone(), exit),
+            another_byte: u8::dep_decode_or_exit(input, c.clone(), exit),
+            uint_32: u32::dep_decode_or_exit(input, c.clone(), exit),
+            uint_64: u64::dep_decode_or_exit(input, c.clone(), exit),
+        }
+    }
 }
 
 impl TopDecode for SerExample1 {

--- a/test-contracts/basic-features/src/ser_ex2.rs
+++ b/test-contracts/basic-features/src/ser_ex2.rs
@@ -52,7 +52,7 @@ impl NestedDecode for SerExample2 {
 }
 
 impl TopDecode for SerExample2 {
-    fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-        dep_decode_from_byte_slice(input.get_slice_u8())
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        top_decode_from_nested(input)
     }
 }

--- a/test-contracts/basic-features/src/ser_ex2.rs
+++ b/test-contracts/basic-features/src/ser_ex2.rs
@@ -9,23 +9,23 @@ pub enum SerExample2 {
 }
 
 impl NestedEncode for SerExample2 {
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
         match self {
             SerExample2::Unit => {
-                0u32.dep_encode_to(dest)?;
+                0u32.dep_encode(dest)?;
             },
             SerExample2::Newtype(arg1) => {
-                1u32.dep_encode_to(dest)?;
-                arg1.dep_encode_to(dest)?;
+                1u32.dep_encode(dest)?;
+                arg1.dep_encode(dest)?;
             },
             SerExample2::Tuple(arg1, arg2) => {
-                2u32.dep_encode_to(dest)?;
-                arg1.dep_encode_to(dest)?;
-                arg2.dep_encode_to(dest)?;
+                2u32.dep_encode(dest)?;
+                arg1.dep_encode(dest)?;
+                arg2.dep_encode(dest)?;
             },
             SerExample2::Struct { a } => {
-                3u32.dep_encode_to(dest)?;
-                a.dep_encode_to(dest)?;
+                3u32.dep_encode(dest)?;
+                a.dep_encode(dest)?;
             },
         }
         Ok(())
@@ -33,9 +33,14 @@ impl NestedEncode for SerExample2 {
 }
 
 impl TopEncode for SerExample2 {
+    #[inline]
     fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
-        output.set_slice_u8(dep_encode_to_vec(self)?.as_slice());
-        Ok(())
+        top_encode_from_nested(self, output)
+    }
+
+    #[inline]
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        top_encode_from_nested_or_exit(self, output, c, exit);
     }
 }
 

--- a/test-contracts/basic-features/src/ser_ex2.rs
+++ b/test-contracts/basic-features/src/ser_ex2.rs
@@ -75,6 +75,16 @@ impl NestedDecode for SerExample2 {
             _ => Err(DecodeError::INVALID_VALUE),
         }
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        match u32::dep_decode_or_exit(input, c.clone(), exit) {
+            0 => SerExample2::Unit,
+            1 => SerExample2::Newtype(u32::dep_decode_or_exit(input, c.clone(), exit)),
+            2 => SerExample2::Tuple(u32::dep_decode_or_exit(input, c.clone(), exit), u32::dep_decode_or_exit(input, c.clone(), exit)),
+            3 => SerExample2::Struct{ a: u32::dep_decode_or_exit(input, c.clone(), exit) },
+            _ => exit(c, DecodeError::INVALID_VALUE),
+        }
+    }
 }
 
 impl TopDecode for SerExample2 {

--- a/test-contracts/basic-features/src/ser_ex2.rs
+++ b/test-contracts/basic-features/src/ser_ex2.rs
@@ -30,6 +30,27 @@ impl NestedEncode for SerExample2 {
         }
         Ok(())
     }
+
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        match self {
+            SerExample2::Unit => {
+                0u32.dep_encode_or_exit(dest, c.clone(), exit);
+            },
+            SerExample2::Newtype(arg1) => {
+                1u32.dep_encode_or_exit(dest, c.clone(), exit);
+                arg1.dep_encode_or_exit(dest, c.clone(), exit);
+            },
+            SerExample2::Tuple(arg1, arg2) => {
+                2u32.dep_encode_or_exit(dest, c.clone(), exit);
+                arg1.dep_encode_or_exit(dest, c.clone(), exit);
+                arg2.dep_encode_or_exit(dest, c.clone(), exit);
+            },
+            SerExample2::Struct { a } => {
+                3u32.dep_encode_or_exit(dest, c.clone(), exit);
+                a.dep_encode_or_exit(dest, c.clone(), exit);
+            },
+        }
+    }
 }
 
 impl TopEncode for SerExample2 {

--- a/test-contracts/basic-features/src/ser_ex2.rs
+++ b/test-contracts/basic-features/src/ser_ex2.rs
@@ -81,4 +81,8 @@ impl TopDecode for SerExample2 {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         top_decode_from_nested(input)
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        top_decode_from_nested_or_exit(input, c, exit)
+    }
 }

--- a/test-contracts/basic-features/src/ser_ex2.rs
+++ b/test-contracts/basic-features/src/ser_ex2.rs
@@ -40,12 +40,12 @@ impl TopEncode for SerExample2 {
 }
 
 impl NestedDecode for SerExample2 {
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        match u32::dep_decode_to(input)? {
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        match u32::dep_decode(input)? {
             0 => Ok(SerExample2::Unit),
-            1 => Ok(SerExample2::Newtype(u32::dep_decode_to(input)?)),
-            2 => Ok(SerExample2::Tuple(u32::dep_decode_to(input)?, u32::dep_decode_to(input)?)),
-            3 => Ok(SerExample2::Struct{ a: u32::dep_decode_to(input)? }),
+            1 => Ok(SerExample2::Newtype(u32::dep_decode(input)?)),
+            2 => Ok(SerExample2::Tuple(u32::dep_decode(input)?, u32::dep_decode(input)?)),
+            3 => Ok(SerExample2::Struct{ a: u32::dep_decode(input)? }),
             _ => Err(DecodeError::INVALID_VALUE),
         }
     }

--- a/test-contracts/basic-features/src/ser_ex2.rs
+++ b/test-contracts/basic-features/src/ser_ex2.rs
@@ -52,7 +52,7 @@ impl NestedDecode for SerExample2 {
 }
 
 impl TopDecode for SerExample2 {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        top_decode_from_nested(input, f)
+    fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+        dep_decode_from_byte_slice(input.get_slice_u8())
     }
 }

--- a/test-contracts/basic-features/src/simple_enum.rs
+++ b/test-contracts/basic-features/src/simple_enum.rs
@@ -41,8 +41,8 @@ impl TopEncode for SimpleEnum {
 }
 
 impl NestedDecode for SimpleEnum {
-    fn dep_decode_to<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        SimpleEnum::from_i64(i64::dep_decode_to(input)?)
+    fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
+        SimpleEnum::from_i64(i64::dep_decode(input)?)
     }
 }
 

--- a/test-contracts/basic-features/src/simple_enum.rs
+++ b/test-contracts/basic-features/src/simple_enum.rs
@@ -58,4 +58,8 @@ impl TopDecode for SimpleEnum {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
         top_decode_from_nested(input)
     }
+
+    fn top_decode_or_exit<I: TopDecodeInput, ExitCtx: Clone>(input: I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        top_decode_from_nested_or_exit(input, c, exit)
+    }
 }

--- a/test-contracts/basic-features/src/simple_enum.rs
+++ b/test-contracts/basic-features/src/simple_enum.rs
@@ -27,8 +27,8 @@ impl SimpleEnum {
 }
 
 impl NestedEncode for SimpleEnum {
-    fn dep_encode_to<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
-        self.to_i64().dep_encode_to(dest)?;
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+        self.to_i64().dep_encode(dest)?;
         Ok(())
     }
 }

--- a/test-contracts/basic-features/src/simple_enum.rs
+++ b/test-contracts/basic-features/src/simple_enum.rs
@@ -31,6 +31,10 @@ impl NestedEncode for SimpleEnum {
         self.to_i64().dep_encode(dest)?;
         Ok(())
     }
+
+    fn dep_encode_or_exit<O: NestedEncodeOutput, ExitCtx: Clone>(&self, dest: &mut O, c: ExitCtx, exit: fn(ExitCtx, EncodeError) -> !) {
+        self.to_i64().dep_encode_or_exit(dest, c, exit);
+    }
 }
 
 impl TopEncode for SimpleEnum {
@@ -38,6 +42,10 @@ impl TopEncode for SimpleEnum {
         output.set_i64(self.to_i64());
         Ok(())
     }
+
+    fn top_encode_or_exit<O: TopEncodeOutput, ExitCtx: Clone>(&self, output: O, _: ExitCtx, _: fn(ExitCtx, EncodeError) -> !) {
+		output.set_i64(self.to_i64());
+	}
 }
 
 impl NestedDecode for SimpleEnum {

--- a/test-contracts/basic-features/src/simple_enum.rs
+++ b/test-contracts/basic-features/src/simple_enum.rs
@@ -47,7 +47,7 @@ impl NestedDecode for SimpleEnum {
 }
 
 impl TopDecode for SimpleEnum {
-    fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
-        dep_decode_from_byte_slice(input.get_slice_u8())
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        top_decode_from_nested(input)
     }
 }

--- a/test-contracts/basic-features/src/simple_enum.rs
+++ b/test-contracts/basic-features/src/simple_enum.rs
@@ -52,6 +52,15 @@ impl NestedDecode for SimpleEnum {
     fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
         SimpleEnum::from_i64(i64::dep_decode(input)?)
     }
+
+    fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(input: &mut I, c: ExitCtx, exit: fn(ExitCtx, DecodeError) -> !) -> Self {
+        match u32::dep_decode_or_exit(input, c.clone(), exit) {
+            0 => SimpleEnum::Variant0,
+            1 => SimpleEnum::Variant1,
+            2 => SimpleEnum::Variant2,
+            _ => exit(c, DecodeError::INVALID_VALUE),
+        }
+    }
 }
 
 impl TopDecode for SimpleEnum {

--- a/test-contracts/basic-features/src/simple_enum.rs
+++ b/test-contracts/basic-features/src/simple_enum.rs
@@ -47,7 +47,7 @@ impl NestedDecode for SimpleEnum {
 }
 
 impl TopDecode for SimpleEnum {
-    fn top_decode<I: TopDecodeInput, R, F: FnOnce(Result<Self, DecodeError>) -> R>(input: I, f: F) -> R {
-        top_decode_from_nested(input, f)
+    fn top_decode<I: TopDecodeInput>(mut input: I) -> Result<Self, DecodeError> {
+        dep_decode_from_byte_slice(input.get_slice_u8())
     }
 }

--- a/test-contracts/basic-features/wasm/Cargo.toml
+++ b/test-contracts/basic-features/wasm/Cargo.toml
@@ -25,3 +25,4 @@ path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 
 [workspace]
+members = ["."]

--- a/test-contracts/basic-features/wasm/Cargo.toml
+++ b/test-contracts/basic-features/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.9.0"
+version = "0.9.1"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/test-contracts/basic-features/wasm/Cargo.toml
+++ b/test-contracts/basic-features/wasm/Cargo.toml
@@ -20,7 +20,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/test-contracts/use-module/Cargo.toml
+++ b/test-contracts/use-module/Cargo.toml
@@ -21,14 +21,14 @@ default = [
 
 [dependencies]
 # modules
-elrond-wasm-module-features-wasm = { package = "elrond-wasm-module-features", version = "0.9.0", path = "../../modules/elrond-wasm-module-features", features = ["wasm-output-mode"], optional = true }
-elrond-wasm-module-features-default = { package = "elrond-wasm-module-features", version = "0.9.0", path = "../../modules/elrond-wasm-module-features", optional = true }
-elrond-wasm-module-pause-wasm = { package = "elrond-wasm-module-pause", version = "0.9.0", path = "../../modules/elrond-wasm-module-pause", features = ["wasm-output-mode"], optional = true }
-elrond-wasm-module-pause-default = { package = "elrond-wasm-module-pause", version = "0.9.0", path = "../../modules/elrond-wasm-module-pause", optional = true }
+elrond-wasm-module-features-wasm = { package = "elrond-wasm-module-features", version = "0.9.1", path = "../../modules/elrond-wasm-module-features", features = ["wasm-output-mode"], optional = true }
+elrond-wasm-module-features-default = { package = "elrond-wasm-module-features", version = "0.9.1", path = "../../modules/elrond-wasm-module-features", optional = true }
+elrond-wasm-module-pause-wasm = { package = "elrond-wasm-module-pause", version = "0.9.1", path = "../../modules/elrond-wasm-module-pause", features = ["wasm-output-mode"], optional = true }
+elrond-wasm-module-pause-default = { package = "elrond-wasm-module-pause", version = "0.9.1", path = "../../modules/elrond-wasm-module-pause", optional = true }
 
-elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.1", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.1", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.1", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.1", path = "../../elrond-wasm-debug" }

--- a/test-contracts/use-module/Cargo.toml
+++ b/test-contracts/use-module/Cargo.toml
@@ -21,14 +21,14 @@ default = [
 
 [dependencies]
 # modules
-elrond-wasm-module-features-wasm = { package = "elrond-wasm-module-features", version = "0.8.0", path = "../../modules/elrond-wasm-module-features", features = ["wasm-output-mode"], optional = true }
-elrond-wasm-module-features-default = { package = "elrond-wasm-module-features", version = "0.8.0", path = "../../modules/elrond-wasm-module-features", optional = true }
-elrond-wasm-module-pause-wasm = { package = "elrond-wasm-module-pause", version = "0.8.0", path = "../../modules/elrond-wasm-module-pause", features = ["wasm-output-mode"], optional = true }
-elrond-wasm-module-pause-default = { package = "elrond-wasm-module-pause", version = "0.8.0", path = "../../modules/elrond-wasm-module-pause", optional = true }
+elrond-wasm-module-features-wasm = { package = "elrond-wasm-module-features", version = "0.9.0", path = "../../modules/elrond-wasm-module-features", features = ["wasm-output-mode"], optional = true }
+elrond-wasm-module-features-default = { package = "elrond-wasm-module-features", version = "0.9.0", path = "../../modules/elrond-wasm-module-features", optional = true }
+elrond-wasm-module-pause-wasm = { package = "elrond-wasm-module-pause", version = "0.9.0", path = "../../modules/elrond-wasm-module-pause", features = ["wasm-output-mode"], optional = true }
+elrond-wasm-module-pause-default = { package = "elrond-wasm-module-pause", version = "0.9.0", path = "../../modules/elrond-wasm-module-pause", optional = true }
 
-elrond-wasm = { version = "0.8.0", path = "../../elrond-wasm" }
-elrond-wasm-derive = { version = "0.8.0", path = "../../elrond-wasm-derive" }
-elrond-wasm-node = { version = "0.8.0", path = "../../elrond-wasm-node", optional = true }
+elrond-wasm = { version = "0.9.0", path = "../../elrond-wasm" }
+elrond-wasm-derive = { version = "0.9.0", path = "../../elrond-wasm-derive" }
+elrond-wasm-node = { version = "0.9.0", path = "../../elrond-wasm-node", optional = true }
 
 [dev-dependencies]
-elrond-wasm-debug = { version = "0.8.0", path = "../../elrond-wasm-debug" }
+elrond-wasm-debug = { version = "0.9.0", path = "../../elrond-wasm-debug" }

--- a/test-contracts/use-module/wasm/Cargo.toml
+++ b/test-contracts/use-module/wasm/Cargo.toml
@@ -19,3 +19,4 @@ use-module = { path = "..", default-features = false, features=["wasm-output-mod
 elrond-wasm-output = { version = "0.9.0", path = "../../../elrond-wasm-output", default-features = false, features=["wasm-output-mode"] }
 
 [workspace]
+members = ["."]

--- a/test-contracts/use-module/wasm/Cargo.toml
+++ b/test-contracts/use-module/wasm/Cargo.toml
@@ -16,6 +16,6 @@ panic = "abort"
 
 [dependencies]
 use-module = { path = "..", default-features = false, features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.8.0", path = "../../../elrond-wasm-output", default-features = false, features=["wasm-output-mode"] }
+elrond-wasm-output = { version = "0.9.0", path = "../../../elrond-wasm-output", default-features = false, features=["wasm-output-mode"] }
 
 [workspace]

--- a/test-contracts/use-module/wasm/Cargo.toml
+++ b/test-contracts/use-module/wasm/Cargo.toml
@@ -16,7 +16,7 @@ panic = "abort"
 
 [dependencies]
 use-module = { path = "..", default-features = false, features=["wasm-output-mode"] }
-elrond-wasm-output = { version = "0.9.0", path = "../../../elrond-wasm-output", default-features = false, features=["wasm-output-mode"] }
+elrond-wasm-output = { version = "0.9.1", path = "../../../elrond-wasm-output", default-features = false, features=["wasm-output-mode"] }
 
 [workspace]
 members = ["."]


### PR DESCRIPTION
Coded traits now all have "[top|dep]_[encode|decode]_or_exit" variants, which take a context and a reference to an "exit" function.

The exit function acts like a panic, in that it immediately halts execution. This is indicated by the "-> !" return.
It can be specified by the caller, but it will be expanded lower down the call chain. This is not a function pointer since it is not dynamic, it gets expanded statically.
Since encoding never fails in our scenarios, the encoding exit will never appear in smart contracts (unlike the Result<(), EncodeError> which was producing an if-like statement after each return). It is, however, possible to have encoding errors in custom types, so this logic is necessary.
Decoding exit also appears just a few times, because I've pushed it far down the call graph, to the decode input trait implementations, which are called by everyone.
All in all I've managed to chop ~5kB off the basic-features contract (debug info included) with this strategy, compared to the version with closures (v0.8.0).

This serialization pattern seems to be the winner, so it's likely final.