### PR TITLE
Simplified ABI tuple and array syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ There are several crates in this repo, this changelog will keep track of all of 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+- Simplified ABI syntax for tuples and fixed-size arrays
 
 ## [elrond-wasm 0.14.2]
 - Fixed contract call/callback logs in mandos-rs

--- a/contracts/feature-tests/abi-tester/abi_test_expected.abi.json
+++ b/contracts/feature-tests/abi-tester/abi_test_expected.abi.json
@@ -47,7 +47,7 @@
                 },
                 {
                     "name": "multi-result-2",
-                    "type": "[u8; 3]"
+                    "type": "array3<u8>"
                 },
                 {
                     "name": "multi-result-3",
@@ -65,7 +65,7 @@
                 },
                 {
                     "name": "multi-too-few-2",
-                    "type": "[u8; 3]"
+                    "type": "array3<u8>"
                 },
                 {
                     "type": "bytes"
@@ -248,7 +248,7 @@
                         "Also, just like above, recursive types need to work even when nested into a tuple."
                     ],
                     "name": "tuple_madness",
-                    "type": "(OnlyShowsUpAsNested02,Option<AbiTestType>)"
+                    "type": "tuple2<OnlyShowsUpAsNested02,Option<AbiTestType>>"
                 }
             ]
         },

--- a/elrond-wasm/src/abi/type_abi.rs
+++ b/elrond-wasm/src/abi/type_abi.rs
@@ -187,14 +187,16 @@ macro_rules! tuple_impls {
                 $($name: TypeAbi,)+
             {
 				fn type_name() -> String {
-					let mut repr = String::from("(");
+					let mut repr = String::from("tuple");
+					repr.push_str(stringify!($len));
+					repr.push_str("<");
 					$(
 						if $n > 0 {
 							repr.push(',');
 						}
 						repr.push_str($name::type_name().as_str());
                     )+
-					repr.push(')');
+					repr.push('>');
 					repr
 				}
 
@@ -232,11 +234,11 @@ macro_rules! array_impls {
         $(
             impl<T: TypeAbi> TypeAbi for [T; $n] {
 				fn type_name() -> String {
-					let mut repr = String::from("[");
-					repr.push_str(T::type_name().as_str());
-					repr.push_str("; ");
+					let mut repr = String::from("array");
 					repr.push_str(stringify!($n));
-					repr.push(']');
+					repr.push_str("<");
+					repr.push_str(T::type_name().as_str());
+					repr.push('>');
 					repr
 				}
 


### PR DESCRIPTION
Syntax like `[Type; 5]` and `(Type1, Type2)` is too difficult to parse and too reminiscent of Rust.
New syntax: `array5<Type>`, `tuple2<Type1, Type2>`.