### PR TITLE
impl

### DIFF
--- a/contracts/feature-tests/basic-features/src/lib.rs
+++ b/contracts/feature-tests/basic-features/src/lib.rs
@@ -354,8 +354,16 @@ pub trait BasicFeatures {
 	fn load_u64(&self) -> u64;
 
 	#[endpoint]
+	#[storage_get_or_default("u64")]
+	fn load_u64_or_default(&self) -> u64;
+
+	#[endpoint]
 	#[storage_get("usize")]
 	fn load_usize(&self) -> usize;
+
+	#[endpoint]
+	#[storage_get_or_default("usize")]
+	fn load_usize_or_default(&self) -> usize;
 
 	#[endpoint]
 	#[storage_get("i64")]
@@ -366,12 +374,20 @@ pub trait BasicFeatures {
 	fn load_bool(&self) -> bool;
 
 	#[endpoint]
+	#[storage_get_or_default("bool")]
+	fn load_bool_or_default(&self) -> bool;
+
+	#[endpoint]
 	#[storage_get("vec_u8")]
 	fn load_vec_u8(&self) -> Vec<u8>;
 
 	#[endpoint]
 	#[storage_get("addr")]
 	fn load_addr(&self) -> Address;
+
+	#[endpoint]
+	#[storage_get_or_default("addr")]
+	fn load_addr_or_default(&self) -> Address;
 
 	#[storage_get("opt_addr")]
 	fn _get_opt_addr(&self) -> Option<Address>;

--- a/elrond-wasm-derive/src/contract_gen.rs
+++ b/elrond-wasm-derive/src/contract_gen.rs
@@ -106,6 +106,7 @@ impl Contract {
 				| MethodMetadata::StorageGetter { .. }
 				| MethodMetadata::StorageSetter { .. }
 				| MethodMetadata::StorageGetMut { .. }
+				| MethodMetadata::StorageGetOrDefault { .. }
 				| MethodMetadata::StorageIsEmpty { .. }
 				| MethodMetadata::StorageClear { .. }
 				| MethodMetadata::Module { .. } => {
@@ -137,6 +138,10 @@ impl Contract {
 					visibility: _,
 					identifier,
 				} => Some(generate_borrow_impl(&m, identifier.clone())),
+				MethodMetadata::StorageGetOrDefault {
+					visibility: _,
+					identifier,
+				} => Some(generate_getter_or_default_impl(&m, identifier.clone())),
 				MethodMetadata::StorageIsEmpty {
 					visibility: _,
 					identifier,

--- a/elrond-wasm-derive/src/contract_gen_storage.rs
+++ b/elrond-wasm-derive/src/contract_gen_storage.rs
@@ -107,6 +107,28 @@ pub fn generate_borrow_impl(m: &Method, identifier: String) -> proc_macro2::Toke
 	}
 }
 
+pub fn generate_getter_or_default_impl(m: &Method, identifier: String) -> proc_macro2::TokenStream {
+	let msig = m.generate_sig();
+	let key_snippet = generate_key_snippet(&m.method_args.as_slice(), identifier);
+	match m.return_type.clone() {
+		syn::ReturnType::Default => panic!("getter should return some value"),
+		syn::ReturnType::Type(_, ty) => {
+			let load_snippet = storage_load_snippet(&ty);
+			quote! {
+				#msig {
+					#key_snippet
+					if self.api.storage_load_len(&key[..]) > 0 {
+						#load_snippet
+					}
+					else {
+						<#ty>::default()
+					}
+				}
+			}
+		},
+	}
+}
+
 pub fn generate_is_empty_impl(m: &Method, identifier: String) -> proc_macro2::TokenStream {
 	let msig = m.generate_sig();
 	let key_snippet = generate_key_snippet(&m.method_args.as_slice(), identifier);

--- a/elrond-wasm-derive/src/parse_attr.rs
+++ b/elrond-wasm-derive/src/parse_attr.rs
@@ -13,6 +13,7 @@ static ATTR_MULTI: &str = "multi";
 static ATTR_STORAGE_GET: &str = "storage_get";
 static ATTR_STORAGE_SET: &str = "storage_set";
 static ATTR_STORAGE_GET_MUT: &str = "storage_get_mut";
+static ATTR_STORAGE_GET_OR_DEFAULT: &str = "storage_get_or_default";
 static ATTR_STORAGE_IS_EMPTY: &str = "storage_is_empty";
 static ATTR_STORAGE_CLEAR: &str = "storage_clear";
 static ATTR_MODULE: &str = "module";
@@ -212,6 +213,21 @@ impl StorageGetMutAttribute {
 		match find_attr_one_string_arg(m, ATTR_STORAGE_GET_MUT) {
 			None => None,
 			Some(arg_str) => Some(StorageGetMutAttribute {
+				identifier: arg_str,
+			}),
+		}
+	}
+}
+
+pub struct StorageGetOrDefaultAttribute {
+	pub identifier: String,
+}
+
+impl StorageGetOrDefaultAttribute {
+	pub fn parse(m: &syn::TraitItemMethod) -> Option<Self> {
+		match find_attr_one_string_arg(m, ATTR_STORAGE_GET_OR_DEFAULT) {
+			None => None,
+			Some(arg_str) => Some(StorageGetOrDefaultAttribute {
 				identifier: arg_str,
 			}),
 		}

--- a/elrond-wasm/src/types/boxed_bytes.rs
+++ b/elrond-wasm/src/types/boxed_bytes.rs
@@ -125,6 +125,12 @@ impl BoxedBytes {
 	}
 }
 
+impl Default for BoxedBytes {
+	fn default() -> Self {
+		BoxedBytes::empty()
+	}
+}
+
 impl AsRef<[u8]> for BoxedBytes {
 	#[inline]
 	fn as_ref(&self) -> &[u8] {

--- a/elrond-wasm/src/types/h256.rs
+++ b/elrond-wasm/src/types/h256.rs
@@ -13,6 +13,12 @@ const ZERO_32: &[u8] = &[0u8; 32];
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub struct H256(Box<[u8; 32]>);
 
+impl Default for H256 {
+	fn default() -> Self {
+		H256::zero()
+	}
+}
+
 impl From<[u8; 32]> for H256 {
 	/// Constructs a hash type from the given bytes array of fixed length.
 	///

--- a/elrond-wasm/src/types/h256_address.rs
+++ b/elrond-wasm/src/types/h256_address.rs
@@ -11,6 +11,12 @@ use core::fmt::Debug;
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub struct Address(H256);
 
+impl Default for Address {
+	fn default() -> Self {
+		Address::zero()
+	}
+}
+
 impl From<H256> for Address {
 	#[inline]
 	fn from(hash: H256) -> Self {


### PR DESCRIPTION
#[storage_get_or_default("key")] can now be used instead of having to use #[storage_is_empty] + #[storage_get].

Returned types have to implement the "Default" trait.