### PR TITLE
Fix TopDecodeOrDefault for generics, add tests

### DIFF
--- a/elrond-codec-derive/src/top_de_derive.rs
+++ b/elrond-codec-derive/src/top_de_derive.rs
@@ -202,7 +202,7 @@ pub fn top_decode_or_default_impl(ast: &syn::DeriveInput) -> TokenStream {
 		impl #impl_generics elrond_codec::TopDecode for #name #ty_generics #where_clause {
 			fn top_decode<I: elrond_codec::TopDecodeInput>(top_input: I) -> core::result::Result<Self, elrond_codec::DecodeError> {
 				if top_input.byte_len() == 0 {
-					Ok(<#name as elrond_codec::DecodeDefault>::default())
+					Ok(<#name #ty_generics as elrond_codec::DecodeDefault>::default())
 				} else {
 					#top_decode_body
 				}
@@ -214,7 +214,7 @@ pub fn top_decode_or_default_impl(ast: &syn::DeriveInput) -> TokenStream {
 				exit: fn(ExitCtx, elrond_codec::DecodeError) -> !,
 			) -> Self {
 				if top_input.byte_len() == 0 {
-					<#name as elrond_codec::DecodeDefault>::default()
+					<#name #ty_generics as elrond_codec::DecodeDefault>::default()
 				} else {
 					#top_decode_or_exit_body
 				}

--- a/elrond-codec/tests/struct_or_default_generic_derive_test.rs
+++ b/elrond-codec/tests/struct_or_default_generic_derive_test.rs
@@ -1,0 +1,77 @@
+extern crate elrond_codec_derive;
+use elrond_codec::*;
+use elrond_codec_derive::*;
+
+use elrond_codec::test_util::check_top_encode_decode;
+
+#[derive(TopEncodeOrDefault, TopDecodeOrDefault, PartialEq, Clone, Debug)]
+pub struct StructOrDefault<T>
+where
+	T: NestedEncode + NestedDecode + Default + 'static,
+{
+	pub int: u16,
+	pub seq: Vec<u8>,
+	pub another_byte: u8,
+	pub uint_32: T,
+	pub uint_64: u64,
+}
+
+impl<T> elrond_codec::EncodeDefault for StructOrDefault<T>
+where
+	T: NestedEncode + NestedDecode + Default + 'static,
+{
+	fn is_default(&self) -> bool {
+		self.int == 5
+	}
+}
+
+impl<T> elrond_codec::DecodeDefault for StructOrDefault<T>
+where
+	T: NestedEncode + NestedDecode + Default + 'static,
+{
+	fn default() -> Self {
+		StructOrDefault {
+			int: 5,
+			seq: vec![],
+			another_byte: 0,
+			uint_32: T::default(),
+			uint_64: 0,
+		}
+	}
+}
+
+#[test]
+fn struct_default() {
+	let s = StructOrDefault {
+		int: 5,
+		seq: vec![],
+		another_byte: 0,
+		uint_32: 0,
+		uint_64: 0,
+	};
+
+	check_top_encode_decode(s.clone(), &[]);
+}
+
+#[test]
+fn struct_or_default_not_default() {
+	let s = StructOrDefault {
+		int: 0x42,
+		seq: vec![0x1, 0x2, 0x3, 0x4, 0x5],
+		another_byte: 0x6,
+		uint_32: 0x12345,
+		uint_64: 0x123456789,
+	};
+
+	#[rustfmt::skip]
+	let bytes_1 = &[
+		/* int */ 0, 0x42, 
+		/* seq length */ 0, 0, 0, 5, 
+		/* seq contents */ 1, 2, 3, 4, 5,
+		/* another_byte */ 6,
+		/* uint_32 */ 0x00, 0x01, 0x23, 0x45,
+		/* uint_64 */ 0x00, 0x00, 0x00, 0x01, 0x23, 0x45, 0x67, 0x89,
+	];
+
+	check_top_encode_decode(s.clone(), bytes_1);
+}

--- a/elrond-codec/tests/struct_or_default_generic_derive_test.rs
+++ b/elrond-codec/tests/struct_or_default_generic_derive_test.rs
@@ -50,7 +50,7 @@ fn struct_default() {
 		uint_64: 0,
 	};
 
-	check_top_encode_decode(s.clone(), &[]);
+	check_top_encode_decode(s, &[]);
 }
 
 #[test]
@@ -73,5 +73,5 @@ fn struct_or_default_not_default() {
 		/* uint_64 */ 0x00, 0x00, 0x00, 0x01, 0x23, 0x45, 0x67, 0x89,
 	];
 
-	check_top_encode_decode(s.clone(), bytes_1);
+	check_top_encode_decode(s, bytes_1);
 }

--- a/elrond-wasm/src/macros.rs
+++ b/elrond-wasm/src/macros.rs
@@ -34,7 +34,8 @@ macro_rules! derive_imports {
 	() => {
 		use elrond_wasm::elrond_codec;
 		use elrond_wasm::elrond_codec::elrond_codec_derive::{
-			NestedDecode, NestedEncode, TopDecode, TopEncode,
+			NestedDecode, NestedEncode, TopDecode, TopDecodeOrDefault, TopEncode,
+			TopEncodeOrDefault,
 		};
 		use elrond_wasm_derive::TypeAbi;
 	};


### PR DESCRIPTION
- fix deriving from TopEncodeOrDefault when using it for a struct with generic parameters (eg. MyStruct<BigUint>)
- add TopEncodeOrDefault, TopDecodeOrDefault to the derive_imports! macro