### PR TITLE
Multisig discardAction endpoint and other minor improvements

### DIFF
--- a/contracts/examples/multisig/mandos/changeQuorum.scen.json
+++ b/contracts/examples/multisig/mandos/changeQuorum.scen.json
@@ -53,6 +53,26 @@
         },
         {
             "step": "scCall",
+            "txId": "pending-action-data",
+            "tx": {
+                "from": "address:bob",
+                "to": "address:multisig",
+                "value": "0",
+                "function": "getPendingActionData",
+                "arguments": [],
+                "gasLimit": "100,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [ "u8:4|u32:3"],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
             "txId": "change-quorum-perform",
             "tx": {
                 "from": "address:alice",
@@ -87,6 +107,26 @@
                 "out": [
                     "3"
                 ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "pending-action-data-none",
+            "tx": {
+                "from": "address:bob",
+                "to": "address:multisig",
+                "value": "0",
+                "function": "getPendingActionData",
+                "arguments": [],
+                "gasLimit": "100,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
                 "status": "",
                 "logs": [],
                 "gas": "*",

--- a/contracts/examples/multisig/mandos/deployAdder_then_call.scen.json
+++ b/contracts/examples/multisig/mandos/deployAdder_then_call.scen.json
@@ -71,7 +71,6 @@
                         "``num_proposers": "1",
                         "``quorum": "2",
                         "``action_last_index": "3",
-                        "``pending_action_count": "1",
                         "``action_data|u32:3": {
                             "discriminant": "0x06",
                             "amount": "u32:0",

--- a/contracts/examples/multisig/mandos/deployFactorial.scen.json
+++ b/contracts/examples/multisig/mandos/deployFactorial.scen.json
@@ -70,7 +70,6 @@
                         "``num_proposers": "1",
                         "``quorum": "2",
                         "``action_last_index": "3",
-                        "``pending_action_count": "1",
                         "``action_data|u32:3": {
                             "discriminant": "0x06",
                             "amount": "u32:0",

--- a/contracts/examples/multisig/src/action.rs
+++ b/contracts/examples/multisig/src/action.rs
@@ -32,6 +32,18 @@ impl<BigUint: BigUintApi> Action<BigUint> {
 	/// both executed and discarded actions are removed (converted to `Nothing`).
 	/// So this is equivalent to `action != Action::Nothing`.
 	pub fn is_pending(&self) -> bool {
-		matches!(*self, Action::Nothing)
+		!matches!(*self, Action::Nothing)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::Action;
+	use elrond_wasm_debug::RustBigUint;
+
+	#[test]
+	fn test_is_pending() {
+		assert!(!Action::<RustBigUint>::Nothing.is_pending());
+		assert!(Action::<RustBigUint>::ChangeQuorum(5).is_pending());
 	}
 }

--- a/contracts/examples/multisig/src/action.rs
+++ b/contracts/examples/multisig/src/action.rs
@@ -26,3 +26,12 @@ pub enum Action<BigUint: BigUintApi> {
 		arguments: Vec<BoxedBytes>,
 	},
 }
+
+impl<BigUint: BigUintApi> Action<BigUint> {
+	/// Only pending actions are kept in storage,
+	/// both executed and discarded actions are removed (converted to `Nothing`).
+	/// So this is equivalent to `action != Action::Nothing`.
+	pub fn is_pending(&self) -> bool {
+		matches!(*self, Action::Nothing)
+	}
+}

--- a/contracts/examples/multisig/src/lib.rs
+++ b/contracts/examples/multisig/src/lib.rs
@@ -124,6 +124,21 @@ pub trait Multisig {
 		Ok(action_id)
 	}
 
+	/// Iterates through all actions and retrieves those that are still pending.
+	/// Only retrieves the serialized action data, not the signers.
+	#[view(getPendingActionData)]
+	fn get_pending_action_data(&self) -> MultiResultVec<Action<BigUint>> {
+		let mut result = Vec::new();
+		let action_last_index = self.get_action_last_index();
+		for action_id in 1..=action_last_index{
+			let action = self.get_action_data(action_id);
+			if action.is_pending() {
+				result.push(action);
+			}
+		}
+		result.into()
+	}
+
 	#[endpoint(proposeAddBoardMember)]
 	fn propose_add_board_member(&self, board_member_address: Address) -> SCResult<usize> {
 		self.propose_action(Action::AddBoardMember(board_member_address))

--- a/contracts/examples/multisig/src/lib.rs
+++ b/contracts/examples/multisig/src/lib.rs
@@ -135,7 +135,7 @@ pub trait Multisig {
 	fn get_pending_action_data(&self) -> MultiResultVec<Action<BigUint>> {
 		let mut result = Vec::new();
 		let action_last_index = self.get_action_last_index();
-		for action_id in 1..=action_last_index{
+		for action_id in 1..=action_last_index {
 			let action = self.get_action_data(action_id);
 			if action.is_pending() {
 				result.push(action);

--- a/contracts/examples/multisig/src/lib.rs
+++ b/contracts/examples/multisig/src/lib.rs
@@ -63,13 +63,6 @@ pub trait Multisig {
 	#[storage_set("action_last_index")]
 	fn set_action_last_index(&self, action_last_index: usize);
 
-	#[view(getPendingActionCount)]
-	#[storage_get("pending_action_count")]
-	fn get_pending_action_count(&self) -> usize;
-
-	#[storage_set("pending_action_count")]
-	fn set_pending_action_count(&self, pending_action_count: usize);
-
 	/// Serialized action data of an action with index.
 	#[view(getActionData)]
 	#[storage_get("action_data")]
@@ -126,7 +119,6 @@ pub trait Multisig {
 
 		let action_id = self.get_action_last_index() + 1;
 		self.set_action_last_index(action_id);
-		self.set_pending_action_count(self.get_pending_action_count() + 1);
 		self.set_action_data(action_id, &action);
 		if caller_role.can_sign() {
 			// also sign
@@ -513,7 +505,6 @@ pub trait Multisig {
 	fn clear_action(&self, action_id: usize) {
 		self.set_action_data(action_id, &Action::Nothing);
 		self.set_action_signer_ids(action_id, &[][..]);
-		self.set_pending_action_count(self.get_pending_action_count() - 1);
 	}
 
 	/// Clears storage pertaining to an action that is no longer supposed to be executed.

--- a/contracts/examples/multisig/src/user_role.rs
+++ b/contracts/examples/multisig/src/user_role.rs
@@ -16,6 +16,10 @@ impl UserRole {
 		self.can_propose()
 	}
 
+	pub fn can_discard_action(&self) -> bool {
+		self.can_propose()
+	}
+
 	pub fn can_sign(&self) -> bool {
 		matches!(*self, UserRole::BoardMember)
 	}

--- a/contracts/examples/ping-pong-egld/tests/mandos_test.rs
+++ b/contracts/examples/ping-pong-egld/tests/mandos_test.rs
@@ -1,8 +1,7 @@
-
 extern crate ping_pong_egld;
-use ping_pong_egld::*;
 use elrond_wasm::*;
 use elrond_wasm_debug::*;
+use ping_pong_egld::*;
 
 fn contract_map() -> ContractMap<TxContext> {
 	let mut contract_map = ContractMap::new();
@@ -15,20 +14,14 @@ fn contract_map() -> ContractMap<TxContext> {
 
 #[test]
 fn ping_pong_init() {
-	parse_execute_mandos(
-        "mandos/ping-pong-init.scen.json",
-        &contract_map()
-    );
+	parse_execute_mandos("mandos/ping-pong-init.scen.json", &contract_map());
 }
 
 // ping tests
 
 #[test]
 fn ping_pong_call_ping() {
-	parse_execute_mandos(
-        "mandos/ping-pong-call-ping.scen.json",
-        &contract_map()
-    );
+	parse_execute_mandos("mandos/ping-pong-call-ping.scen.json", &contract_map());
 }
 
 #[test]
@@ -67,10 +60,7 @@ fn ping_pong_call_ping_second_user() {
 
 #[test]
 fn ping_pong_call_pong() {
-	parse_execute_mandos(
-		"mandos/ping-pong-call-pong.scen.json",
-		&contract_map(),
-	);
+	parse_execute_mandos("mandos/ping-pong-call-pong.scen.json", &contract_map());
 }
 
 #[test]
@@ -101,10 +91,7 @@ fn ping_pong_call_pong_before_deadline() {
 
 #[test]
 fn ping_pong_call_pong_all() {
-	parse_execute_mandos(
-		"mandos/ping-pong-call-pong-all.scen.json",
-		&contract_map(),
-	);
+	parse_execute_mandos("mandos/ping-pong-call-pong-all.scen.json", &contract_map());
 }
 
 #[test]


### PR DESCRIPTION
- explicit discardAction endpoint, unsign no longer removes actions automatically
- getPendingActionData view
- getPendingActionCount no longer needed, removed
- ample Rust/ABI docs