### PR TITLE
async call redesign - finishing touches

### DIFF
--- a/contracts/feature-tests/basic-features/src/lib.rs
+++ b/contracts/feature-tests/basic-features/src/lib.rs
@@ -571,7 +571,7 @@ pub trait BasicFeatures {
 			OptionalArg::None => &[],
 		};
 		self.send()
-			.direct_esdt(to, token_id.as_slice(), amount, data);
+			.direct_esdt_via_transf_exec(to, token_id.as_slice(), amount, data);
 	}
 
 	#[endpoint]
@@ -588,9 +588,9 @@ pub trait BasicFeatures {
 			OptionalArg::None => &[],
 		};
 		self.send()
-			.direct_esdt(to, token_id.as_slice(), amount_first_time, data);
+			.direct_esdt_via_transf_exec(to, token_id.as_slice(), amount_first_time, data);
 		self.send()
-			.direct_esdt(to, token_id.as_slice(), amount_second_time, data);
+			.direct_esdt_via_transf_exec(to, token_id.as_slice(), amount_second_time, data);
 	}
 
 	// BLOCK INFO

--- a/contracts/feature-tests/basic-features/src/lib.rs
+++ b/contracts/feature-tests/basic-features/src/lib.rs
@@ -525,6 +525,16 @@ pub trait BasicFeatures {
 		self.get_caller()
 	}
 
+	#[endpoint(get_shard_of_address)]
+	fn get_shard_of_address_endpoint(&self, address: &Address) -> u32 {
+		self.get_shard_of_address(address)
+	}
+
+	#[endpoint(is_smart_contract)]
+	fn is_smart_contract_endpoint(&self, address: &Address) -> bool {
+		self.is_smart_contract(address)
+	}
+
 	#[endpoint(get_gas_left)]
 	fn get_gas_left_endpoint(&self) -> u64 {
 		self.get_gas_left()

--- a/elrond-wasm-debug/src/api/contract_api_mock.rs
+++ b/elrond-wasm-debug/src/api/contract_api_mock.rs
@@ -34,6 +34,14 @@ impl elrond_wasm::api::ContractHookApi<RustBigInt, RustBigUint> for TxContext {
 			.unwrap_or_else(|| panic!("contract owner address not set"))
 	}
 
+	fn get_shard_of_address(&self, _address: &Address) -> u32 {
+		panic!("get_shard_of_address not implemented")
+	}
+
+	fn is_smart_contract(&self, _address: &Address) -> bool {
+		panic!("is_smart_contract not implemented")
+	}
+
 	fn get_caller(&self) -> Address {
 		self.tx_input_box.from.clone()
 	}

--- a/elrond-wasm-derive/src/snippets.rs
+++ b/elrond-wasm-derive/src/snippets.rs
@@ -90,6 +90,16 @@ pub fn contract_trait_api_impl(contract_struct: &syn::Path) -> proc_macro2::Toke
 			}
 
 			#[inline]
+			fn get_shard_of_address(&self, address: &Address) -> u32 {
+				self.api.get_shard_of_address(address)
+			}
+
+			#[inline]
+			fn is_smart_contract(&self, address: &Address) -> bool {
+				self.api.is_smart_contract(address)
+			}
+
+			#[inline]
 			fn get_caller(&self) -> Address {
 				self.api.get_caller()
 			}

--- a/elrond-wasm-node/src/api/contract_api_node.rs
+++ b/elrond-wasm-node/src/api/contract_api_node.rs
@@ -6,6 +6,8 @@ use elrond_wasm::types::{Address, Box, H256};
 extern "C" {
 	fn getSCAddress(resultOffset: *mut u8);
 	fn getOwnerAddress(resultOffset: *mut u8);
+	fn getShardOfAddress(address_ptr: *const u8) -> i32;
+	fn isSmartContract(address_ptr: *const u8) -> i32;
 
 	/// Currently not used.
 	#[allow(dead_code)]
@@ -74,6 +76,16 @@ impl ContractHookApi<ArwenBigInt, ArwenBigUint> for ArwenApiImpl {
 			getOwnerAddress(res.as_mut_ptr());
 			res
 		}
+	}
+
+	#[inline]
+	fn get_shard_of_address(&self, address: &Address) -> u32 {
+		unsafe { getShardOfAddress(address.as_ref().as_ptr()) as u32 }
+	}
+
+	#[inline]
+	fn is_smart_contract(&self, address: &Address) -> bool {
+		unsafe { isSmartContract(address.as_ref().as_ptr()) > 0 }
 	}
 
 	#[inline]

--- a/elrond-wasm-node/src/api/send_api_node.rs
+++ b/elrond-wasm-node/src/api/send_api_node.rs
@@ -22,16 +22,6 @@ extern "C" {
 		dataOffset: *const u8,
 	) -> i32;
 
-	fn transferESDT(
-		dstOffset: *const u8,
-		tokenIdOffset: *const u8,
-		tokenIdLen: i32,
-		valueOffset: *const u8,
-		gasLimit: i64,
-		dataOffset: *const u8,
-		dataLength: i32,
-	) -> i32;
-
 	fn transferESDTExecute(
 		dstOffset: *const u8,
 		tokenIdOffset: *const u8,
@@ -128,22 +118,6 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 				arg_buffer.num_args() as i32,
 				arg_buffer.arg_lengths_bytes_ptr(),
 				arg_buffer.arg_data_ptr(),
-			);
-		}
-	}
-
-	/// Same as the implementation in the trait, but avoids creating a new ArgBuffer instance.
-	fn direct_esdt(&self, to: &Address, token: &[u8], amount: &ArwenBigUint, data: &[u8]) {
-		unsafe {
-			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
-			let _ = transferESDT(
-				to.as_ref().as_ptr(),
-				token.as_ptr(),
-				token.len() as i32,
-				amount_bytes32_ptr,
-				0i64,
-				data.as_ptr(),
-				data.len() as i32,
 			);
 		}
 	}

--- a/elrond-wasm/src/api/contract_api.rs
+++ b/elrond-wasm/src/api/contract_api.rs
@@ -43,6 +43,10 @@ where
 
 	fn get_owner_address(&self) -> Address;
 
+	fn get_shard_of_address(&self, address: &Address) -> u32;
+
+	fn is_smart_contract(&self, address: &Address) -> bool;
+
 	fn get_caller(&self) -> Address;
 
 	fn get_balance(&self, address: &Address) -> BigUint;

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -27,7 +27,13 @@ where
 	/// Used especially for sending ESDT to regular accounts.
 	///
 	/// Unlike sending ESDT via async call, this method can be called multiple times per transaction.
-	fn direct_esdt_via_transf_exec(&self, to: &Address, token: &[u8], amount: &BigUint, data: &[u8]) {
+	fn direct_esdt_via_transf_exec(
+		&self,
+		to: &Address,
+		token: &[u8],
+		amount: &BigUint,
+		data: &[u8],
+	) {
 		self.direct_esdt_execute(to, token, amount, 0, data, &ArgBuffer::new());
 	}
 

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -27,7 +27,7 @@ where
 	/// Used especially for sending ESDT to regular accounts.
 	///
 	/// Unlike sending ESDT via async call, this method can be called multiple times per transaction.
-	fn direct_esdt(&self, to: &Address, token: &[u8], amount: &BigUint, data: &[u8]) {
+	fn direct_esdt_via_transf_exec(&self, to: &Address, token: &[u8], amount: &BigUint, data: &[u8]) {
 		self.direct_esdt_execute(to, token, amount, 0, data, &ArgBuffer::new());
 	}
 
@@ -48,7 +48,7 @@ where
 		if token.is_egld() {
 			self.direct_egld(to, amount, data);
 		} else {
-			self.direct_esdt(to, token.as_slice(), amount, data);
+			self.direct_esdt_via_transf_exec(to, token.as_slice(), amount, data);
 		}
 	}
 


### PR DESCRIPTION
- is_smart_contract
- get_shard_of_address
- a few more endpoints in the test contracts,
- removed calls to `transferESDT`