### PR TITLE
elrond-codec-derive immune to type shadowing

### DIFF
--- a/contracts/feature-tests/basic-features/src/lib.rs
+++ b/contracts/feature-tests/basic-features/src/lib.rs
@@ -464,7 +464,7 @@ pub trait BasicFeatures {
 	}
 
 	#[view(get_block_random_seed)]
-	fn get_block_random_seed_view(&self) -> Box<[u8;48]> {
+	fn get_block_random_seed_view(&self) -> Box<[u8; 48]> {
 		self.get_block_random_seed()
 	}
 
@@ -489,7 +489,7 @@ pub trait BasicFeatures {
 	}
 
 	#[view(get_prev_block_random_seed)]
-	fn get_prev_block_random_seed_view(&self) -> Box<[u8;48]> {
+	fn get_prev_block_random_seed_view(&self) -> Box<[u8; 48]> {
 		self.get_prev_block_random_seed()
 	}
 

--- a/elrond-codec-derive/src/nested_de_derive.rs
+++ b/elrond-codec-derive/src/nested_de_derive.rs
@@ -44,7 +44,7 @@ pub fn variant_dep_decode_snippets(
 				dep_decode_snippet(index, field)
 			});
 			quote! {
-				#variant_index_u8 => Result::Ok( #name::#variant_ident #variant_field_snippets ),
+				#variant_index_u8 => core::result::Result::Ok( #name::#variant_ident #variant_field_snippets ),
 			}
 		})
 		.collect()
@@ -86,8 +86,8 @@ pub fn nested_decode_impl(ast: &syn::DeriveInput) -> TokenStream {
 				});
 			quote! {
 				impl #impl_generics elrond_codec::NestedDecode for #name #ty_generics #where_clause {
-					fn dep_decode<I: elrond_codec::NestedDecodeInput>(input: &mut I) -> Result<Self, elrond_codec::DecodeError> {
-						Result::Ok(
+					fn dep_decode<I: elrond_codec::NestedDecodeInput>(input: &mut I) -> core::result::Result<Self, elrond_codec::DecodeError> {
+						core::result::Result::Ok(
 							#name #field_dep_decode_snippets
 						)
 					}
@@ -113,10 +113,10 @@ pub fn nested_decode_impl(ast: &syn::DeriveInput) -> TokenStream {
 
 			quote! {
 				impl #impl_generics elrond_codec::NestedDecode for #name #ty_generics #where_clause {
-					fn dep_decode<I: elrond_codec::NestedDecodeInput>(input: &mut I) -> Result<Self, elrond_codec::DecodeError> {
+					fn dep_decode<I: elrond_codec::NestedDecodeInput>(input: &mut I) -> core::result::Result<Self, elrond_codec::DecodeError> {
 						match <u8 as elrond_codec::NestedDecode>::dep_decode(input)? {
 							#(#variant_dep_decode_snippets)*
-							_ => Result::Err(elrond_codec::DecodeError::INVALID_VALUE),
+							_ => core::result::Result::Err(elrond_codec::DecodeError::INVALID_VALUE),
 						}
 					}
 

--- a/elrond-codec-derive/src/nested_en_derive.rs
+++ b/elrond-codec-derive/src/nested_en_derive.rs
@@ -80,9 +80,9 @@ pub fn nested_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
 				});
 			quote! {
 				impl #impl_generics elrond_codec::NestedEncode for #name #ty_generics #where_clause {
-					fn dep_encode<O: elrond_codec::NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), elrond_codec::EncodeError> {
+					fn dep_encode<O: elrond_codec::NestedEncodeOutput>(&self, dest: &mut O) -> core::result::Result<(), elrond_codec::EncodeError> {
 						#(#field_dep_encode_snippets)*
-						Result::Ok(())
+						core::result::Result::Ok(())
 					}
 
 					fn dep_encode_or_exit<O: elrond_codec::NestedEncodeOutput, ExitCtx: Clone>(
@@ -107,11 +107,11 @@ pub fn nested_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
 
 			quote! {
 				impl #impl_generics elrond_codec::NestedEncode for #name #ty_generics #where_clause {
-					fn dep_encode<O: elrond_codec::NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), elrond_codec::EncodeError> {
+					fn dep_encode<O: elrond_codec::NestedEncodeOutput>(&self, dest: &mut O) -> core::result::Result<(), elrond_codec::EncodeError> {
 						match self {
 							#(#variant_dep_encode_snippets)*
 						};
-						Ok(())
+						core::result::Result::Ok(())
 					}
 
 					fn dep_encode_or_exit<O: elrond_codec::NestedEncodeOutput, ExitCtx: Clone>(

--- a/elrond-codec-derive/src/top_en_derive.rs
+++ b/elrond-codec-derive/src/top_en_derive.rs
@@ -35,7 +35,7 @@ pub fn variant_top_encode_snippets(
 						elrond_codec::NestedEncode::dep_encode(&#variant_index_u8, dest)?;
 						#(#variant_field_snippets)*
 						output.set_slice_u8(&buffer[..]);
-						Result::Ok(())
+						core::result::Result::Ok(())
 					},
 				}
 			}
@@ -95,12 +95,12 @@ pub fn top_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
 				});
 			quote! {
 				impl #impl_generics elrond_codec::TopEncode for #name #ty_generics #where_clause {
-					fn top_encode<O: elrond_codec::TopEncodeOutput>(&self, output: O) -> Result<(), elrond_codec::EncodeError> {
+					fn top_encode<O: elrond_codec::TopEncodeOutput>(&self, output: O) -> core::result::Result<(), elrond_codec::EncodeError> {
 						let mut buffer = elrond_codec::Vec::<u8>::new();
 						let dest = &mut buffer;
 						#(#field_dep_encode_snippets)*
 						output.set_slice_u8(&buffer[..]);
-						Result::Ok(())
+						core::result::Result::Ok(())
 					}
 
 					fn top_encode_or_exit<O: elrond_codec::TopEncodeOutput, ExitCtx: Clone>(
@@ -128,7 +128,7 @@ pub fn top_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
 
 			quote! {
 				impl #impl_generics elrond_codec::TopEncode for #name #ty_generics #where_clause {
-					fn top_encode<O: elrond_codec::TopEncodeOutput>(&self, output: O) -> Result<(), elrond_codec::EncodeError> {
+					fn top_encode<O: elrond_codec::TopEncodeOutput>(&self, output: O) -> core::result::Result<(), elrond_codec::EncodeError> {
 						match self {
 							#(#variant_top_encode_snippets)*
 						}

--- a/elrond-codec/Cargo.toml
+++ b/elrond-codec/Cargo.toml
@@ -24,3 +24,7 @@ optional = true
 [dependencies]
 wee_alloc = "0.4"
 arrayvec = { version = "0.5.2", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
+
+[dev-dependencies.elrond-codec-derive]
+path = "../elrond-codec-derive"
+version = "0.4.1"

--- a/elrond-codec/src/lib.rs
+++ b/elrond-codec/src/lib.rs
@@ -25,9 +25,9 @@ pub use crate::nested_de_input::NestedDecodeInput;
 pub use crate::nested_ser_output::NestedEncodeOutput;
 pub use crate::num_conv::{bytes_to_number, top_encode_number_to_output, using_encoded_number};
 pub use codec_err::{DecodeError, EncodeError};
-pub use nested_de::*;
-pub use nested_ser::*;
-pub use top_de::*;
+pub use nested_de::{dep_decode_from_byte_slice, dep_decode_from_byte_slice_or_exit, NestedDecode};
+pub use nested_ser::{dep_encode_to_vec, NestedEncode, NestedEncodeNoErr};
+pub use top_de::{top_decode_from_nested, top_decode_from_nested_or_exit, TopDecode};
 pub use top_de_input::TopDecodeInput;
 pub use top_ser::{
 	top_encode_from_nested, top_encode_from_nested_or_exit, top_encode_to_vec, TopEncode,

--- a/elrond-codec/tests/interference_test.rs
+++ b/elrond-codec/tests/interference_test.rs
@@ -1,0 +1,98 @@
+#![allow(dead_code)]
+
+extern crate elrond_codec_derive;
+use elrond_codec_derive::*;
+
+// This test doesn't run any code, the fact that it compiles is the actual testing.
+// It checks that defining other types with the same name as elrond-codec types does not break the derive macro generation.
+// The derive macro must generate fully qualified type names everywhere to avoid this hurdle.
+
+// All exported traits:
+struct TopEncode;
+struct TopDecode;
+struct NestedEncode;
+struct NestedDecode;
+struct EncodeError;
+struct DecodeError;
+struct TopDecodeInput;
+struct TopEncodeOutput;
+struct NestedDecodeInput;
+struct NestedEncodeOutput;
+struct NestedEncodeNoErr;
+
+// Making sure derive explicitly only works with core::result::Result
+// and doesn't get tricked by other enums with the same name.
+enum Result {
+	Ok,
+	Err,
+}
+
+// This one will interfere with any improperly generated `Ok` and `Err` expressions.
+#[allow(unused_imports)]
+use crate::Result::{Err, Ok};
+
+// Also adding all public functions exposed by elrond-codec.
+// They are not used in the derive, but just to make sure:
+fn bytes_to_number() {}
+fn top_encode_number_to_output() {}
+fn using_encoded_number() {}
+fn dep_decode_from_byte_slice() {}
+fn dep_decode_from_byte_slice_or_exit() {}
+fn dep_encode_to_vec() {}
+fn top_decode_from_nested() {}
+fn top_decode_from_nested_or_exit() {}
+fn top_encode_from_nested() {}
+fn top_encode_from_nested_or_exit() {}
+fn top_encode_to_vec() {}
+fn boxed_slice_into_vec() {}
+fn vec_into_boxed_slice() {}
+
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, PartialEq, Clone, Debug)]
+pub struct Struct {
+	pub int: u16,
+	pub seq: Vec<u8>,
+	pub another_byte: u8,
+	pub uint_32: u32,
+	pub uint_64: u64,
+}
+
+#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, PartialEq, Clone, Debug)]
+enum DayOfWeek {
+	Monday,
+	Tuesday,
+	Wednesday,
+	Thursday,
+	Friday,
+	Saturday,
+	Sunday,
+}
+
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, PartialEq, Clone, Debug)]
+enum EnumWithEverything {
+	Quit,
+	Today(DayOfWeek),
+	Write(Vec<u8>, u16),
+	Struct {
+		int: u16,
+		seq: Vec<u8>,
+		another_byte: u8,
+		uint_32: u32,
+		uint_64: u64,
+	},
+}
+
+trait SimpleTrait {
+	fn simple_function(&self);
+}
+
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, PartialEq, Clone, Debug)]
+struct StructWithNamedFieldsWithGeneric<ST: SimpleTrait>
+where
+	ST: elrond_codec::NestedEncode
+		+ elrond_codec::NestedDecode
+		+ elrond_codec::TopEncode
+		+ elrond_codec::TopDecode,
+{
+	data: u64,
+	trait_stuff: ST,
+}

--- a/elrond-codec/tests/shadowing_test.rs
+++ b/elrond-codec/tests/shadowing_test.rs
@@ -4,7 +4,8 @@ extern crate elrond_codec_derive;
 use elrond_codec_derive::*;
 
 // This test doesn't run any code, the fact that it compiles is the actual testing.
-// It checks that defining other types with the same name as elrond-codec types does not break the derive macro generation.
+// It checks that the derive macro generation is immune to type shadowing,
+// i.e. any types that are in scope and happen to have the same name as elrond-codec types do not break the build.
 // The derive macro must generate fully qualified type names everywhere to avoid this hurdle.
 
 // All exported traits:
@@ -55,6 +56,9 @@ pub struct Struct {
 	pub uint_32: u32,
 	pub uint_64: u64,
 }
+
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, PartialEq, Clone, Debug)]
+struct TupleStruct(u8, u16, u32);
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, PartialEq, Clone, Debug)]
 enum DayOfWeek {

--- a/elrond-wasm-debug/src/blockchain_mock.rs
+++ b/elrond-wasm-debug/src/blockchain_mock.rs
@@ -83,7 +83,7 @@ pub struct BlockInfo {
 	pub block_nonce: u64,
 	pub block_round: u64,
 	pub block_epoch: u64,
-	pub block_random_seed: Box<[u8;48]>,
+	pub block_random_seed: Box<[u8; 48]>,
 }
 
 impl BlockInfo {
@@ -93,7 +93,7 @@ impl BlockInfo {
 			block_nonce: 0,
 			block_round: 0,
 			block_epoch: 0,
-			block_random_seed: Box::from([0u8;48]),
+			block_random_seed: Box::from([0u8; 48]),
 		}
 	}
 }

--- a/elrond-wasm-debug/src/execute_mandos.rs
+++ b/elrond-wasm-debug/src/execute_mandos.rs
@@ -81,7 +81,10 @@ fn parse_execute_mandos_steps(
 						const SEED_LEN: usize = 48;
 						let val = &bytes_value.value;
 
-						assert!(val.len() <= SEED_LEN, "block random seed input value too long!");
+						assert!(
+							val.len() <= SEED_LEN,
+							"block random seed input value too long!"
+						);
 
 						let mut seed = [0u8; SEED_LEN];
 						&seed[SEED_LEN - val.len()..].copy_from_slice(val.as_slice());
@@ -105,7 +108,10 @@ fn parse_execute_mandos_steps(
 						const SEED_LEN: usize = 48;
 						let val = &bytes_value.value;
 
-						assert!(val.len() <= SEED_LEN, "block random seed input value too long!");
+						assert!(
+							val.len() <= SEED_LEN,
+							"block random seed input value too long!"
+						);
 
 						let mut seed = [0u8; SEED_LEN];
 						&seed[SEED_LEN - val.len()..].copy_from_slice(val.as_slice());

--- a/elrond-wasm-debug/src/ext_mock.rs
+++ b/elrond-wasm-debug/src/ext_mock.rs
@@ -402,7 +402,10 @@ impl elrond_wasm::ContractHookApi<RustBigInt, RustBigUint> for TxContext {
 	}
 
 	fn get_block_random_seed(&self) -> Box<[u8; 48]> {
-		self.blockchain_info_box.current_block_info.block_random_seed.clone()
+		self.blockchain_info_box
+			.current_block_info
+			.block_random_seed
+			.clone()
 	}
 
 	fn get_prev_block_timestamp(&self) -> u64 {
@@ -422,7 +425,10 @@ impl elrond_wasm::ContractHookApi<RustBigInt, RustBigUint> for TxContext {
 	}
 
 	fn get_prev_block_random_seed(&self) -> Box<[u8; 48]> {
-		self.blockchain_info_box.previous_block_info.block_random_seed.clone()
+		self.blockchain_info_box
+			.previous_block_info
+			.block_random_seed
+			.clone()
 	}
 
 	fn sha256(&self, data: &[u8]) -> H256 {


### PR DESCRIPTION
The derive macro generation is immune to type shadowing,
i.e. any types that are in scope and happen to have the same name as elrond-codec types do not break the build.
The derive macro must generate fully qualified type names everywhere to avoid this hurdle.