### PR TITLE
async call redesign - part 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
   "contracts/feature-tests/async",
   "contracts/feature-tests/async/async-alice",
   "contracts/feature-tests/async/async-bob",
+  "contracts/feature-tests/async/forwarder",
   "contracts/feature-tests/async/forwarder-raw",
   "contracts/feature-tests/async/vault",
   "contracts/feature-tests/basic-features",

--- a/contracts/examples/crypto-kitties/kitty-auction/src/auction.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/src/auction.rs
@@ -1,6 +1,7 @@
 elrond_wasm::derive_imports!();
 
-use elrond_wasm::{api::BigUintApi, Address};
+use elrond_wasm::api::BigUintApi;
+use elrond_wasm::types::Address;
 
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
 pub enum AuctionType {

--- a/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
@@ -71,16 +71,6 @@ pub trait KittyAuction {
 		}
 	}
 
-	#[endpoint]
-	fn claim(&self) -> SCResult<()> {
-		only_owner!(self, "Only owner may call this function!");
-
-		self.send()
-			.direct_egld(&self.get_caller(), &self.get_sc_balance(), b"claim");
-
-		Ok(())
-	}
-
 	// views
 
 	#[view(isUpForAuction)]

--- a/contracts/examples/lottery-egld/src/lottery_info.rs
+++ b/contracts/examples/lottery-egld/src/lottery_info.rs
@@ -1,5 +1,5 @@
 use elrond_wasm::api::BigUintApi;
-use elrond_wasm::{Address, Vec};
+use elrond_wasm::types::{Address, Vec};
 
 elrond_wasm::derive_imports!();
 

--- a/contracts/examples/lottery-erc20/src/lottery_info.rs
+++ b/contracts/examples/lottery-erc20/src/lottery_info.rs
@@ -1,5 +1,5 @@
 use elrond_wasm::api::BigUintApi;
-use elrond_wasm::{Address, Vec};
+use elrond_wasm::types::{Address, Vec};
 elrond_wasm::derive_imports!();
 
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]

--- a/contracts/examples/lottery-esdt/src/lottery_info.rs
+++ b/contracts/examples/lottery-esdt/src/lottery_info.rs
@@ -1,5 +1,5 @@
 use elrond_wasm::api::BigUintApi;
-use elrond_wasm::{Address, TokenIdentifier, Vec};
+use elrond_wasm::types::{Address, TokenIdentifier, Vec};
 
 elrond_wasm::derive_imports!();
 

--- a/contracts/examples/multisig/src/action.rs
+++ b/contracts/examples/multisig/src/action.rs
@@ -1,6 +1,6 @@
 use elrond_wasm::api::{BigUintApi, EndpointFinishApi, ErrorApi, SendApi};
 use elrond_wasm::io::EndpointResult;
-use elrond_wasm::{Address, AsyncCall, BoxedBytes, CodeMetadata, SendEgld, Vec};
+use elrond_wasm::types::{Address, AsyncCall, BoxedBytes, CodeMetadata, SendEgld, Vec};
 elrond_wasm::derive_imports!();
 
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]

--- a/contracts/examples/multisig/src/action.rs
+++ b/contracts/examples/multisig/src/action.rs
@@ -23,8 +23,8 @@ pub enum Action<BigUint: BigUintApi> {
 	},
 	SCCall {
 		to: Address,
-		amount: BigUint,
-		function: BoxedBytes,
+		egld_payment: BigUint,
+		endpoint_name: BoxedBytes,
 		arguments: Vec<BoxedBytes>,
 	},
 }

--- a/contracts/examples/multisig/src/lib.rs
+++ b/contracts/examples/multisig/src/lib.rs
@@ -227,14 +227,14 @@ pub trait Multisig {
 	fn propose_sc_call(
 		&self,
 		to: Address,
-		amount: BigUint,
-		function: BoxedBytes,
+		egld_payment: BigUint,
+		endpoint_name: BoxedBytes,
 		#[var_args] arguments: VarArgs<BoxedBytes>,
 	) -> SCResult<usize> {
 		self.propose_action(Action::SCCall {
 			to,
-			amount,
-			function,
+			egld_payment,
+			endpoint_name,
 			arguments: arguments.into_vec(),
 		})
 	}
@@ -492,7 +492,7 @@ pub trait Multisig {
 				let gas_left = self.get_gas_left();
 				let mut arg_buffer = ArgBuffer::new();
 				for arg in arguments {
-					arg_buffer.push_raw_arg(arg.as_slice());
+					arg_buffer.push_argument_bytes(arg.as_slice());
 				}
 				let new_address = self.send().deploy_contract(
 					gas_left,
@@ -505,12 +505,12 @@ pub trait Multisig {
 			},
 			Action::SCCall {
 				to,
-				amount,
-				function,
+				egld_payment,
+				endpoint_name,
 				arguments,
 			} => {
 				let mut contract_call_raw =
-					ContractCall::new(to, TokenIdentifier::egld(), amount, function.as_slice());
+					ContractCall::new(to, TokenIdentifier::egld(), egld_payment, endpoint_name);
 				for arg in arguments {
 					contract_call_raw.push_argument_raw_bytes(arg.as_slice());
 				}

--- a/contracts/feature-tests/abi-tester/src/lib.rs
+++ b/contracts/feature-tests/abi-tester/src/lib.rs
@@ -8,7 +8,6 @@ mod only_nested;
 
 use abi_enum::*;
 use abi_test_type::*;
-use elrond_wasm::TokenIdentifier;
 use only_nested::*;
 
 /// Contract whose sole purpose is to verify that

--- a/contracts/feature-tests/async/forwarder-raw/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder-raw/src/lib.rs
@@ -26,7 +26,7 @@ pub trait ForwarderRaw {
 
 	#[endpoint]
 	#[payable("*")]
-	fn forward_call(
+	fn forward_async_call(
 		&self,
 		to: Address,
 		#[payment_token] token: TokenIdentifier,
@@ -43,7 +43,7 @@ pub trait ForwarderRaw {
 
 	#[endpoint]
 	#[payable("*")]
-	fn forward_call_half_payment(
+	fn forward_async_call_half_payment(
 		&self,
 		to: Address,
 		#[payment_token] token: TokenIdentifier,
@@ -52,12 +52,12 @@ pub trait ForwarderRaw {
 		#[var_args] args: VarArgs<BoxedBytes>,
 	) -> AsyncCall<BigUint> {
 		let half_payment = payment / 2u32.into();
-		self.forward_call(to, token, half_payment, endpoint_name, args)
+		self.forward_async_call(to, token, half_payment, endpoint_name, args)
 	}
 
 	#[view]
-	#[storage_mapper("callback_raw_data")]
-	fn callback_raw_data(
+	#[storage_mapper("callback_data")]
+	fn callback_data(
 		&self,
 	) -> VecMapper<Self::Storage, (TokenIdentifier, BigUint, Vec<BoxedBytes>)>;
 
@@ -66,13 +66,13 @@ pub trait ForwarderRaw {
 		&self,
 		index: usize,
 	) -> MultiResult3<TokenIdentifier, BigUint, MultiResultVec<BoxedBytes>> {
-		let (token, payment, args) = self.callback_raw_data().get(index);
+		let (token, payment, args) = self.callback_data().get(index);
 		(token, payment, args.into()).into()
 	}
 
 	#[endpoint]
 	fn clear_callback_info(&self) {
-		self.callback_raw_data().clear();
+		self.callback_data().clear();
 	}
 
 	#[callback_raw]
@@ -82,7 +82,7 @@ pub trait ForwarderRaw {
 		#[payment] payment: BigUint,
 		#[var_args] args: VarArgs<BoxedBytes>,
 	) {
-		self.callback_raw_data()
+		self.callback_data()
 			.push(&(token, payment, args.into_vec()));
 	}
 }

--- a/contracts/feature-tests/async/forwarder-raw/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder-raw/src/lib.rs
@@ -34,7 +34,7 @@ pub trait ForwarderRaw {
 		endpoint_name: BoxedBytes,
 		#[var_args] args: VarArgs<BoxedBytes>,
 	) -> AsyncCall<BigUint> {
-		let mut contract_call = ContractCall::new(to, token, payment, endpoint_name.as_slice());
+		let mut contract_call = ContractCall::new(to, token, payment, endpoint_name);
 		for arg in args.into_vec() {
 			contract_call.push_argument_raw_bytes(arg.as_slice());
 		}

--- a/contracts/feature-tests/async/forwarder/Cargo.toml
+++ b/contracts/feature-tests/async/forwarder/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "forwarder"
+version = "0.0.0"
+authors = ["Andrei Marinica <andrei.marinica@elrond.com>"]
+edition = "2018"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+wasm-output-mode = ["elrond-wasm-node"]
+
+[dependencies.elrond-wasm]
+version = "0.11.0"
+path = "../../../../elrond-wasm"
+
+[dependencies.elrond-wasm-derive]
+version = "0.11.0"
+path = "../../../../elrond-wasm-derive"
+
+[dependencies.elrond-wasm-node]
+version = "0.11.0"
+path = "../../../../elrond-wasm-node"
+optional = true
+
+[dev-dependencies.elrond-wasm-debug]
+version = "0.11.0"
+path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/async/forwarder/elrond.json
+++ b/contracts/feature-tests/async/forwarder/elrond.json
@@ -1,0 +1,3 @@
+{
+    "language": "rust"
+}

--- a/contracts/feature-tests/async/forwarder/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder/src/lib.rs
@@ -1,0 +1,111 @@
+#![no_std]
+
+elrond_wasm::imports!();
+
+#[elrond_wasm_derive::callable(VaultProxy)]
+pub trait Vault {
+	fn echo_arguments(&self, args: VarArgs<BoxedBytes>) -> ContractCall<BigUint>;
+
+	#[payable("*")]
+	fn accept_funds(&self) -> ContractCall<BigUint>;
+
+	#[payable("*")]
+	fn reject_funds(&self) -> ContractCall<BigUint>;
+
+	fn retrieve_funds(&self, token: TokenIdentifier, amount: BigUint) -> ContractCall<BigUint>;
+}
+
+/// Test contract for investigating async calls.
+#[elrond_wasm_derive::contract(ForwarderImpl)]
+pub trait Forwarder {
+	#[init]
+	fn init(&self) {}
+
+	#[endpoint]
+	#[payable("*")]
+	fn direct_payment(
+		&self,
+		to: Address,
+		#[payment_token] token: TokenIdentifier,
+		#[payment] payment: BigUint,
+	) {
+		self.send().direct(&to, &token, &payment, &[]);
+	}
+
+	#[endpoint]
+	#[payable("*")]
+	fn deposit(
+		&self,
+		to: Address,
+		#[payment_token] token: TokenIdentifier,
+		#[payment] payment: BigUint,
+	) -> AsyncCall<BigUint> {
+		contract_call!(self, to, VaultProxy)
+			.with_token_transfer(token, payment)
+			.accept_funds()
+			.async_call()
+	}
+
+	#[endpoint]
+	#[payable("*")]
+	fn deposit_half_payment(
+		&self,
+		to: Address,
+		#[payment_token] token: TokenIdentifier,
+		#[payment] payment: BigUint,
+	) -> AsyncCall<BigUint> {
+		let half_payment = payment / 2u32.into();
+		contract_call!(self, to, VaultProxy)
+			.with_token_transfer(token, half_payment)
+			.accept_funds()
+			.async_call()
+	}
+
+	#[endpoint]
+	#[payable("*")]
+	fn retrieve_funds(
+		&self,
+		to: Address,
+		token: TokenIdentifier,
+		payment: BigUint,
+	) -> AsyncCall<BigUint> {
+		contract_call!(self, to, VaultProxy)
+			.retrieve_funds(token, payment)
+			.async_call()
+			.with_callback(self.callbacks().retrieve_funds_callback())
+	}
+
+	#[callback]
+	fn retrieve_funds_callback(
+		&self,
+		#[payment_token] token: TokenIdentifier,
+		#[payment] payment: BigUint,
+	) {
+		self.callback_data().push(&(
+			BoxedBytes::from(&b"retrieve_funds_callback"[..]),
+			token,
+			payment,
+			Vec::new(),
+		));
+	}
+
+	#[view]
+	#[storage_mapper("callback_data")]
+	fn callback_data(
+		&self,
+	) -> VecMapper<Self::Storage, (BoxedBytes, TokenIdentifier, BigUint, Vec<BoxedBytes>)>;
+
+	#[view]
+	fn callback_data_at_index(
+		&self,
+		index: usize,
+	) -> MultiResult4<BoxedBytes, TokenIdentifier, BigUint, MultiResultVec<BoxedBytes>> {
+		let (cb_name, token, payment, args) = self.callback_data().get(index);
+		(cb_name, token, payment, args.into()).into()
+	}
+
+	#[endpoint]
+	fn clear_callback_data(&self) {
+		self.callback_data().clear();
+	}
+}

--- a/contracts/feature-tests/async/forwarder/wasm/Cargo.toml
+++ b/contracts/feature-tests/async/forwarder/wasm/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "forwarder-wasm"
+version = "0.0.0"
+authors = ["Andrei Marinica <andrei.marinica@elrond.com>"]
+edition = "2018"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[profile.release]
+codegen-units = 1
+opt-level = "z"
+lto = true
+debug = false
+panic = "abort"
+
+[dependencies.forwarder]
+path = ".."
+features=["wasm-output-mode"]
+
+[dependencies.elrond-wasm-output]
+version = "0.11.0"
+path = "../../../../../elrond-wasm-output"
+features=["wasm-output-mode"]
+
+[workspace]
+members = ["."]

--- a/contracts/feature-tests/async/forwarder/wasm/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder/wasm/src/lib.rs
@@ -1,0 +1,4 @@
+#![no_std]
+
+pub use forwarder::*;
+pub use elrond_wasm_output::*;

--- a/contracts/feature-tests/basic-features/mandos/get_caller.scen.json
+++ b/contracts/feature-tests/basic-features/mandos/get_caller.scen.json
@@ -1,0 +1,58 @@
+{
+    "name": "count ones",
+    "comment": "should fail if the processor doesn't support the `count ones` instruction",
+    "steps": [
+        {
+            "step": "setState",
+            "accounts": {
+                "address:features_contract": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "storage": {},
+                    "code": "file:../output/basic-features.wasm"
+                },
+                "address:an_account": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "storage": {},
+                    "code": ""
+                }
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "get_caller",
+            "tx": {
+                "from": "address:an_account",
+                "to": "address:features_contract",
+                "value": "0",
+                "function": "get_caller",
+                "arguments": [],
+                "gasLimit": "0x100000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [ "address:an_account" ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "get_caller",
+            "tx": {
+                "to": "address:features_contract",
+                "function": "get_prev_block_timestamp",
+            },
+            "expect": {
+                "out": [ "address:an_account" ],
+                "status": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        }
+    ]
+}

--- a/contracts/feature-tests/basic-features/mandos/get_caller.scen.json
+++ b/contracts/feature-tests/basic-features/mandos/get_caller.scen.json
@@ -1,6 +1,5 @@
 {
-    "name": "count ones",
-    "comment": "should fail if the processor doesn't support the `count ones` instruction",
+    "name": "get caller",
     "steps": [
         {
             "step": "setState",
@@ -41,13 +40,13 @@
         },
         {
             "step": "scQuery",
-            "txId": "get_caller",
+            "txId": "get_caller_query",
             "tx": {
                 "to": "address:features_contract",
-                "function": "get_prev_block_timestamp",
+                "function": "get_caller"
             },
             "expect": {
-                "out": [ "address:an_account" ],
+                "out": [ "address:features_contract" ],
                 "status": "",
                 "logs": [],
                 "gas": "*",

--- a/contracts/feature-tests/basic-features/mandos/storage_mapper_map.scen.json
+++ b/contracts/feature-tests/basic-features/mandos/storage_mapper_map.scen.json
@@ -25,7 +25,7 @@
                 "from": "address:an_account",
                 "to": "address:features_contract",
                 "value": "0",
-                "function": "map_mapper",
+                "function": "map_mapper_keys",
                 "arguments": [],
                 "gasLimit": "0x100000",
                 "gasPrice": "0"

--- a/contracts/feature-tests/basic-features/src/lib.rs
+++ b/contracts/feature-tests/basic-features/src/lib.rs
@@ -519,6 +519,17 @@ pub trait BasicFeatures {
 		map_mapper.remove(&item)
 	}
 
+	// BASIC API
+	#[endpoint(get_caller)]
+	fn get_caller_endpoint(&self) -> Address {
+		self.get_caller()
+	}
+
+	#[endpoint(get_gas_left)]
+	fn get_gas_left_endpoint(&self) -> u64 {
+		self.get_gas_left()
+	}
+
 	// EVENTS
 
 	#[endpoint(logEventA)]

--- a/contracts/feature-tests/basic-features/src/ser_ex1.rs
+++ b/contracts/feature-tests/basic-features/src/ser_ex1.rs
@@ -1,4 +1,4 @@
-use elrond_wasm::{BoxedBytes, Vec};
+use elrond_wasm::types::{BoxedBytes, Vec};
 elrond_wasm::derive_imports!();
 
 /// Copied from elrond-wasm serialization tests.

--- a/contracts/feature-tests/basic-features/tests/basic_features_test.rs
+++ b/contracts/feature-tests/basic-features/tests/basic_features_test.rs
@@ -1,6 +1,6 @@
 extern crate basic_features;
 use basic_features::*;
-use elrond_wasm::*;
+use elrond_wasm::types::{SCError, SCResult};
 use elrond_wasm_debug::*;
 
 #[test]

--- a/elrond-wasm-debug/src/api/contract_api_mock.rs
+++ b/elrond-wasm-debug/src/api/contract_api_mock.rs
@@ -1,7 +1,7 @@
 use super::big_int_api_mock::*;
 use super::big_uint_api_mock::*;
 use crate::TxContext;
-use elrond_wasm::{Address, H256};
+use elrond_wasm::types::{Address, H256};
 
 impl elrond_wasm::api::ContractHookApi<RustBigInt, RustBigUint> for TxContext {
 	type Storage = Self;

--- a/elrond-wasm-debug/src/api/send_api_mock.rs
+++ b/elrond-wasm-debug/src/api/send_api_mock.rs
@@ -66,6 +66,17 @@ impl SendApi<RustBigUint> for TxContext {
 		})
 	}
 
+	fn direct_egld_execute(
+		&self,
+		_to: &Address,
+		_amount: &RustBigUint,
+		_gas_limit: u64,
+		_function: &[u8],
+		_arg_buffer: &ArgBuffer,
+	) {
+		panic!("direct_egld_execute not yet implemented")
+	}
+
 	fn direct_esdt_execute(
 		&self,
 		to: &Address,

--- a/elrond-wasm-debug/src/async_data.rs
+++ b/elrond-wasm-debug/src/async_data.rs
@@ -1,7 +1,7 @@
 use crate::tx_context::*;
 use elrond_wasm::elrond_codec::*;
 use elrond_wasm::hex_call_data::HexCallDataDeserializer;
-use elrond_wasm::{Address, H256};
+use elrond_wasm::types::{Address, H256};
 
 use num_bigint::BigUint;
 

--- a/elrond-wasm-debug/src/execute_mandos.rs
+++ b/elrond-wasm-debug/src/execute_mandos.rs
@@ -1,7 +1,7 @@
 #![allow(unused_variables)] // for now
 
 use super::*;
-use elrond_wasm::*;
+use elrond_wasm::types::*;
 use mandos::*;
 use num_bigint::BigUint;
 use std::path::Path;

--- a/elrond-wasm-debug/src/tx_context.rs
+++ b/elrond-wasm-debug/src/tx_context.rs
@@ -4,7 +4,7 @@ use crate::display_util::*;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::cell::RefCell;
-use elrond_wasm::{Address, TokenIdentifier, H256};
+use elrond_wasm::types::{Address, TokenIdentifier, H256};
 use num_bigint::BigUint;
 use std::collections::HashMap;
 use std::fmt;

--- a/elrond-wasm-debug/tests/test_hash_map_mapper.rs
+++ b/elrond-wasm-debug/tests/test_hash_map_mapper.rs
@@ -1,6 +1,6 @@
 use elrond_wasm::storage::mappers::MapMapper;
 use elrond_wasm::storage::mappers::StorageMapper;
-use elrond_wasm::BoxedBytes;
+use elrond_wasm::types::BoxedBytes;
 use elrond_wasm_debug::TxContext;
 
 fn create_map() -> MapMapper<TxContext, u64, u64> {

--- a/elrond-wasm-debug/tests/test_hash_set_mapper.rs
+++ b/elrond-wasm-debug/tests/test_hash_set_mapper.rs
@@ -1,6 +1,6 @@
 use elrond_wasm::storage::mappers::SetMapper;
 use elrond_wasm::storage::mappers::StorageMapper;
-use elrond_wasm::BoxedBytes;
+use elrond_wasm::types::BoxedBytes;
 use elrond_wasm_debug::TxContext;
 
 fn create_set() -> SetMapper<TxContext, u64> {

--- a/elrond-wasm-debug/tests/test_linked_list_mapper.rs
+++ b/elrond-wasm-debug/tests/test_linked_list_mapper.rs
@@ -1,6 +1,6 @@
 use elrond_wasm::storage::mappers::LinkedListMapper;
 use elrond_wasm::storage::mappers::StorageMapper;
-use elrond_wasm::BoxedBytes;
+use elrond_wasm::types::BoxedBytes;
 use elrond_wasm_debug::TxContext;
 
 fn create_list() -> LinkedListMapper<TxContext, u64> {

--- a/elrond-wasm-derive/src/arg_str_serialize.rs
+++ b/elrond-wasm-derive/src/arg_str_serialize.rs
@@ -10,7 +10,7 @@ pub fn arg_serialize_push(
 	match arg_ty {
 		syn::Type::Path(_) => {
 			quote! {
-				elrond_wasm::io::serialize_contract_call_arg(&#var_name, #arg_accumulator, self.api.clone());
+				elrond_wasm::io::serialize_contract_call_arg(#var_name, #arg_accumulator, self.api.clone());
 			}
 		},
 		syn::Type::Reference(type_reference) => {

--- a/elrond-wasm-derive/src/arg_str_serialize.rs
+++ b/elrond-wasm-derive/src/arg_str_serialize.rs
@@ -10,9 +10,7 @@ pub fn arg_serialize_push(
 	match arg_ty {
 		syn::Type::Path(_) => {
 			quote! {
-				if let Result::Err(sc_err) = AsyncCallArg::push_async_arg(&#var_name, #arg_accumulator) {
-					self.api.signal_error(sc_err.as_bytes());
-				}
+				elrond_wasm::io::serialize_contract_call_arg(&#var_name, #arg_accumulator, self.api.clone());
 			}
 		},
 		syn::Type::Reference(type_reference) => {
@@ -20,42 +18,7 @@ pub fn arg_serialize_push(
 				panic!("Mutable references not supported as contract method arguments");
 			}
 			quote! {
-				if let Result::Err(sc_err) = AsyncCallArg::push_async_arg(#var_name, #arg_accumulator) {
-					self.api.signal_error(sc_err.as_bytes());
-				}
-			}
-		},
-		other_arg => panic!(
-			"Unsupported argument type: {:?}, neither path nor reference",
-			other_arg
-		),
-	}
-}
-
-pub fn arg_serialize_push_multi(
-	arg: &MethodArg,
-	arg_accumulator: &proc_macro2::TokenStream,
-	expected_count_expr: &proc_macro2::TokenStream,
-) -> proc_macro2::TokenStream {
-	let pat = &arg.pat;
-	let var_name = quote! { #pat };
-	let arg_ty = &arg.ty;
-	match arg_ty {
-		syn::Type::Path(_) => {
-			quote! {
-				if let Result::Err(sc_err) = AsyncCallArg::push_async_arg_exact(&#var_name, &mut #arg_accumulator, #expected_count_expr) {
-					self.api.signal_error(sc_err.as_bytes());
-				}
-			}
-		},
-		syn::Type::Reference(type_reference) => {
-			if type_reference.mutability.is_some() {
-				panic!("Mutable references not supported as contract method arguments");
-			}
-			quote! {
-				if let Result::Err(sc_err) = AsyncCallArg::push_async_arg_exact(#var_name, &mut #arg_accumulator, #expected_count_expr) {
-					self.api.signal_error(sc_err.as_bytes());
-				}
+				elrond_wasm::io::serialize_contract_call_arg(#var_name, #arg_accumulator, self.api.clone());
 			}
 		},
 		other_arg => panic!(

--- a/elrond-wasm-derive/src/callable.rs
+++ b/elrond-wasm-derive/src/callable.rs
@@ -58,14 +58,8 @@ pub fn process_callable(
 				}
 			}
 
-			fn token_transfer(mut self, token: TokenIdentifier, payment: BigUint) -> Self {
+			fn with_token_transfer(mut self, token: TokenIdentifier, payment: BigUint) -> Self {
 				self.token = token;
-				self.payment = payment;
-				self
-			}
-
-			fn egld_transfer(mut self, payment: BigUint) -> Self {
-				self.token = elrond_wasm::types::TokenIdentifier::egld();
 				self.payment = payment;
 				self
 			}

--- a/elrond-wasm-derive/src/callable_gen.rs
+++ b/elrond-wasm-derive/src/callable_gen.rs
@@ -8,7 +8,7 @@ use super::util::*;
 #[derive(Clone, Debug)]
 pub struct CallableMethod {
 	pub name: syn::Ident,
-	pub payable: bool,
+	pub payable: MethodPayableMetadata,
 	pub generics: syn::Generics,
 	pub method_args: Vec<MethodArg>,
 	pub return_type: syn::ReturnType,
@@ -17,15 +17,10 @@ pub struct CallableMethod {
 impl CallableMethod {
 	pub fn parse(m: &syn::TraitItemMethod) -> CallableMethod {
 		let payable = process_payable(m);
-		if let MethodPayableMetadata::SingleEsdtToken(_) | MethodPayableMetadata::AnyToken = payable
-		{
-			panic!("payable methods in async call proxies currently only accept EGLD");
-		}
-
 		let method_args = extract_method_args(m);
 		CallableMethod {
 			name: m.sig.ident.clone(),
-			payable: payable.is_payable(),
+			payable,
 			generics: m.sig.generics.clone(),
 			method_args,
 			return_type: m.sig.output.clone(),

--- a/elrond-wasm-derive/src/callable_gen.rs
+++ b/elrond-wasm-derive/src/callable_gen.rs
@@ -104,7 +104,7 @@ impl Callable {
 					.method_args
 					.iter()
 					.map(|arg| {
-						let arg_accumulator = quote! { &mut async_call.hex_data };
+						let arg_accumulator = quote! { ___contract_call___.get_mut_arg_buffer() };
 
 						match &arg.metadata {
 							ArgMetadata::Single | ArgMetadata::VarArgs => {
@@ -141,13 +141,13 @@ impl Callable {
 				let m_name_literal = ident_str_literal(&m.name);
 				let sig = quote! {
 					#msig {
-						let mut async_call = elrond_wasm::types::ContractCall::<BigUint>::new(
+						let mut ___contract_call___ = elrond_wasm::types::ContractCall::<BigUint>::new(
 							self.address,
 							#token_expr,
 							#payment_expr,
-							#m_name_literal);
+							elrond_wasm::types::BoxedBytes::from(#m_name_literal));
 						#(#arg_push_snippets)*
-						async_call
+						___contract_call___
 					}
 				};
 				sig

--- a/elrond-wasm-derive/src/contract_gen_callback.rs
+++ b/elrond-wasm-derive/src/contract_gen_callback.rs
@@ -127,7 +127,7 @@ pub fn generate_callback_proxies(methods: &[Method]) -> proc_macro2::TokenStream
 					.method_args
 					.iter()
 					.map(|arg| {
-						let arg_accumulator = quote! { &mut closure_data };
+						let arg_accumulator = quote! { &mut ___closure_arg_buffer___ };
 
 						match &arg.metadata {
 							ArgMetadata::Single | ArgMetadata::VarArgs => {
@@ -141,9 +141,9 @@ pub fn generate_callback_proxies(methods: &[Method]) -> proc_macro2::TokenStream
 					.collect();
 				let proxy_decl = quote! {
 					pub fn #method_name ( &self , #(#arg_decl),* ) -> elrond_wasm::types::CallbackCall{
-						let mut closure_data = elrond_wasm::hex_call_data::HexCallDataSerializer::new(#cb_name_literal);
+						let mut ___closure_arg_buffer___ = elrond_wasm::types::ArgBuffer::new();
 						#(#arg_push_snippets)*
-						elrond_wasm::types::CallbackCall::from_raw(closure_data)
+						elrond_wasm::types::CallbackCall::from_arg_buffer(#cb_name_literal, &___closure_arg_buffer___)
 					}
 
 				};
@@ -160,7 +160,7 @@ pub fn generate_callback_proxies(methods: &[Method]) -> proc_macro2::TokenStream
 		where
 			BigUint: elrond_wasm::api::BigUintApi + 'static,
 			BigInt: elrond_wasm::api::BigIntApi<BigUint> + 'static,
-			A: elrond_wasm::api::ErrorApi + 'static,
+			A: elrond_wasm::api::ErrorApi + Clone + 'static,
 		{
 			pub api: A,
 			_phantom1: core::marker::PhantomData<BigInt>,
@@ -171,7 +171,7 @@ pub fn generate_callback_proxies(methods: &[Method]) -> proc_macro2::TokenStream
 		where
 			BigUint: elrond_wasm::api::BigUintApi + 'static,
 			BigInt: elrond_wasm::api::BigIntApi<BigUint> + 'static,
-			A: elrond_wasm::api::ErrorApi + 'static,
+			A: elrond_wasm::api::ErrorApi + Clone + 'static,
 		{
 			pub fn new(api: A) -> Self {
 				CallbackProxies {

--- a/elrond-wasm-derive/src/contract_gen_payable.rs
+++ b/elrond-wasm-derive/src/contract_gen_payable.rs
@@ -69,10 +69,14 @@ fn payable_snippet_for_metadata(
 			}
 		},
 		MethodPayableMetadata::AnyToken => {
-			let payment_var_name = var_name_or_underscore(payment_arg);
-			let token_var_name = var_name_or_underscore(token_arg);
-			quote! {
-				let (#payment_var_name, #token_var_name) = self.call_value().payment_token_pair();
+			if payment_arg.is_none() && token_arg.is_none() {
+				quote! {}
+			} else {
+				let payment_var_name = var_name_or_underscore(payment_arg);
+				let token_var_name = var_name_or_underscore(token_arg);
+				quote! {
+					let (#payment_var_name, #token_var_name) = self.call_value().payment_token_pair();
+				}
 			}
 		},
 	}

--- a/elrond-wasm-node/src/api/contract_api_node.rs
+++ b/elrond-wasm-node/src/api/contract_api_node.rs
@@ -1,7 +1,7 @@
 use super::{ArwenBigInt, ArwenBigUint};
 use crate::ArwenApiImpl;
 use elrond_wasm::api::ContractHookApi;
-use elrond_wasm::{Address, Box, H256};
+use elrond_wasm::types::{Address, Box, H256};
 
 extern "C" {
 	fn getSCAddress(resultOffset: *mut u8);

--- a/elrond-wasm/src/hex_call_data/cd_ser.rs
+++ b/elrond-wasm/src/hex_call_data/cd_ser.rs
@@ -1,3 +1,4 @@
+use crate::types::ArgBuffer;
 use alloc::vec::Vec;
 
 use super::SEPARATOR;
@@ -30,10 +31,16 @@ fn byte_to_hex(byte: u8) -> (u8, u8) {
 pub struct HexCallDataSerializer(Vec<u8>);
 
 impl HexCallDataSerializer {
-	pub fn new(func_name: &[u8]) -> Self {
-		let mut data = Vec::with_capacity(func_name.len());
-		data.extend_from_slice(func_name);
+	pub fn new(endpoint_name: &[u8]) -> Self {
+		let mut data = Vec::with_capacity(endpoint_name.len());
+		data.extend_from_slice(endpoint_name);
 		HexCallDataSerializer(data)
+	}
+
+	pub fn from_arg_buffer(endpoint_name: &[u8], arg_buffer: &ArgBuffer) -> Self {
+		let mut hex_data = HexCallDataSerializer::new(endpoint_name);
+		arg_buffer.for_each_arg(|arg_bytes| hex_data.push_argument_bytes(arg_bytes));
+		hex_data
 	}
 
 	pub fn as_slice(&self) -> &[u8] {

--- a/elrond-wasm/src/io/contract_call_serialize.rs
+++ b/elrond-wasm/src/io/contract_call_serialize.rs
@@ -1,78 +1,74 @@
-use crate::hex_call_data::*;
+use crate::api::ErrorApi;
+use crate::types::ArgBuffer;
 use crate::*;
-use elrond_codec::*;
+use elrond_codec::{TopEncode, TopEncodeOutput};
 
-pub trait AsyncCallArg: Sized {
-	fn push_async_arg(&self, serializer: &mut HexCallDataSerializer) -> Result<(), SCError>;
-
-	fn push_async_arg_exact(
-		&self,
-		_serializer: &mut HexCallDataSerializer,
-		_expected_len: usize,
-	) -> Result<(), SCError> {
-		Err(SCError::from(&b"not supported"[..]))
+pub fn serialize_contract_call_arg<I, A>(arg: I, arg_buffer: &mut ArgBuffer, error_api: A)
+where
+	I: ContractCallArg,
+	A: ErrorApi,
+{
+	// TODO: convert to fast exit
+	if let Result::Err(sc_err) = arg.push_async_arg(arg_buffer) {
+		error_api.signal_error(sc_err.as_bytes());
 	}
 }
 
-struct AsyncCallArgOutput<'c> {
-	call_data_ser_ref: &'c mut HexCallDataSerializer,
+/// Trait that specifies how arguments are serialized in contract calls.
+///
+/// TODO: unite with DynArg trait when reorganizing argument handling.
+pub trait ContractCallArg: Sized {
+	fn push_async_arg(&self, serializer: &mut ArgBuffer) -> Result<(), SCError>;
 }
 
-impl<'c> AsyncCallArgOutput<'c> {
+/// Local adapter the connects the ArgBuffer to the TopEncode trait.
+struct ContractCallArgOutput<'s> {
+	arg_buffer: &'s mut ArgBuffer,
+}
+
+impl<'c> ContractCallArgOutput<'c> {
 	#[inline]
-	fn new(call_data_ser_ref: &'c mut HexCallDataSerializer) -> Self {
-		AsyncCallArgOutput { call_data_ser_ref }
+	fn new(arg_buffer: &'c mut ArgBuffer) -> Self {
+		ContractCallArgOutput { arg_buffer }
 	}
 }
 
-impl<'c> TopEncodeOutput for AsyncCallArgOutput<'c> {
+impl<'c> TopEncodeOutput for ContractCallArgOutput<'c> {
 	fn set_slice_u8(self, bytes: &[u8]) {
-		self.call_data_ser_ref.push_argument_bytes(bytes);
+		self.arg_buffer.push_argument_bytes(bytes);
 	}
 }
 
-impl<T> AsyncCallArg for T
+impl<T> ContractCallArg for T
 where
 	T: TopEncode,
 {
 	#[inline]
 	#[allow(clippy::redundant_closure)]
-	fn push_async_arg(&self, serializer: &mut HexCallDataSerializer) -> Result<(), SCError> {
-		self.top_encode(AsyncCallArgOutput::new(serializer))
+	fn push_async_arg(&self, serializer: &mut ArgBuffer) -> Result<(), SCError> {
+		self.top_encode(ContractCallArgOutput::new(serializer))
 			.map_err(|err| SCError::from(err))
 	}
 }
 
-impl<T> AsyncCallArg for VarArgs<T>
+impl<T> ContractCallArg for VarArgs<T>
 where
-	T: AsyncCallArg,
+	T: ContractCallArg,
 {
-	fn push_async_arg(&self, serializer: &mut HexCallDataSerializer) -> Result<(), SCError> {
+	fn push_async_arg(&self, serializer: &mut ArgBuffer) -> Result<(), SCError> {
 		for elem in self.0.iter() {
 			elem.push_async_arg(serializer)?;
 		}
 		Ok(())
 	}
-
-	fn push_async_arg_exact(
-		&self,
-		serializer: &mut HexCallDataSerializer,
-		expected_len: usize,
-	) -> Result<(), SCError> {
-		if self.len() != expected_len {
-			return Err(SCError::from(err_msg::ARG_ASYNC_WRONG_NUMBER));
-		}
-		self.push_async_arg(serializer)?;
-		Ok(())
-	}
 }
 
-impl<T> AsyncCallArg for OptionalArg<T>
+impl<T> ContractCallArg for OptionalArg<T>
 where
-	T: AsyncCallArg,
+	T: ContractCallArg,
 {
 	#[inline]
-	fn push_async_arg(&self, serializer: &mut HexCallDataSerializer) -> Result<(), SCError> {
+	fn push_async_arg(&self, serializer: &mut ArgBuffer) -> Result<(), SCError> {
 		if let OptionalArg::Some(t) = self {
 			t.push_async_arg(serializer)?;
 		}
@@ -83,12 +79,12 @@ where
 macro_rules! multi_arg_result_impls {
     ($(($mr:ident $($n:tt $name:ident)+) )+) => {
         $(
-            impl<$($name),+> AsyncCallArg for $mr<$($name,)+>
+            impl<$($name),+> ContractCallArg for $mr<$($name,)+>
             where
-                $($name: AsyncCallArg,)+
+                $($name: ContractCallArg,)+
             {
                 #[inline]
-                fn push_async_arg(&self, serializer: &mut HexCallDataSerializer) -> Result<(), SCError> {
+                fn push_async_arg(&self, serializer: &mut ArgBuffer) -> Result<(), SCError> {
                     $(
                         (self.0).$n.push_async_arg(serializer)?;
                     )+

--- a/elrond-wasm/src/io/contract_call_serialize.rs
+++ b/elrond-wasm/src/io/contract_call_serialize.rs
@@ -1,6 +1,5 @@
 use crate::api::ErrorApi;
-use crate::types::ArgBuffer;
-use crate::*;
+use crate::types::*;
 use elrond_codec::{TopEncode, TopEncodeOutput};
 
 pub fn serialize_contract_call_arg<I, A>(arg: I, arg_buffer: &mut ArgBuffer, error_api: A)

--- a/elrond-wasm/src/io/mod.rs
+++ b/elrond-wasm/src/io/mod.rs
@@ -1,6 +1,6 @@
 pub mod arg_de_input;
 pub mod arg_id;
-pub mod arg_serialize;
+pub mod contract_call_serialize;
 pub mod dyn_arg;
 pub mod dyn_arg_input;
 pub mod dyn_arg_input_cd;
@@ -11,7 +11,7 @@ pub mod signal_error;
 
 pub use arg_de_input::*;
 pub use arg_id::ArgId;
-pub use arg_serialize::*;
+pub use contract_call_serialize::*;
 pub use dyn_arg::*;
 pub use dyn_arg_input::*;
 pub use dyn_arg_input_cd::*;

--- a/elrond-wasm/src/io/signal_error.rs
+++ b/elrond-wasm/src/io/signal_error.rs
@@ -1,7 +1,7 @@
 use super::ArgId;
 use crate::api::ErrorApi;
 use crate::err_msg;
-use crate::BoxedBytes;
+use crate::types::BoxedBytes;
 use elrond_codec::DecodeError;
 
 pub fn signal_arg_de_error<EA: ErrorApi>(api: &EA, arg_id: ArgId, de_err: DecodeError) -> ! {

--- a/elrond-wasm/src/lib.rs
+++ b/elrond-wasm/src/lib.rs
@@ -21,4 +21,3 @@ pub mod types;
 pub use hex_call_data::*;
 pub use io::*;
 pub use storage::{storage_get, storage_set};
-pub use types::*;

--- a/elrond-wasm/src/macros.rs
+++ b/elrond-wasm/src/macros.rs
@@ -22,9 +22,8 @@ macro_rules! imports {
 		use elrond_wasm::non_zero_util::*;
 		use elrond_wasm::storage::mappers::*;
 		use elrond_wasm::types::*;
-		use elrond_wasm::AsyncCallError;
-		use elrond_wasm::{BorrowedMutStorage, Box, BoxedBytes, Queue, VarArgs, Vec};
-		use elrond_wasm::{SCError, SCResult, SCResult::Err, SCResult::Ok};
+		use elrond_wasm::types::{SCResult::Err, SCResult::Ok};
+		use elrond_wasm::{Box, Vec};
 	};
 }
 
@@ -44,7 +43,7 @@ macro_rules! derive_imports {
 #[macro_export]
 macro_rules! sc_error {
 	($s:expr) => {
-		elrond_wasm::SCResult::Err(elrond_wasm::SCError::from($s.as_bytes()))
+		elrond_wasm::types::SCResult::Err(elrond_wasm::types::SCError::from($s.as_bytes()))
 	};
 }
 
@@ -53,9 +52,9 @@ macro_rules! sc_error {
 macro_rules! sc_try {
 	($s:expr) => {
 		match $s {
-			elrond_wasm::SCResult::Ok(t) => t,
-			elrond_wasm::SCResult::Err(e) => {
-				return elrond_wasm::SCResult::Err(e);
+			elrond_wasm::types::SCResult::Ok(t) => t,
+			elrond_wasm::types::SCResult::Err(e) => {
+				return elrond_wasm::types::SCResult::Err(e);
 			},
 		}
 	};
@@ -66,7 +65,8 @@ macro_rules! sc_try {
 /// It can only be used in a function that returns `SCResult<_>` where _ can be any type.
 ///
 /// ```rust
-/// # use elrond_wasm::{*, SCResult::Ok};
+/// # use elrond_wasm::*;
+/// # use elrond_wasm::types::{*, SCResult::Ok};
 /// # pub trait ExampleContract<BigInt, BigUint>: elrond_wasm::api::ContractHookApi<BigInt, BigUint>
 /// # where
 /// # 	BigInt: elrond_wasm::api::BigIntApi<BigUint> + 'static,
@@ -92,7 +92,8 @@ macro_rules! require {
 /// It can only be used in a function that returns `SCResult<_>` where _ can be any type.
 ///
 /// ```rust
-/// # use elrond_wasm::{*, SCResult::Ok};
+/// # use elrond_wasm::*;
+/// # use elrond_wasm::types::{*, SCResult::Ok};
 /// # pub trait ExampleContract<BigInt, BigUint>: elrond_wasm::api::ContractHookApi<BigInt, BigUint>
 /// # where
 /// # 	BigInt: elrond_wasm::api::BigIntApi<BigUint> + 'static,

--- a/elrond-wasm/src/storage/storage_get.rs
+++ b/elrond-wasm/src/storage/storage_get.rs
@@ -1,5 +1,7 @@
 use crate::api::{ErrorApi, StorageReadApi};
-use crate::*;
+use crate::err_msg;
+use crate::types::BoxedBytes;
+use alloc::boxed::Box;
 use elrond_codec::*;
 
 struct StorageGetInput<'k, SRA>

--- a/elrond-wasm/src/types/general/h256.rs
+++ b/elrond-wasm/src/types/general/h256.rs
@@ -1,5 +1,5 @@
 use crate::abi::TypeAbi;
-use crate::BoxedBytes;
+use crate::types::BoxedBytes;
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/elrond-wasm/src/types/general/h256_address.rs
+++ b/elrond-wasm/src/types/general/h256_address.rs
@@ -1,6 +1,6 @@
 use super::h256::H256;
 use crate::abi::TypeAbi;
-use crate::BoxedBytes;
+use crate::types::BoxedBytes;
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/elrond-wasm/src/types/interaction/async_call.rs
+++ b/elrond-wasm/src/types/interaction/async_call.rs
@@ -1,11 +1,8 @@
 use crate::abi::{OutputAbi, TypeAbi, TypeDescriptionContainer};
+use crate::api::{BigUintApi, ErrorApi, SendApi};
 use crate::hex_call_data::HexCallDataSerializer;
 use crate::io::EndpointResult;
-use crate::types::Address;
-use crate::{
-	api::{BigUintApi, ErrorApi, SendApi},
-	CallbackCall,
-};
+use crate::types::{Address, CallbackCall};
 use alloc::string::String;
 use alloc::vec::Vec;
 

--- a/elrond-wasm/src/types/interaction/async_call.rs
+++ b/elrond-wasm/src/types/interaction/async_call.rs
@@ -11,10 +11,10 @@ use alloc::vec::Vec;
 
 #[must_use]
 pub struct AsyncCall<BigUint: BigUintApi> {
-	pub(super) to: Address,
-	pub(super) egld_payment: BigUint,
-	pub(super) hex_data: HexCallDataSerializer,
-	pub(super) callback_data: HexCallDataSerializer,
+	pub(crate) to: Address,
+	pub(crate) egld_payment: BigUint,
+	pub(crate) hex_data: HexCallDataSerializer,
+	pub(crate) callback_data: HexCallDataSerializer,
 }
 
 impl<BigUint: BigUintApi> AsyncCall<BigUint> {

--- a/elrond-wasm/src/types/interaction/callback_call.rs
+++ b/elrond-wasm/src/types/interaction/callback_call.rs
@@ -2,9 +2,9 @@
 
 use crate::api::{BigUintApi, ErrorApi, SendApi, ESDT_TRANSFER_STRING};
 use crate::hex_call_data::HexCallDataSerializer;
-use crate::io::AsyncCallArg;
+use crate::io::ContractCallArg;
 use crate::io::EndpointResult;
-use crate::types::{Address, SCError};
+use crate::types::{Address, ArgBuffer, SCError};
 use crate::{
 	abi::{OutputAbi, TypeAbi, TypeDescriptionContainer},
 	TokenIdentifier,
@@ -13,6 +13,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 pub struct CallbackCall {
+	// TODO: maybe also convert this to the more lightweight ArgBuffer at some point
 	pub closure_data: HexCallDataSerializer,
 }
 
@@ -21,6 +22,13 @@ impl CallbackCall {
 		CallbackCall {
 			closure_data: HexCallDataSerializer::new(callback_name),
 		}
+	}
+
+	pub fn from_arg_buffer(endpoint_name: &[u8], arg_buffer: &ArgBuffer) -> Self {
+		CallbackCall::from_raw(HexCallDataSerializer::from_arg_buffer(
+			endpoint_name,
+			arg_buffer,
+		))
 	}
 
 	pub fn from_raw(closure_data: HexCallDataSerializer) -> Self {

--- a/elrond-wasm/src/types/interaction/callback_call.rs
+++ b/elrond-wasm/src/types/interaction/callback_call.rs
@@ -1,14 +1,11 @@
 #![allow(unused_imports)]
 
+use crate::abi::{OutputAbi, TypeAbi, TypeDescriptionContainer};
 use crate::api::{BigUintApi, ErrorApi, SendApi, ESDT_TRANSFER_STRING};
 use crate::hex_call_data::HexCallDataSerializer;
 use crate::io::ContractCallArg;
 use crate::io::EndpointResult;
-use crate::types::{Address, ArgBuffer, SCError};
-use crate::{
-	abi::{OutputAbi, TypeAbi, TypeDescriptionContainer},
-	TokenIdentifier,
-};
+use crate::types::{Address, ArgBuffer, SCError, TokenIdentifier};
 use alloc::string::String;
 use alloc::vec::Vec;
 

--- a/elrond-wasm/src/types/interaction/contract_call.rs
+++ b/elrond-wasm/src/types/interaction/contract_call.rs
@@ -1,84 +1,115 @@
 use crate::api::{BigUintApi, ESDT_TRANSFER_STRING};
 use crate::hex_call_data::HexCallDataSerializer;
-use crate::io::AsyncCallArg;
-use crate::types::{Address, AsyncCall, SCError};
-use crate::TokenIdentifier;
+use crate::types::{
+	Address, ArgBuffer, AsyncCall, BoxedBytes, TokenIdentifier, TransferEgldExecute,
+	TransferEsdtExecute, TransferExecute,
+};
 
 /// Represents metadata for calling another contract.
 /// Can transform into either an async call, transfer call or other types of calls.
 #[must_use]
 pub struct ContractCall<BigUint: BigUintApi> {
 	to: Address,
-	egld_payment: BigUint,
-	pub hex_data: HexCallDataSerializer, // TODO: make private and find a better way to serialize
+	token: TokenIdentifier,
+	payment: BigUint,
+	endpoint_name: BoxedBytes,
+	pub arg_buffer: ArgBuffer, // TODO: make private and find a better way to serialize
 }
 
 impl<BigUint: BigUintApi> ContractCall<BigUint> {
-	pub fn new_egld(to: Address, egld_payment: BigUint, endpoint_name: &[u8]) -> Self {
-		ContractCall {
-			to,
-			egld_payment,
-			hex_data: HexCallDataSerializer::new(endpoint_name),
-		}
-	}
-
-	pub fn new_esdt(
-		to: Address,
-		esdt_token_name: &[u8],
-		esdt_payment: &BigUint,
-		endpoint_name: &[u8],
-	) -> Self {
-		let mut hex_data = HexCallDataSerializer::new(ESDT_TRANSFER_STRING);
-		hex_data.push_argument_bytes(esdt_token_name);
-		hex_data.push_argument_bytes(esdt_payment.to_bytes_be().as_slice());
-		hex_data.push_argument_bytes(endpoint_name);
-		ContractCall {
-			to,
-			egld_payment: BigUint::zero(),
-			hex_data,
-		}
-	}
-
 	pub fn new(
 		to: Address,
 		token: TokenIdentifier,
 		payment: BigUint,
-		endpoint_name: &[u8],
+		endpoint_name: BoxedBytes,
 	) -> Self {
-		if token.is_egld() {
-			Self::new_egld(to, payment, endpoint_name)
-		} else {
-			Self::new_esdt(to, token.as_slice(), &payment, endpoint_name)
+		ContractCall {
+			to,
+			token,
+			payment,
+			endpoint_name,
+			arg_buffer: ArgBuffer::new(),
 		}
 	}
 
+	pub fn get_mut_arg_buffer(&mut self) -> &mut ArgBuffer {
+		&mut self.arg_buffer
+	}
+
+	/// Provided for cases where we build the contract call by hand.
 	pub fn push_argument_raw_bytes(&mut self, bytes: &[u8]) {
-		self.hex_data.push_argument_bytes(bytes);
+		self.arg_buffer.push_argument_bytes(bytes);
 	}
 
-	pub fn push_callback_argument_raw_bytes(&mut self, bytes: &[u8]) {
-		self.hex_data.push_argument_bytes(bytes);
-	}
+	/// If this is an ESDT call, it converts it to a regular call to ESDTTransfer.
+	/// Async calls require this step, but not `transfer_esdt_execute`.
+	fn convert_to_esdt_transfer_call(self) -> Self {
+		if !self.token.is_egld() {
+			let mut new_arg_buffer = ArgBuffer::new();
+			new_arg_buffer.push_argument_bytes(self.token.as_slice());
+			new_arg_buffer.push_argument_bytes(self.payment.to_bytes_be().as_slice());
+			new_arg_buffer.push_argument_bytes(self.endpoint_name.as_slice());
 
-	pub fn push_argument_or_exit<A: AsyncCallArg, ExitCtx: Clone>(
-		&mut self,
-		arg: A,
-		c: ExitCtx,
-		exit: fn(ExitCtx, SCError) -> !,
-	) {
-		// TODO: propagate fast exit down the serializer
-		// TODO: also expose an EncodingError instead of the SCError
-		if let Err(serialization_err) = arg.push_async_arg(&mut self.hex_data) {
-			exit(c, serialization_err);
+			ContractCall {
+				to: self.to,
+				token: TokenIdentifier::egld(),
+				payment: BigUint::zero(),
+				endpoint_name: BoxedBytes::from(ESDT_TRANSFER_STRING),
+				arg_buffer: new_arg_buffer.concat(self.arg_buffer),
+			}
+		} else {
+			self
 		}
 	}
 
-	pub fn async_call(self) -> AsyncCall<BigUint> {
+	pub fn async_call(mut self) -> AsyncCall<BigUint> {
+		self = self.convert_to_esdt_transfer_call();
 		AsyncCall {
 			to: self.to,
-			egld_payment: self.egld_payment,
-			hex_data: self.hex_data,
+			egld_payment: self.payment,
+			hex_data: HexCallDataSerializer::from_arg_buffer(
+				self.endpoint_name.as_slice(),
+				&self.arg_buffer,
+			),
 			callback_data: HexCallDataSerializer::new(&[]),
+		}
+	}
+
+	/// Produces an EGLD (or no value) transfer-execute call, no callback.
+	/// Will always result in a `transferValueExecute` call.
+	pub fn transfer_egld_execute(self) -> TransferEgldExecute<BigUint> {
+		TransferEgldExecute {
+			to: self.to,
+			egld_payment: self.payment,
+			endpoint_name: self.endpoint_name,
+			arg_buffer: self.arg_buffer,
+			gas_limit: 0,
+		}
+	}
+
+	/// Produces an ESDT transfer-execute call, no callback.
+	/// Will always result in a `transferESDTExecute` call.
+	pub fn transfer_esdt_execute(self) -> TransferEsdtExecute<BigUint> {
+		TransferEsdtExecute {
+			to: self.to,
+			token_name: self.token.into_boxed_bytes(),
+			amount: self.payment,
+			endpoint_name: self.endpoint_name,
+			arg_buffer: self.arg_buffer,
+			gas_limit: 0,
+		}
+	}
+
+	/// Produces a transfer-execute call, no callback.
+	/// Will result in either a `transferValueExecute` or a `transferESDTExecute` call, depending on input.
+	pub fn transfer_execute(self) -> TransferExecute<BigUint> {
+		TransferExecute {
+			to: self.to,
+			token: self.token,
+			amount: self.payment,
+			endpoint_name: self.endpoint_name,
+			arg_buffer: self.arg_buffer,
+			gas_limit: 0,
 		}
 	}
 }

--- a/elrond-wasm/src/types/interaction/contract_proxy.rs
+++ b/elrond-wasm/src/types/interaction/contract_proxy.rs
@@ -9,7 +9,5 @@ where
 {
 	fn new(send_api: SA, address: Address) -> Self;
 
-	fn token_transfer(self, token: TokenIdentifier, amount: BigUint) -> Self;
-
-	fn egld_transfer(self, amount: BigUint) -> Self;
+	fn with_token_transfer(self, token: TokenIdentifier, amount: BigUint) -> Self;
 }

--- a/elrond-wasm/src/types/interaction/contract_proxy.rs
+++ b/elrond-wasm/src/types/interaction/contract_proxy.rs
@@ -1,8 +1,5 @@
-use crate::types::Address;
-use crate::{
-	api::{BigIntApi, BigUintApi, SendApi},
-	TokenIdentifier,
-};
+use crate::api::{BigIntApi, BigUintApi, SendApi};
+use crate::types::{Address, TokenIdentifier};
 
 pub trait ContractProxy<SA, BigInt, BigUint>
 where

--- a/elrond-wasm/src/types/interaction/mod.rs
+++ b/elrond-wasm/src/types/interaction/mod.rs
@@ -1,3 +1,4 @@
+mod arg_buffer;
 mod async_call;
 mod callback_call;
 mod contract_call;
@@ -5,7 +6,11 @@ mod contract_proxy;
 mod send_egld;
 mod send_esdt;
 mod send_token;
+mod transfer_egld_execute;
+mod transfer_esdt_execute;
+mod transfer_execute;
 
+pub use arg_buffer::ArgBuffer;
 pub use async_call::AsyncCall;
 pub use callback_call::CallbackCall;
 pub use contract_call::ContractCall;
@@ -13,3 +18,6 @@ pub use contract_proxy::ContractProxy;
 pub use send_egld::SendEgld;
 pub use send_esdt::SendEsdt;
 pub use send_token::SendToken;
+pub use transfer_egld_execute::TransferEgldExecute;
+pub use transfer_esdt_execute::TransferEsdtExecute;
+pub use transfer_execute::TransferExecute;

--- a/elrond-wasm/src/types/interaction/transfer_egld_execute.rs
+++ b/elrond-wasm/src/types/interaction/transfer_egld_execute.rs
@@ -1,0 +1,54 @@
+use crate::abi::{OutputAbi, TypeAbi, TypeDescriptionContainer};
+use crate::api::{BigUintApi, ErrorApi, SendApi};
+use crate::io::EndpointResult;
+use crate::types::{Address, ArgBuffer, BoxedBytes};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[must_use]
+pub struct TransferEgldExecute<BigUint: BigUintApi> {
+	pub(super) to: Address,
+	pub(super) egld_payment: BigUint,
+	pub(super) endpoint_name: BoxedBytes,
+	pub(super) arg_buffer: ArgBuffer,
+	pub(super) gas_limit: u64,
+}
+
+impl<BigUint> TransferEgldExecute<BigUint>
+where
+	BigUint: BigUintApi + 'static,
+{
+	pub fn with_gas_limit(self, gas_limit: u64) -> Self {
+		TransferEgldExecute { gas_limit, ..self }
+	}
+}
+
+impl<FA, BigUint> EndpointResult<FA> for TransferEgldExecute<BigUint>
+where
+	BigUint: BigUintApi + 'static,
+	FA: SendApi<BigUint> + ErrorApi + Clone + 'static,
+{
+	#[inline]
+	fn finish(&self, api: FA) {
+		api.direct_egld_execute(
+			&self.to,
+			&self.egld_payment,
+			self.gas_limit,
+			self.endpoint_name.as_slice(),
+			&self.arg_buffer,
+		);
+	}
+}
+
+impl<BigUint: BigUintApi> TypeAbi for TransferEgldExecute<BigUint> {
+	fn type_name() -> String {
+		"TransferEgldExecute".into()
+	}
+
+	/// No ABI output.
+	fn output_abis(_: &[&'static str]) -> Vec<OutputAbi> {
+		Vec::new()
+	}
+
+	fn provide_type_descriptions<TDC: TypeDescriptionContainer>(_: &mut TDC) {}
+}

--- a/elrond-wasm/src/types/interaction/transfer_esdt_execute.rs
+++ b/elrond-wasm/src/types/interaction/transfer_esdt_execute.rs
@@ -1,0 +1,56 @@
+use crate::abi::{OutputAbi, TypeAbi, TypeDescriptionContainer};
+use crate::api::{BigUintApi, ErrorApi, SendApi};
+use crate::io::EndpointResult;
+use crate::types::{Address, ArgBuffer, BoxedBytes};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[must_use]
+pub struct TransferEsdtExecute<BigUint: BigUintApi> {
+	pub(super) to: Address,
+	pub(super) token_name: BoxedBytes,
+	pub(super) amount: BigUint,
+	pub(super) endpoint_name: BoxedBytes,
+	pub(super) arg_buffer: ArgBuffer,
+	pub(super) gas_limit: u64,
+}
+
+impl<BigUint> TransferEsdtExecute<BigUint>
+where
+	BigUint: BigUintApi + 'static,
+{
+	pub fn with_gas_limit(self, gas_limit: u64) -> Self {
+		TransferEsdtExecute { gas_limit, ..self }
+	}
+}
+
+impl<FA, BigUint> EndpointResult<FA> for TransferEsdtExecute<BigUint>
+where
+	BigUint: BigUintApi + 'static,
+	FA: SendApi<BigUint> + ErrorApi + Clone + 'static,
+{
+	#[inline]
+	fn finish(&self, api: FA) {
+		api.direct_esdt_execute(
+			&self.to,
+			self.token_name.as_slice(),
+			&self.amount,
+			self.gas_limit,
+			self.endpoint_name.as_slice(),
+			&self.arg_buffer,
+		);
+	}
+}
+
+impl<BigUint: BigUintApi> TypeAbi for TransferEsdtExecute<BigUint> {
+	fn type_name() -> String {
+		"TransferEsdtExecute".into()
+	}
+
+	/// No ABI output.
+	fn output_abis(_: &[&'static str]) -> Vec<OutputAbi> {
+		Vec::new()
+	}
+
+	fn provide_type_descriptions<TDC: TypeDescriptionContainer>(_: &mut TDC) {}
+}

--- a/elrond-wasm/src/types/interaction/transfer_execute.rs
+++ b/elrond-wasm/src/types/interaction/transfer_execute.rs
@@ -1,0 +1,66 @@
+use crate::abi::{OutputAbi, TypeAbi, TypeDescriptionContainer};
+use crate::api::{BigUintApi, ErrorApi, SendApi};
+use crate::io::EndpointResult;
+use crate::types::{Address, ArgBuffer, BoxedBytes, TokenIdentifier};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[must_use]
+pub struct TransferExecute<BigUint: BigUintApi> {
+	pub(super) to: Address,
+	pub(super) token: TokenIdentifier,
+	pub(super) amount: BigUint,
+	pub(super) endpoint_name: BoxedBytes,
+	pub(super) arg_buffer: ArgBuffer,
+	pub(super) gas_limit: u64,
+}
+
+impl<BigUint> TransferExecute<BigUint>
+where
+	BigUint: BigUintApi + 'static,
+{
+	pub fn with_gas_limit(self, gas_limit: u64) -> Self {
+		TransferExecute { gas_limit, ..self }
+	}
+}
+
+impl<FA, BigUint> EndpointResult<FA> for TransferExecute<BigUint>
+where
+	BigUint: BigUintApi + 'static,
+	FA: SendApi<BigUint> + ErrorApi + Clone + 'static,
+{
+	#[inline]
+	fn finish(&self, api: FA) {
+		if self.token.is_egld() {
+			api.direct_egld_execute(
+				&self.to,
+				&self.amount,
+				self.gas_limit,
+				self.endpoint_name.as_slice(),
+				&self.arg_buffer,
+			);
+		} else {
+			api.direct_esdt_execute(
+				&self.to,
+				self.token.as_slice(),
+				&self.amount,
+				self.gas_limit,
+				self.endpoint_name.as_slice(),
+				&self.arg_buffer,
+			);
+		}
+	}
+}
+
+impl<BigUint: BigUintApi> TypeAbi for TransferExecute<BigUint> {
+	fn type_name() -> String {
+		"TransferExecute".into()
+	}
+
+	/// No ABI output.
+	fn output_abis(_: &[&'static str]) -> Vec<OutputAbi> {
+		Vec::new()
+	}
+
+	fn provide_type_descriptions<TDC: TypeDescriptionContainer>(_: &mut TDC) {}
+}

--- a/elrond-wasm/src/types/io/mod.rs
+++ b/elrond-wasm/src/types/io/mod.rs
@@ -1,4 +1,3 @@
-mod arg_buffer;
 mod async_call_result;
 mod multi_args;
 mod multi_result;
@@ -9,7 +8,6 @@ mod sc_error;
 mod sc_result;
 mod var_args;
 
-pub use arg_buffer::ArgBuffer;
 pub use async_call_result::{AsyncCallError, AsyncCallResult};
 pub use multi_args::*;
 pub use multi_result::*;

--- a/elrond-wasm/src/types/mod.rs
+++ b/elrond-wasm/src/types/mod.rs
@@ -3,6 +3,7 @@ mod general;
 mod interaction;
 mod io;
 
+pub use super::{Box, Vec};
 pub use borrowed_mut_storage::BorrowedMutStorage;
 pub use general::*;
 pub use interaction::*;

--- a/elrond-wasm/tests/test_arg_load.rs
+++ b/elrond-wasm/tests/test_arg_load.rs
@@ -1,4 +1,6 @@
-use elrond_wasm::{api::PanickingErrorApi, *};
+use elrond_wasm::api::PanickingErrorApi;
+use elrond_wasm::types::*;
+use elrond_wasm::*;
 
 #[test]
 fn test_simple_args() {


### PR DESCRIPTION
Added support for transfer-execute hooks.
Syntax update, the highlight being:
```
		contract_call!(self, to, VaultProxy) // -> creates a ContractProxy
			.retrieve_funds(token, payment) // -> creates a ContractCall with serialized call data
			.async_call() // -> converts to an AsyncCall object, replace this line to get transfer-execute
			.with_callback(self.callbacks().retrieve_funds_callback()) // -> also add a callback programatically, this saves the closure data
```
Also some minor imports cleanup.