### PR TITLE
Mandos biguint, nested

### DIFF
--- a/mandos/src/value_interpreter.rs
+++ b/mandos/src/value_interpreter.rs
@@ -11,6 +11,7 @@ const FILE_PREFIX: &str = "file:";
 const KECCAK256_PREFIX: &str = "keccak256:";
 
 const BIGUNT_PREFIX: &str = "biguint:";
+const NESTED_PREFIX: &str = "nested:";
 const U64_PREFIX: &str = "u64:";
 const U32_PREFIX: &str = "u32:";
 const U16_PREFIX: &str = "u16:";
@@ -101,6 +102,10 @@ pub fn interpret_string(s: &str, context: &InterpreterContext) -> Vec<u8> {
 
 fn try_parse_fixed_width(s: &str) -> Option<Vec<u8>> {
 	if let Some(stripped) = s.strip_prefix(BIGUNT_PREFIX) {
+		return Some(parse_biguint(stripped));
+	}
+
+	if let Some(stripped) = s.strip_prefix(NESTED_PREFIX) {
 		return Some(parse_biguint(stripped));
 	}
 


### PR DESCRIPTION
Add mandos "biguint:" type specifier, which can be used when dealing with **nested** BigUint values.
The "biguint:" specifier serializes the number N as an u32, which represents the number of bytes in the binary representation of the value. The u32 is followed by N bytes representing the actual value.
Example usage:
"biguint:1234" (equivalent to "u32:2|1234")
"biguint:0x112233" (equivalent to "u32:3|0x112233")
Add "nested:", which is identical in behavior, but should be used for nested byte arrays (BoxedBytes, Vec<u8>, [u8] etc.)
Example usage:
"nested:0x112233" (equivalent to "u32:3|0x112233")