### PR TITLE
Added return value to send api functions

### DIFF
--- a/contracts/examples/egld-esdt-swap/src/lib.rs
+++ b/contracts/examples/egld-esdt-swap/src/lib.rs
@@ -144,7 +144,7 @@ pub trait EgldEsdtSwap {
 		self.unused_wrapped_egld().set(&unused_wrapped_egld);
 
 		let caller = self.get_caller();
-		self.send().direct_esdt_via_transf_exec(
+		let _ = self.send().direct_esdt_via_transf_exec(
 			&caller,
 			self.wrapped_egld_token_id().get().as_esdt_identifier(),
 			&payment,

--- a/contracts/examples/esdt-nft-marketplace/src/lib.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/lib.rs
@@ -239,7 +239,7 @@ pub trait EsdtNftMarketplace {
 			);
 
 			// send NFT to auction winner
-			self.send().direct_esdt_nft_via_transfer_exec(
+			let _ = self.send().direct_esdt_nft_via_transfer_exec(
 				&auction.current_winner,
 				nft_type.as_esdt_identifier(),
 				nft_nonce,
@@ -248,7 +248,7 @@ pub trait EsdtNftMarketplace {
 			);
 		} else {
 			// return to original owner
-			self.send().direct_esdt_nft_via_transfer_exec(
+			let _ = self.send().direct_esdt_nft_via_transfer_exec(
 				&auction.original_owner,
 				nft_type.as_esdt_identifier(),
 				nft_nonce,
@@ -281,7 +281,7 @@ pub trait EsdtNftMarketplace {
 
 		self.auction_for_token(&nft_type, nft_nonce).clear();
 
-		self.send().direct_esdt_nft_via_transfer_exec(
+		let _ = self.send().direct_esdt_nft_via_transfer_exec(
 			&caller,
 			nft_type.as_esdt_identifier(),
 			nft_nonce,
@@ -415,7 +415,7 @@ pub trait EsdtNftMarketplace {
 			self.send()
 				.direct(to, &token_id, amount, self.data_or_empty_if_sc(to, data));
 		} else {
-			self.send().direct_esdt_nft_via_transfer_exec(
+			let _ = self.send().direct_esdt_nft_via_transfer_exec(
 				to,
 				token_id.as_esdt_identifier(),
 				nonce,

--- a/contracts/feature-tests/async/forwarder-raw/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder-raw/src/lib.rs
@@ -34,8 +34,12 @@ pub trait ForwarderRaw {
 		#[payment_token] token: TokenIdentifier,
 		#[payment] payment: BigUint,
 	) {
-		let _ = self.send()
-			.direct_esdt_via_transf_exec(&to, &token.as_esdt_identifier(), &payment, &[]);
+		let _ = self.send().direct_esdt_via_transf_exec(
+			&to,
+			&token.as_esdt_identifier(),
+			&payment,
+			&[],
+		);
 	}
 
 	fn forward_contract_call(

--- a/contracts/feature-tests/async/forwarder-raw/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder-raw/src/lib.rs
@@ -34,7 +34,7 @@ pub trait ForwarderRaw {
 		#[payment_token] token: TokenIdentifier,
 		#[payment] payment: BigUint,
 	) {
-		self.send()
+		let _ = self.send()
 			.direct_esdt_via_transf_exec(&to, &token.as_esdt_identifier(), &payment, &[]);
 	}
 

--- a/contracts/feature-tests/async/forwarder/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder/src/lib.rs
@@ -38,7 +38,8 @@ pub trait Forwarder {
 			OptionalArg::Some(data) => data.as_slice(),
 			OptionalArg::None => &[],
 		};
-		let _ = self.send()
+		let _ = self
+			.send()
 			.direct_esdt_via_transf_exec(to, token_id.as_slice(), amount, data);
 	}
 

--- a/contracts/feature-tests/async/forwarder/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder/src/lib.rs
@@ -38,7 +38,7 @@ pub trait Forwarder {
 			OptionalArg::Some(data) => data.as_slice(),
 			OptionalArg::None => &[],
 		};
-		self.send()
+		let _ = self.send()
 			.direct_esdt_via_transf_exec(to, token_id.as_slice(), amount, data);
 	}
 
@@ -55,10 +55,18 @@ pub trait Forwarder {
 			OptionalArg::Some(data) => data.as_slice(),
 			OptionalArg::None => &[],
 		};
-		self.send()
-			.direct_esdt_via_transf_exec(to, token_id.as_slice(), amount_first_time, data);
-		self.send()
-			.direct_esdt_via_transf_exec(to, token_id.as_slice(), amount_second_time, data);
+		let _ = self.send().direct_esdt_via_transf_exec(
+			to,
+			token_id.as_slice(),
+			amount_first_time,
+			data,
+		);
+		let _ = self.send().direct_esdt_via_transf_exec(
+			to,
+			token_id.as_slice(),
+			amount_second_time,
+			data,
+		);
 	}
 
 	#[endpoint]

--- a/contracts/feature-tests/esdt-contract-pair/first-contract/src/lib.rs
+++ b/contracts/feature-tests/esdt-contract-pair/first-contract/src/lib.rs
@@ -99,7 +99,7 @@ pub trait FirstContract {
 		require!(esdt_value > 0, "no esdt transfered!");
 		require!(actual_token_name == expected_token_name, "Wrong esdt token");
 
-		self.send().direct_esdt_execute(
+		let _ = self.send().direct_esdt_execute(
 			&second_contract_address,
 			expected_token_name.as_esdt_identifier(),
 			&esdt_value,
@@ -124,7 +124,7 @@ pub trait FirstContract {
 		require!(esdt_value > 0, "no esdt transfered!");
 		require!(actual_token_name == expected_token_name, "Wrong esdt token");
 
-		self.send().direct_esdt_execute(
+		let _ = self.send().direct_esdt_execute(
 			&second_contract_address,
 			expected_token_name.as_esdt_identifier(),
 			&esdt_value,

--- a/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
+++ b/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
@@ -177,7 +177,7 @@ pub trait LocalEsdtAndEsdtNft {
 			arg_buffer.push_argument_bytes(arg.as_slice());
 		}
 
-		self.send().direct_esdt_nft_execute(
+		let _ = self.send().direct_esdt_nft_execute(
 			&to,
 			token_identifier.as_esdt_identifier(),
 			nonce,

--- a/elrond-wasm-debug/src/api/send_api_mock.rs
+++ b/elrond-wasm-debug/src/api/send_api_mock.rs
@@ -50,7 +50,7 @@ impl TxContext {
 }
 
 impl SendApi<RustBigUint> for TxContext {
-	fn direct_egld(&self, to: &Address, amount: &RustBigUint, _data: &[u8]) -> i32 {
+	fn direct_egld(&self, to: &Address, amount: &RustBigUint, _data: &[u8]) {
 		if amount.value() > self.get_available_egld_balance() {
 			std::panic::panic_any(TxPanic {
 				status: 10,
@@ -64,7 +64,6 @@ impl SendApi<RustBigUint> for TxContext {
 			token: TokenIdentifier::egld(),
 			amount: amount.value(),
 		});
-		0
 	}
 
 	fn direct_egld_execute(
@@ -74,7 +73,7 @@ impl SendApi<RustBigUint> for TxContext {
 		_gas_limit: u64,
 		_function: &[u8],
 		_arg_buffer: &ArgBuffer,
-	) -> i32 {
+	) -> Result<(), &'static [u8]> {
 		panic!("direct_egld_execute not yet implemented")
 	}
 
@@ -86,7 +85,7 @@ impl SendApi<RustBigUint> for TxContext {
 		_gas: u64,
 		_function: &[u8],
 		_arg_buffer: &ArgBuffer,
-	) -> i32 {
+	) -> Result<(), &'static [u8]> {
 		if amount.value() > self.get_available_esdt_balance(token) {
 			std::panic::panic_any(TxPanic {
 				status: 10,
@@ -100,7 +99,7 @@ impl SendApi<RustBigUint> for TxContext {
 			token: TokenIdentifier::from(token),
 			amount: amount.value(),
 		});
-		0
+		Ok(())
 	}
 
 	fn direct_esdt_nft_execute(
@@ -112,7 +111,7 @@ impl SendApi<RustBigUint> for TxContext {
 		_gas_limit: u64,
 		_function: &[u8],
 		_arg_buffer: &ArgBuffer,
-	) -> i32 {
+	) -> Result<(), &'static [u8]> {
 		panic!("direct_esdt_nft_execute not implemented yet");
 	}
 

--- a/elrond-wasm-debug/src/api/send_api_mock.rs
+++ b/elrond-wasm-debug/src/api/send_api_mock.rs
@@ -50,7 +50,7 @@ impl TxContext {
 }
 
 impl SendApi<RustBigUint> for TxContext {
-	fn direct_egld(&self, to: &Address, amount: &RustBigUint, _data: &[u8]) {
+	fn direct_egld(&self, to: &Address, amount: &RustBigUint, _data: &[u8]) -> i32 {
 		if amount.value() > self.get_available_egld_balance() {
 			std::panic::panic_any(TxPanic {
 				status: 10,
@@ -63,7 +63,8 @@ impl SendApi<RustBigUint> for TxContext {
 			recipient: to.clone(),
 			token: TokenIdentifier::egld(),
 			amount: amount.value(),
-		})
+		});
+		0
 	}
 
 	fn direct_egld_execute(
@@ -73,7 +74,7 @@ impl SendApi<RustBigUint> for TxContext {
 		_gas_limit: u64,
 		_function: &[u8],
 		_arg_buffer: &ArgBuffer,
-	) {
+	) -> i32 {
 		panic!("direct_egld_execute not yet implemented")
 	}
 
@@ -85,7 +86,7 @@ impl SendApi<RustBigUint> for TxContext {
 		_gas: u64,
 		_function: &[u8],
 		_arg_buffer: &ArgBuffer,
-	) {
+	) -> i32 {
 		if amount.value() > self.get_available_esdt_balance(token) {
 			std::panic::panic_any(TxPanic {
 				status: 10,
@@ -98,7 +99,8 @@ impl SendApi<RustBigUint> for TxContext {
 			recipient: to.clone(),
 			token: TokenIdentifier::from(token),
 			amount: amount.value(),
-		})
+		});
+		0
 	}
 
 	fn direct_esdt_nft_execute(
@@ -110,7 +112,7 @@ impl SendApi<RustBigUint> for TxContext {
 		_gas_limit: u64,
 		_function: &[u8],
 		_arg_buffer: &ArgBuffer,
-	) {
+	) -> i32 {
 		panic!("direct_esdt_nft_execute not implemented yet");
 	}
 

--- a/elrond-wasm-node/src/api/call_value_api_node.rs
+++ b/elrond-wasm-node/src/api/call_value_api_node.rs
@@ -62,8 +62,6 @@ impl CallValueApi<ArwenBigUint> for ArwenApiImpl {
 	}
 
 	fn esdt_token_type(&self) -> EsdtTokenType {
-		unsafe {
-			(getESDTTokenType() as u8).into()
-		}
+		unsafe { (getESDTTokenType() as u8).into() }
 	}
 }

--- a/elrond-wasm-node/src/api/send_api_node.rs
+++ b/elrond-wasm-node/src/api/send_api_node.rs
@@ -108,15 +108,20 @@ extern "C" {
 }
 
 impl SendApi<ArwenBigUint> for ArwenApiImpl {
-	fn direct_egld(&self, to: &Address, amount: &ArwenBigUint, data: &[u8]) ->i32 {
+	fn direct_egld(
+		&self,
+		to: &Address,
+		amount: &ArwenBigUint,
+		data: &[u8],
+	) {
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
-			transferValue(
+			let _ = transferValue(
 				to.as_ref().as_ptr(),
 				amount_bytes32_ptr,
 				data.as_ptr(),
 				data.len() as i32,
-			)
+			);
 		}
 	}
 
@@ -127,10 +132,10 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	) -> i32 {
+	) -> Result<(), &'static [u8]> {
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
-			transferValueExecute(
+			let result = transferValueExecute(
 				to.as_ref().as_ptr(),
 				amount_bytes32_ptr,
 				gas_limit as i64,
@@ -139,7 +144,12 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 				arg_buffer.num_args() as i32,
 				arg_buffer.arg_lengths_bytes_ptr(),
 				arg_buffer.arg_data_ptr(),
-			)
+			);
+			if result == 0 {
+				Ok(())
+			} else {
+				Err(b"transferValueExecute failed")
+			}
 		}
 	}
 
@@ -151,10 +161,10 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	) -> i32 {
+	) -> Result<(), &'static [u8]> {
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
-			transferESDTExecute(
+			let result = transferESDTExecute(
 				to.as_ref().as_ptr(),
 				token.as_ptr(),
 				token.len() as i32,
@@ -165,7 +175,12 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 				arg_buffer.num_args() as i32,
 				arg_buffer.arg_lengths_bytes_ptr(),
 				arg_buffer.arg_data_ptr(),
-			)
+			);
+			if result == 0 {
+				Ok(())
+			} else {
+				Err(b"transferESDTExecute failed")
+			}
 		}
 	}
 
@@ -178,10 +193,10 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	) -> i32 {
+	) -> Result<(), &'static [u8]> {
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
-			transferESDTNFTExecute(
+			let result = transferESDTNFTExecute(
 				to.as_ref().as_ptr(),
 				token.as_ptr(),
 				token.len() as i32,
@@ -193,7 +208,12 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 				arg_buffer.num_args() as i32,
 				arg_buffer.arg_lengths_bytes_ptr(),
 				arg_buffer.arg_data_ptr(),
-			)
+			);
+			if result == 0 {
+				Ok(())
+			} else {
+				Err(b"transferESDTNFTExecute failed")
+			}
 		}
 	}
 

--- a/elrond-wasm-node/src/api/send_api_node.rs
+++ b/elrond-wasm-node/src/api/send_api_node.rs
@@ -108,15 +108,15 @@ extern "C" {
 }
 
 impl SendApi<ArwenBigUint> for ArwenApiImpl {
-	fn direct_egld(&self, to: &Address, amount: &ArwenBigUint, data: &[u8]) {
+	fn direct_egld(&self, to: &Address, amount: &ArwenBigUint, data: &[u8]) ->i32 {
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
-			let _ = transferValue(
+			transferValue(
 				to.as_ref().as_ptr(),
 				amount_bytes32_ptr,
 				data.as_ptr(),
 				data.len() as i32,
-			);
+			)
 		}
 	}
 
@@ -127,10 +127,10 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	) {
+	) -> i32 {
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
-			let _ = transferValueExecute(
+			transferValueExecute(
 				to.as_ref().as_ptr(),
 				amount_bytes32_ptr,
 				gas_limit as i64,
@@ -139,7 +139,7 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 				arg_buffer.num_args() as i32,
 				arg_buffer.arg_lengths_bytes_ptr(),
 				arg_buffer.arg_data_ptr(),
-			);
+			)
 		}
 	}
 
@@ -151,10 +151,10 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	) {
+	) -> i32 {
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
-			let _ = transferESDTExecute(
+			transferESDTExecute(
 				to.as_ref().as_ptr(),
 				token.as_ptr(),
 				token.len() as i32,
@@ -165,7 +165,7 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 				arg_buffer.num_args() as i32,
 				arg_buffer.arg_lengths_bytes_ptr(),
 				arg_buffer.arg_data_ptr(),
-			);
+			)
 		}
 	}
 
@@ -178,10 +178,10 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	) {
+	) -> i32 {
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
-			let _ = transferESDTNFTExecute(
+			transferESDTNFTExecute(
 				to.as_ref().as_ptr(),
 				token.as_ptr(),
 				token.len() as i32,
@@ -193,7 +193,7 @@ impl SendApi<ArwenBigUint> for ArwenApiImpl {
 				arg_buffer.num_args() as i32,
 				arg_buffer.arg_lengths_bytes_ptr(),
 				arg_buffer.arg_data_ptr(),
-			);
+			)
 		}
 	}
 

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -17,7 +17,7 @@ where
 {
 	/// Sends EGLD to a given address, directly.
 	/// Used especially for sending EGLD to regular accounts.
-	fn direct_egld(&self, to: &Address, amount: &BigUint, data: &[u8]) -> i32;
+	fn direct_egld(&self, to: &Address, amount: &BigUint, data: &[u8]);
 
 	/// Sends EGLD to an address (optionally) and executes like an async call, but without callback.
 	fn direct_egld_execute(
@@ -27,7 +27,7 @@ where
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	) -> i32;
+	) -> Result<(), &'static [u8]>;
 
 	/// Sends an ESDT token to a given address, directly.
 	/// Used especially for sending ESDT to regular accounts.
@@ -39,7 +39,7 @@ where
 		token: &[u8],
 		amount: &BigUint,
 		data: &[u8],
-	) -> i32 {
+	) -> Result<(), &'static [u8]> {
 		self.direct_esdt_execute(to, token, amount, 0, data, &ArgBuffer::new())
 	}
 
@@ -52,7 +52,7 @@ where
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	) -> i32;
+	) -> Result<(), &'static [u8]>;
 
 	/// Sends ESDT NFT to an address and executes like an async call, but without callback.
 	fn direct_esdt_nft_execute(
@@ -64,15 +64,21 @@ where
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	) -> i32;
+	) -> Result<(), &'static [u8]>;
 
 	/// Sends either EGLD or an ESDT token to the target address,
 	/// depending on what token identifier was specified.
-	fn direct(&self, to: &Address, token: &TokenIdentifier, amount: &BigUint, data: &[u8]) -> i32 {
+	fn direct(
+		&self,
+		to: &Address,
+		token: &TokenIdentifier,
+		amount: &BigUint,
+		data: &[u8],
+	) {
 		if token.is_egld() {
-			self.direct_egld(to, amount, data)
+			self.direct_egld(to, amount, data);
 		} else {
-			self.direct_esdt_via_transf_exec(to, token.as_esdt_identifier(), amount, data)
+			let _ = self.direct_esdt_via_transf_exec(to, token.as_esdt_identifier(), amount, data);
 		}
 	}
 
@@ -105,7 +111,7 @@ where
 		data: &[u8],
 	) {
 		if token.is_egld() {
-			self.direct_egld(to, amount, data);
+			let _ = self.direct_egld(to, amount, data);
 		} else {
 			self.direct_esdt_via_async_call(to, token.as_esdt_identifier(), amount, data);
 		}
@@ -291,7 +297,7 @@ where
 		nonce: u64,
 		amount: &BigUint,
 		data: &[u8],
-	) {
-		self.direct_esdt_nft_execute(to, token, nonce, amount, 0, data, &ArgBuffer::new());
+	) -> Result<(), &'static [u8]> {
+		self.direct_esdt_nft_execute(to, token, nonce, amount, 0, data, &ArgBuffer::new())
 	}
 }

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -68,13 +68,7 @@ where
 
 	/// Sends either EGLD or an ESDT token to the target address,
 	/// depending on what token identifier was specified.
-	fn direct(
-		&self,
-		to: &Address,
-		token: &TokenIdentifier,
-		amount: &BigUint,
-		data: &[u8],
-	) {
+	fn direct(&self, to: &Address, token: &TokenIdentifier, amount: &BigUint, data: &[u8]) {
 		if token.is_egld() {
 			self.direct_egld(to, amount, data);
 		} else {

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -17,7 +17,7 @@ where
 {
 	/// Sends EGLD to a given address, directly.
 	/// Used especially for sending EGLD to regular accounts.
-	fn direct_egld(&self, to: &Address, amount: &BigUint, data: &[u8]);
+	fn direct_egld(&self, to: &Address, amount: &BigUint, data: &[u8]) -> i32;
 
 	/// Sends EGLD to an address (optionally) and executes like an async call, but without callback.
 	fn direct_egld_execute(
@@ -27,7 +27,7 @@ where
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	);
+	) -> i32;
 
 	/// Sends an ESDT token to a given address, directly.
 	/// Used especially for sending ESDT to regular accounts.
@@ -39,8 +39,8 @@ where
 		token: &[u8],
 		amount: &BigUint,
 		data: &[u8],
-	) {
-		self.direct_esdt_execute(to, token, amount, 0, data, &ArgBuffer::new());
+	) -> i32 {
+		self.direct_esdt_execute(to, token, amount, 0, data, &ArgBuffer::new())
 	}
 
 	/// Sends ESDT to an address and executes like an async call, but without callback.
@@ -52,7 +52,7 @@ where
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	);
+	) -> i32;
 
 	/// Sends ESDT NFT to an address and executes like an async call, but without callback.
 	fn direct_esdt_nft_execute(
@@ -64,15 +64,15 @@ where
 		gas_limit: u64,
 		function: &[u8],
 		arg_buffer: &ArgBuffer,
-	);
+	) -> i32;
 
 	/// Sends either EGLD or an ESDT token to the target address,
 	/// depending on what token identifier was specified.
-	fn direct(&self, to: &Address, token: &TokenIdentifier, amount: &BigUint, data: &[u8]) {
+	fn direct(&self, to: &Address, token: &TokenIdentifier, amount: &BigUint, data: &[u8]) -> i32 {
 		if token.is_egld() {
-			self.direct_egld(to, amount, data);
+			self.direct_egld(to, amount, data)
 		} else {
-			self.direct_esdt_via_transf_exec(to, token.as_esdt_identifier(), amount, data);
+			self.direct_esdt_via_transf_exec(to, token.as_esdt_identifier(), amount, data)
 		}
 	}
 

--- a/elrond-wasm/src/types/interaction/transfer_egld_execute.rs
+++ b/elrond-wasm/src/types/interaction/transfer_egld_execute.rs
@@ -30,13 +30,16 @@ where
 {
 	#[inline]
 	fn finish(&self, api: FA) {
-		api.direct_egld_execute(
+		let result = api.direct_egld_execute(
 			&self.to,
 			&self.egld_payment,
 			self.gas_limit,
 			self.endpoint_name.as_slice(),
 			&self.arg_buffer,
 		);
+		if let Err(e) = result {
+			api.signal_error(e);
+		}
 	}
 }
 

--- a/elrond-wasm/src/types/interaction/transfer_esdt_execute.rs
+++ b/elrond-wasm/src/types/interaction/transfer_esdt_execute.rs
@@ -31,7 +31,7 @@ where
 {
 	#[inline]
 	fn finish(&self, api: FA) {
-		api.direct_esdt_execute(
+		let result = api.direct_esdt_execute(
 			&self.to,
 			self.token_name.as_slice(),
 			&self.amount,
@@ -39,6 +39,9 @@ where
 			self.endpoint_name.as_slice(),
 			&self.arg_buffer,
 		);
+		if let Err(e) = result {
+			api.signal_error(e);
+		}
 	}
 }
 

--- a/elrond-wasm/src/types/interaction/transfer_execute.rs
+++ b/elrond-wasm/src/types/interaction/transfer_execute.rs
@@ -31,14 +31,14 @@ where
 {
 	#[inline]
 	fn finish(&self, api: FA) {
-		if self.token.is_egld() {
+		let result = if self.token.is_egld() {
 			api.direct_egld_execute(
 				&self.to,
 				&self.amount,
 				self.gas_limit,
 				self.endpoint_name.as_slice(),
 				&self.arg_buffer,
-			);
+			)
 		} else {
 			api.direct_esdt_execute(
 				&self.to,
@@ -47,7 +47,10 @@ where
 				self.gas_limit,
 				self.endpoint_name.as_slice(),
 				&self.arg_buffer,
-			);
+			)
+		};
+		if let Err(e) = result {
+			api.signal_error(e);
 		}
 	}
 }


### PR DESCRIPTION
It has been made a change in Arwen such that when a smart contract A calls direct esdt execute with function call to smart contract B and that function returns sc_error, the execution will continue in A. So return values from send api functions will be needed to check if the function call returned with success or not. Return value of 0 indicates success and != 0 indicates failure. Tested on DEX smart contracts.