### PR TITLE
Removed small-int-ei feature

### DIFF
--- a/contracts/feature-tests/basic-features/Cargo.toml
+++ b/contracts/feature-tests/basic-features/Cargo.toml
@@ -22,7 +22,6 @@ path = "../../../elrond-wasm-derive"
 version = "0.9.7"
 path = "../../../elrond-wasm-node"
 optional = true
-features = ["small-int-ei"]
 
 [dev-dependencies.elrond-wasm-debug]
 version = "0.9.7"

--- a/elrond-wasm-node/Cargo.toml
+++ b/elrond-wasm-node/Cargo.toml
@@ -13,8 +13,5 @@ description = "Elrond WebAssembly VM API wrapper"
 keywords = ["elrond", "wasm", "webassembly", "blockchain", "contract"]
 categories = ["no-std", "wasm", "cryptography::cryptocurrencies", "development-tools::ffi"]
 
-[features]
-small-int-ei = []
-
 [dependencies]
 elrond-wasm = { version = "0.9.7", path = "../elrond-wasm" }

--- a/elrond-wasm-node/src/ext.rs
+++ b/elrond-wasm-node/src/ext.rs
@@ -221,7 +221,6 @@ impl elrond_wasm::ContractHookApi<ArwenBigInt, ArwenBigUint> for ArwenApiImpl {
 		}
 	}
 
-	#[cfg(feature = "small-int-ei")]
 	#[inline]
 	fn storage_store_u64(&self, key: &[u8], value: u64) {
 		unsafe {
@@ -229,15 +228,6 @@ impl elrond_wasm::ContractHookApi<ArwenBigInt, ArwenBigUint> for ArwenApiImpl {
 		}
 	}
 
-	#[cfg(not(feature = "small-int-ei"))]
-	#[inline]
-	fn storage_store_u64(&self, key: &[u8], value: u64) {
-		let mut buffer = Vec::<u8>::new();
-		elrond_wasm::elrond_codec::top_encode_number_to_output(&mut buffer, value, false);
-		self.storage_store_slice_u8(key, &buffer[..]);
-	}
-
-	#[cfg(feature = "small-int-ei")]
 	#[inline]
 	fn storage_store_i64(&self, key: &[u8], value: i64) {
 		unsafe {
@@ -245,44 +235,14 @@ impl elrond_wasm::ContractHookApi<ArwenBigInt, ArwenBigUint> for ArwenApiImpl {
 		}
 	}
 
-	#[cfg(not(feature = "small-int-ei"))]
-	#[inline]
-	fn storage_store_i64(&self, key: &[u8], value: i64) {
-		let mut buffer = Vec::<u8>::new();
-		elrond_wasm::elrond_codec::top_encode_number_to_output(&mut buffer, value as u64, true);
-		self.storage_store_slice_u8(key, &buffer[..]);
-	}
-
-	#[cfg(feature = "small-int-ei")]
 	#[inline]
 	fn storage_load_u64(&self, key: &[u8]) -> u64 {
 		unsafe { smallIntStorageLoadUnsigned(key.as_ref().as_ptr(), key.len() as i32) as u64 }
 	}
 
-	#[cfg(not(feature = "small-int-ei"))]
-	#[inline(never)]
-	fn storage_load_u64(&self, key: &[u8]) -> u64 {
-		let bytes = self.storage_load_boxed_bytes(key);
-		if bytes.len() > 8 {
-			ext_error::signal_error(err_msg::STORAGE_VALUE_OUT_OF_RANGE);
-		}
-		elrond_wasm::elrond_codec::bytes_to_number(&bytes.into_box(), false)
-	}
-
-	#[cfg(feature = "small-int-ei")]
 	#[inline]
 	fn storage_load_i64(&self, key: &[u8]) -> i64 {
 		unsafe { smallIntStorageLoadSigned(key.as_ref().as_ptr(), key.len() as i32) }
-	}
-
-	#[cfg(not(feature = "small-int-ei"))]
-	#[inline(never)]
-	fn storage_load_i64(&self, key: &[u8]) -> i64 {
-		let bytes = self.storage_load_boxed_bytes(key);
-		if bytes.len() > 8 {
-			ext_error::signal_error(err_msg::STORAGE_VALUE_OUT_OF_RANGE);
-		}
-		elrond_wasm::elrond_codec::bytes_to_number(&bytes.into_box(), true) as i64
 	}
 
 	#[inline]
@@ -531,34 +491,14 @@ impl elrond_wasm::ContractIOApi<ArwenBigInt, ArwenBigUint> for ArwenApiImpl {
 		}
 	}
 
-	#[cfg(feature = "small-int-ei")]
 	#[inline]
 	fn get_argument_u64(&self, arg_id: i32) -> u64 {
 		unsafe { smallIntGetUnsignedArgument(arg_id) as u64 }
 	}
 
-	#[cfg(not(feature = "small-int-ei"))]
-	fn get_argument_u64(&self, arg_id: i32) -> u64 {
-		let bytes = self.get_argument_boxed_bytes(arg_id);
-		if bytes.len() > 8 {
-			ext_error::signal_error(err_msg::ARG_OUT_OF_RANGE);
-		}
-		elrond_wasm::elrond_codec::bytes_to_number(&bytes.into_box(), false)
-	}
-
-	#[cfg(feature = "small-int-ei")]
 	#[inline]
 	fn get_argument_i64(&self, arg_id: i32) -> i64 {
 		unsafe { smallIntGetSignedArgument(arg_id) }
-	}
-
-	#[cfg(not(feature = "small-int-ei"))]
-	fn get_argument_i64(&self, arg_id: i32) -> i64 {
-		let bytes = self.get_argument_boxed_bytes(arg_id);
-		if bytes.len() > 8 {
-			ext_error::signal_error(err_msg::ARG_OUT_OF_RANGE);
-		}
-		elrond_wasm::elrond_codec::bytes_to_number(&bytes.into_box(), true) as i64
 	}
 
 	#[inline]
@@ -596,7 +536,6 @@ impl elrond_wasm::ContractIOApi<ArwenBigInt, ArwenBigUint> for ArwenApiImpl {
 		}
 	}
 
-	#[cfg(feature = "small-int-ei")]
 	#[inline]
 	fn finish_u64(&self, value: u64) {
 		unsafe {
@@ -604,26 +543,11 @@ impl elrond_wasm::ContractIOApi<ArwenBigInt, ArwenBigUint> for ArwenApiImpl {
 		}
 	}
 
-	#[cfg(not(feature = "small-int-ei"))]
-	fn finish_u64(&self, value: u64) {
-		let mut buffer = Vec::<u8>::new();
-		elrond_wasm::elrond_codec::top_encode_number_to_output(&mut buffer, value, false);
-		self.finish_slice_u8(&buffer[..]);
-	}
-
-	#[cfg(feature = "small-int-ei")]
 	#[inline]
 	fn finish_i64(&self, value: i64) {
 		unsafe {
 			smallIntFinishSigned(value);
 		}
-	}
-
-	#[cfg(not(feature = "small-int-ei"))]
-	fn finish_i64(&self, value: i64) {
-		let mut buffer = Vec::<u8>::new();
-		elrond_wasm::elrond_codec::top_encode_number_to_output(&mut buffer, value as u64, true);
-		self.finish_slice_u8(&buffer[..]);
 	}
 
 	#[inline]


### PR DESCRIPTION
The small-int-ei feature was introduced to help with compatibility before the Arwen version containing the new small int EI was released. Now that these endpoints are up, no more need to keep the feature flag.