### PR TITLE
elrond-wasm 0.10.5, AsyncCallResult optional error message

### DIFF
--- a/contracts/benchmarks/send-tx-repeat/Cargo.toml
+++ b/contracts/benchmarks/send-tx-repeat/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/benchmarks/send-tx-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/send-tx-repeat/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/benchmarks/str-repeat/Cargo.toml
+++ b/contracts/benchmarks/str-repeat/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/benchmarks/str-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/str-repeat/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/adder/Cargo.toml
+++ b/contracts/examples/adder/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/adder/abi/Cargo.toml
+++ b/contracts/examples/adder/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/adder/wasm/Cargo.toml
+++ b/contracts/examples/adder/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/crowdfunding-egld/Cargo.toml
+++ b/contracts/examples/crowdfunding-egld/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/crowdfunding-egld/abi/Cargo.toml
+++ b/contracts/examples/crowdfunding-egld/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/crowdfunding-egld/wasm/Cargo.toml
+++ b/contracts/examples/crowdfunding-egld/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/crowdfunding-erc20/Cargo.toml
+++ b/contracts/examples/crowdfunding-erc20/Cargo.toml
@@ -15,19 +15,19 @@ wasm-output-mode = ["elrond-wasm-node"]
 path = "../simple-erc20"
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"
 

--- a/contracts/examples/crowdfunding-erc20/abi/Cargo.toml
+++ b/contracts/examples/crowdfunding-erc20/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/crowdfunding-erc20/wasm/Cargo.toml
+++ b/contracts/examples/crowdfunding-erc20/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/crowdfunding-esdt/Cargo.toml
+++ b/contracts/examples/crowdfunding-esdt/Cargo.toml
@@ -12,19 +12,19 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"
 

--- a/contracts/examples/crowdfunding-esdt/abi/Cargo.toml
+++ b/contracts/examples/crowdfunding-esdt/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/crowdfunding-esdt/wasm/Cargo.toml
+++ b/contracts/examples/crowdfunding-esdt/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/crypto-bubbles/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-bubbles/abi/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-bubbles/wasm/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/factorial/Cargo.toml
+++ b/contracts/examples/factorial/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/factorial/abi/Cargo.toml
+++ b/contracts/examples/factorial/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/factorial/wasm/Cargo.toml
+++ b/contracts/examples/factorial/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/lottery-egld/Cargo.toml
+++ b/contracts/examples/lottery-egld/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/lottery-egld/abi/Cargo.toml
+++ b/contracts/examples/lottery-egld/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/lottery-egld/wasm/Cargo.toml
+++ b/contracts/examples/lottery-egld/wasm/Cargo.toml
@@ -23,6 +23,6 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = [ "wasm-output-mode",]

--- a/contracts/examples/lottery-erc20/Cargo.toml
+++ b/contracts/examples/lottery-erc20/Cargo.toml
@@ -12,15 +12,15 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
@@ -28,5 +28,5 @@ optional = true
 path = "../simple-erc20"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/lottery-erc20/abi/Cargo.toml
+++ b/contracts/examples/lottery-erc20/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/lottery-erc20/wasm/Cargo.toml
+++ b/contracts/examples/lottery-erc20/wasm/Cargo.toml
@@ -24,6 +24,6 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = [ "wasm-output-mode",]

--- a/contracts/examples/lottery-esdt/Cargo.toml
+++ b/contracts/examples/lottery-esdt/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/lottery-esdt/abi/Cargo.toml
+++ b/contracts/examples/lottery-esdt/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/lottery-esdt/wasm/Cargo.toml
+++ b/contracts/examples/lottery-esdt/wasm/Cargo.toml
@@ -21,7 +21,7 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = [ "wasm-output-mode",]
 

--- a/contracts/examples/multisig/Cargo.toml
+++ b/contracts/examples/multisig/Cargo.toml
@@ -20,30 +20,30 @@ default = [
 
 [dependencies.elrond-wasm-module-users-wasm]
 package = "elrond-wasm-module-users"
-version = "0.10.4"
+version = "0.10.5"
 path = "../../modules/elrond-wasm-module-users"
 features = ["wasm-output-mode"]
 optional = true
 
 [dependencies.elrond-wasm-module-users-default]
 package = "elrond-wasm-module-users"
-version = "0.10.4"
+version = "0.10.5"
 path = "../../modules/elrond-wasm-module-users"
 optional = true
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/multisig/abi/Cargo.toml
+++ b/contracts/examples/multisig/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/multisig/wasm/Cargo.toml
+++ b/contracts/examples/multisig/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/non-fungible-tokens/Cargo.toml
+++ b/contracts/examples/non-fungible-tokens/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/non-fungible-tokens/abi/Cargo.toml
+++ b/contracts/examples/non-fungible-tokens/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/non-fungible-tokens/wasm/Cargo.toml
+++ b/contracts/examples/non-fungible-tokens/wasm/Cargo.toml
@@ -23,6 +23,6 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = [ "wasm-output-mode",]

--- a/contracts/examples/ping-pong-egld/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/ping-pong-egld/abi/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/ping-pong-egld/wasm/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/wasm/Cargo.toml
@@ -22,5 +22,5 @@ features = [ "wasm-output-mode",]
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 features = [ "wasm-output-mode",]

--- a/contracts/examples/simple-erc20/Cargo.toml
+++ b/contracts/examples/simple-erc20/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/simple-erc20/abi/Cargo.toml
+++ b/contracts/examples/simple-erc20/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/simple-erc20/wasm/Cargo.toml
+++ b/contracts/examples/simple-erc20/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/abi-tester/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/abi-tester/abi/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/abi-tester/wasm/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/async/Cargo.toml
+++ b/contracts/feature-tests/async/Cargo.toml
@@ -18,18 +18,18 @@ path = "async-alice"
 path = "async-bob"
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/async/async-alice/Cargo.toml
+++ b/contracts/feature-tests/async/async-alice/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/async/async-alice/wasm/Cargo.toml
+++ b/contracts/feature-tests/async/async-alice/wasm/Cargo.toml
@@ -20,7 +20,7 @@ path = ".."
 features=["wasm-output-mode"]
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/async/async-bob/Cargo.toml
+++ b/contracts/feature-tests/async/async-bob/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/async/async-bob/wasm/Cargo.toml
+++ b/contracts/feature-tests/async/async-bob/wasm/Cargo.toml
@@ -20,7 +20,7 @@ path = ".."
 features=["wasm-output-mode"]
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/basic-features/Cargo.toml
+++ b/contracts/feature-tests/basic-features/Cargo.toml
@@ -12,18 +12,18 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/basic-features/abi/Cargo.toml
+++ b/contracts/feature-tests/basic-features/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/basic-features/mandos/echo_async_result_empty.scen.json
+++ b/contracts/feature-tests/basic-features/mandos/echo_async_result_empty.scen.json
@@ -63,7 +63,29 @@
                 "gas": "*",
                 "refund": "*"
             }
+        },
+        {
+            "step": "scCall",
+            "txId": "2-err-no-message",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "echo_async_result_empty",
+                "arguments": [
+                    "5"
+                ],
+                "gasLimit": "1,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "4",
+                "message": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
         }
-        
     ]
 }

--- a/contracts/feature-tests/basic-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/basic-features/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/esdt-contract-pair/Cargo.toml
+++ b/contracts/feature-tests/esdt-contract-pair/Cargo.toml
@@ -18,18 +18,18 @@ path = "first-contract"
 path = "second-contract"
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/esdt-contract-pair/first-contract/Cargo.toml
+++ b/contracts/feature-tests/esdt-contract-pair/first-contract/Cargo.toml
@@ -12,19 +12,19 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"
 

--- a/contracts/feature-tests/esdt-contract-pair/first-contract/wasm/Cargo.toml
+++ b/contracts/feature-tests/esdt-contract-pair/first-contract/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/esdt-contract-pair/second-contract/Cargo.toml
+++ b/contracts/feature-tests/esdt-contract-pair/second-contract/Cargo.toml
@@ -12,19 +12,19 @@ path = "src/lib.rs"
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"
 

--- a/contracts/feature-tests/esdt-contract-pair/second-contract/wasm/Cargo.toml
+++ b/contracts/feature-tests/esdt-contract-pair/second-contract/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/use-module/Cargo.toml
+++ b/contracts/feature-tests/use-module/Cargo.toml
@@ -22,43 +22,43 @@ default = [
 
 [dependencies.elrond-wasm-module-features-wasm]
 package = "elrond-wasm-module-features"
-version = "0.10.4"
+version = "0.10.5"
 path = "../../modules/elrond-wasm-module-features"
 features = ["wasm-output-mode"]
 optional = true
 
 [dependencies.elrond-wasm-module-features-default]
 package = "elrond-wasm-module-features"
-version = "0.10.4"
+version = "0.10.5"
 path = "../../modules/elrond-wasm-module-features"
 optional = true
 
 [dependencies.elrond-wasm-module-pause-wasm]
 package = "elrond-wasm-module-pause"
-version = "0.10.4"
+version = "0.10.5"
 path = "../../modules/elrond-wasm-module-pause"
 features = ["wasm-output-mode"]
 optional = true
 
 [dependencies.elrond-wasm-module-pause-default]
 package = "elrond-wasm-module-pause"
-version = "0.10.4"
+version = "0.10.5"
 path = "../../modules/elrond-wasm-module-pause"
 optional = true
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/use-module/abi/Cargo.toml
+++ b/contracts/feature-tests/use-module/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/use-module/wasm/Cargo.toml
+++ b/contracts/feature-tests/use-module/wasm/Cargo.toml
@@ -21,7 +21,7 @@ default-features = false
 features=["wasm-output-mode"]
 
 [dependencies.elrond-wasm-output]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/modules/elrond-wasm-module-features/Cargo.toml
+++ b/contracts/modules/elrond-wasm-module-features/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-module-features"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
@@ -17,18 +17,18 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies"]
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/modules/elrond-wasm-module-pause/Cargo.toml
+++ b/contracts/modules/elrond-wasm-module-pause/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-module-pause"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
@@ -17,18 +17,18 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies"]
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/contracts/modules/elrond-wasm-module-users/Cargo.toml
+++ b/contracts/modules/elrond-wasm-module-users/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-module-users"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
@@ -17,18 +17,18 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies"]
 wasm-output-mode = ["elrond-wasm-node"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-derive]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-derive"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.10.4"
+version = "0.10.5"
 path = "../../../elrond-wasm-debug"

--- a/elrond-wasm-debug/Cargo.toml
+++ b/elrond-wasm-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-debug"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../elrond-wasm"
 
 [dependencies.mandos]

--- a/elrond-wasm-derive/Cargo.toml
+++ b/elrond-wasm-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-derive"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]

--- a/elrond-wasm-node/Cargo.toml
+++ b/elrond-wasm-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-node"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
@@ -14,5 +14,5 @@ keywords = ["elrond", "wasm", "webassembly", "blockchain", "contract"]
 categories = ["no-std", "wasm", "cryptography::cryptocurrencies", "development-tools::ffi"]
 
 [dependencies.elrond-wasm]
-version = "0.10.4"
+version = "0.10.5"
 path = "../elrond-wasm"

--- a/elrond-wasm-output/Cargo.toml
+++ b/elrond-wasm-output/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-output"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
@@ -27,5 +27,5 @@ panic-message = []
 wee_alloc = "0.4"
 
 [dependencies.elrond-wasm-node]
-version = "0.10.4"
+version = "0.10.5"
 path = "../elrond-wasm-node"

--- a/elrond-wasm/Cargo.toml
+++ b/elrond-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]

--- a/elrond-wasm/src/types/async_call_result.rs
+++ b/elrond-wasm/src/types/async_call_result.rs
@@ -6,7 +6,7 @@ use elrond_codec::TopDecodeInput;
 
 pub struct AsyncCallError {
 	pub err_code: u32,
-	pub err_msg: Vec<u8>,
+	pub err_msg: Vec<u8>, // TODO: convert to BoxedBytes
 }
 
 pub enum AsyncCallResult<T> {
@@ -26,7 +26,14 @@ where
 			let arg = T::dyn_load(loader, arg_id);
 			AsyncCallResult::Ok(arg)
 		} else {
-			let err_msg = Vec::<u8>::dyn_load(loader, arg_id);
+			let err_msg = if loader.has_next() {
+				Vec::<u8>::dyn_load(loader, arg_id)
+			} else {
+				// temporary fix, until a problem involving missing error messages in the protocol gets fixed
+				// can be removed after the protocol is patched
+				// error messages should not normally be missing
+				Vec::<u8>::new()
+			};
 			AsyncCallResult::Err(AsyncCallError { err_code, err_msg })
 		}
 	}


### PR DESCRIPTION
AsyncCallResult accepts a missing error message, in order to mitigate an edge case from the protocol.