### PR TITLE
Ping-pong v2

### DIFF
--- a/contracts/examples/ping-pong-egld/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ping-pong-egld"
-version = "0.0.1"
+version = "0.0.2"
 authors = [ "Bruda Claudiu-Marcel <claudiu725@yahoo.com>",]
 edition = "2018"
 publish = false

--- a/contracts/examples/ping-pong-egld/mandos/ping-pong-call-get-user-addresses.scen.json
+++ b/contracts/examples/ping-pong-egld/mandos/ping-pong-call-get-user-addresses.scen.json
@@ -1,0 +1,31 @@
+{
+    "name": "call get_user_addresses in order to check who registered",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "ping-pong-call-ping-second-user.scen.json"
+        },
+        {
+            "step": "scCall",
+            "tx": {
+                "from": "address:participant1",
+                "to": "address:the_ping_pong_contract",
+                "value": "0",
+                "function": "get_user_addresses",
+                "arguments": [],
+                "gasLimit": "100,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "out": [
+                    "address:participant1",
+                    "address:participant2"
+                ],
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        }
+    ]
+}

--- a/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-after-deadline.scen.json
+++ b/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-after-deadline.scen.json
@@ -18,7 +18,9 @@
                 "to": "address:the_ping_pong_contract",
                 "value": "500,000,000,000",
                 "function": "ping",
-                "arguments": [],
+                "arguments": [
+                    ""
+                ],
                 "gasLimit": "100,000,000",
                 "gasPrice": "0"
             },

--- a/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-before-beginning.scen.json
+++ b/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-before-beginning.scen.json
@@ -18,7 +18,9 @@
                 "to": "address:the_ping_pong_contract",
                 "value": "500,000,000,000",
                 "function": "ping",
-                "arguments": [],
+                "arguments": [
+                    ""
+                ],
                 "gasLimit": "100,000,000",
                 "gasPrice": "0"
             },

--- a/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-second-user.scen.json
+++ b/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-second-user.scen.json
@@ -18,7 +18,9 @@
                 "to": "address:the_ping_pong_contract",
                 "value": "500,000,000,000",
                 "function": "ping",
-                "arguments": [],
+                "arguments": [
+                    ""
+                ],
                 "gasLimit": "100,000,000",
                 "gasPrice": "0"
             },

--- a/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-twice.scen.json
+++ b/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-twice.scen.json
@@ -18,7 +18,9 @@
                 "to": "address:the_ping_pong_contract",
                 "value": "500,000,000,000",
                 "function": "ping",
-                "arguments": [],
+                "arguments": [
+                    ""
+                ],
                 "gasLimit": "100,000,000",
                 "gasPrice": "0"
             },

--- a/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-wrong-ammount.scen.json
+++ b/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping-wrong-ammount.scen.json
@@ -12,7 +12,9 @@
                 "to": "address:the_ping_pong_contract",
                 "value": "450,000,000,000",
                 "function": "ping",
-                "arguments": [],
+                "arguments": [
+                    ""
+                ],
                 "gasLimit": "100,000,000",
                 "gasPrice": "0"
             },

--- a/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping.scen.json
+++ b/contracts/examples/ping-pong-egld/mandos/ping-pong-call-ping.scen.json
@@ -18,7 +18,9 @@
                 "to": "address:the_ping_pong_contract",
                 "value": "500,000,000,000",
                 "function": "ping",
-                "arguments": [],
+                "arguments": [
+                    ""
+                ],
                 "gasLimit": "100,000,000",
                 "gasPrice": "0"
             },

--- a/contracts/examples/ping-pong-egld/src/lib.rs
+++ b/contracts/examples/ping-pong-egld/src/lib.rs
@@ -27,7 +27,7 @@ pub trait PingPong {
 
 	#[payable("EGLD")]
 	#[endpoint]
-	fn ping(&self, #[payment] payment: &BigUint) -> SCResult<()> {
+	fn ping(&self, #[payment] payment: &BigUint, _data: BoxedBytes) -> SCResult<()> {
 		require!(
 			payment == &self.get_fixed_sum(),
 			"the payment must match the fixed sum"
@@ -113,6 +113,11 @@ pub trait PingPong {
 			let _ = self.pong_by_user_id(user_id);
 		}
 		Ok(())
+	}
+
+	#[view]
+	fn get_user_addresses(&self) -> MultiResultVec<Address> {
+		self.user_mapper().get_all_addresses().into()
 	}
 
 	// storage

--- a/contracts/examples/ping-pong-egld/tests/mandos_test.rs
+++ b/contracts/examples/ping-pong-egld/tests/mandos_test.rs
@@ -109,3 +109,13 @@ fn ping_pong_call_pong_all_after_pong() {
 		&contract_map(),
 	);
 }
+
+// view
+
+#[test]
+fn ping_pong_call_get_user_addresses() {
+	parse_execute_mandos(
+		"mandos/ping-pong-call-get-user-addresses.scen.json",
+		&contract_map(),
+	);
+}


### PR DESCRIPTION
- add argument to ping in order to allow a payload (such as an ETH address) to be sent as transaction data; note that this argument is ignored in the smart contract code as it is meant to be viewed externally
- add get_user_addresses, for checking who the registered users are