### PR TITLE
api - split off blockchain and crypto api

### DIFF
--- a/contracts/examples/crowdfunding-esdt/src/lib.rs
+++ b/contracts/examples/crowdfunding-esdt/src/lib.rs
@@ -15,7 +15,7 @@ pub enum Status {
 pub trait Crowdfunding {
 	#[init]
 	fn init(&self, target: BigUint, deadline: u64, esdt_token_name: TokenIdentifier) {
-		let my_address: Address = self.get_caller();
+		let my_address: Address = self.blockchain().get_caller();
 		self.set_owner(&my_address);
 		self.set_target(&target);
 		self.set_deadline(deadline);
@@ -29,13 +29,13 @@ pub trait Crowdfunding {
 		#[payment] payment: BigUint,
 		#[payment_token] token: TokenIdentifier,
 	) -> SCResult<()> {
-		if self.get_block_nonce() > self.get_deadline() {
+		if self.blockchain().get_block_nonce() > self.get_deadline() {
 			return sc_error!("cannot fund after deadline");
 		}
 
 		require!(token == self.get_cf_esdt_token_name(), "wrong esdt token");
 
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		let mut deposit = self.get_deposit(&caller);
 		let mut balance = self.get_esdt_balance_storage();
 
@@ -50,7 +50,7 @@ pub trait Crowdfunding {
 
 	#[view]
 	fn status(&self) -> Status {
-		if self.get_block_nonce() <= self.get_deadline() {
+		if self.blockchain().get_block_nonce() <= self.get_deadline() {
 			Status::FundingPeriod
 		} else if self.get_esdt_balance_storage() >= self.get_target() {
 			Status::Successful
@@ -69,7 +69,7 @@ pub trait Crowdfunding {
 		match self.status() {
 			Status::FundingPeriod => sc_error!("cannot claim before deadline"),
 			Status::Successful => {
-				let caller = self.get_caller();
+				let caller = self.blockchain().get_caller();
 				if caller != self.get_owner() {
 					return sc_error!("only owner can claim successful funding");
 				}
@@ -84,7 +84,7 @@ pub trait Crowdfunding {
 				Ok(())
 			},
 			Status::Failed => {
-				let caller = self.get_caller();
+				let caller = self.blockchain().get_caller();
 				let deposit = self.get_deposit(&caller);
 
 				if deposit > 0 {

--- a/contracts/examples/crypto-bubbles/src/lib.rs
+++ b/contracts/examples/crypto-bubbles/src/lib.rs
@@ -10,7 +10,7 @@ pub trait CryptoBubbles {
 	/// is called immediately after the contract is created
 	#[init]
 	fn init(&self) {
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		self.set_owner(&caller);
 	}
 
@@ -18,7 +18,7 @@ pub trait CryptoBubbles {
 	#[payable("EGLD")]
 	#[endpoint(topUp)]
 	fn top_up(&self, #[payment] payment: BigUint) {
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		let mut balance = self.get_player_balance(&caller);
 		balance += &payment;
@@ -30,7 +30,7 @@ pub trait CryptoBubbles {
 	/// player withdraws funds
 	#[endpoint]
 	fn withdraw(&self, amount: &BigUint) -> SCResult<()> {
-		self._transfer_back_to_player_wallet(&self.get_caller(), amount)
+		self._transfer_back_to_player_wallet(&self.blockchain().get_caller(), amount)
 	}
 
 	/// server calls withdraw on behalf of the player
@@ -75,7 +75,7 @@ pub trait CryptoBubbles {
 	#[payable("EGLD")]
 	#[endpoint(joinGame)]
 	fn join_game(&self, game_index: BigUint, #[payment] bet: BigUint) -> SCResult<()> {
-		let player = self.get_caller();
+		let player = self.blockchain().get_caller();
 		self.top_up(self.call_value().egld_value());
 		self._add_player_to_game_state_change(&game_index, &player, &bet)
 	}
@@ -88,7 +88,7 @@ pub trait CryptoBubbles {
 		winner: &Address,
 		prize: &BigUint,
 	) -> SCResult<()> {
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		let owner: Address = self.get_owner();
 		require!(
 			caller == owner,

--- a/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
@@ -109,7 +109,7 @@ pub trait KittyAuction {
 		ending_price: BigUint,
 		duration: u64,
 	) -> SCResult<OptionalResult<AsyncCall<BigUint>>> {
-		let deadline = self.get_block_timestamp() + duration;
+		let deadline = self.blockchain().get_block_timestamp() + duration;
 
 		require!(
 			!self.is_up_for_auction(kitty_id),
@@ -121,7 +121,7 @@ pub trait KittyAuction {
 			"starting price must be less than ending price!"
 		);
 		require!(
-			deadline > self.get_block_timestamp(),
+			deadline > self.blockchain().get_block_timestamp(),
 			"deadline can't be in the past!"
 		);
 
@@ -142,7 +142,7 @@ pub trait KittyAuction {
 		ending_price: BigUint,
 		duration: u64,
 	) -> SCResult<OptionalResult<AsyncCall<BigUint>>> {
-		let deadline = self.get_block_timestamp() + duration;
+		let deadline = self.blockchain().get_block_timestamp() + duration;
 
 		require!(
 			!self.is_up_for_auction(kitty_id),
@@ -154,7 +154,7 @@ pub trait KittyAuction {
 			"starting price must be less than ending price!"
 		);
 		require!(
-			deadline > self.get_block_timestamp(),
+			deadline > self.blockchain().get_block_timestamp(),
 			"deadline can't be in the past!"
 		);
 
@@ -175,7 +175,7 @@ pub trait KittyAuction {
 			"Kitty is not up for auction!"
 		);
 
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		let mut auction = self.get_auction(kitty_id);
 
 		require!(
@@ -183,7 +183,7 @@ pub trait KittyAuction {
 			"can't bid on your own kitty!"
 		);
 		require!(
-			self.get_block_timestamp() < auction.deadline,
+			self.blockchain().get_block_timestamp() < auction.deadline,
 			"auction ended already!"
 		);
 		require!(
@@ -223,7 +223,7 @@ pub trait KittyAuction {
 		let auction = self.get_auction(kitty_id);
 
 		require!(
-			self.get_block_timestamp() > auction.deadline
+			self.blockchain().get_block_timestamp() > auction.deadline
 				|| auction.current_bid == auction.ending_price,
 			"auction has not ended yet!"
 		);
@@ -253,7 +253,7 @@ pub trait KittyAuction {
 		ending_price: BigUint,
 		deadline: u64,
 	) -> OptionalResult<AsyncCall<BigUint>> {
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		let kitty_ownership_contract_address =
 			self._get_kitty_ownership_contract_address_or_default();
@@ -280,14 +280,14 @@ pub trait KittyAuction {
 		let starting_price = self.get_gen_zero_kitty_starting_price();
 		let ending_price = self.get_gen_zero_kitty_ending_price();
 		let duration = self.get_gen_zero_kitty_auction_duration();
-		let deadline = self.get_block_timestamp() + duration;
+		let deadline = self.blockchain().get_block_timestamp() + duration;
 
 		let auction = Auction::new(
 			AuctionType::Selling,
 			&starting_price,
 			&ending_price,
 			deadline,
-			&self.get_sc_address(),
+			&self.blockchain().get_sc_address(),
 		);
 
 		self.set_auction(kitty_id, &auction);
@@ -378,7 +378,7 @@ pub trait KittyAuction {
 				// send winning bid money to kitty owner
 				// condition needed for gen zero kitties, since this sc is their owner
 				// and for when no bid was made
-				if auction.kitty_owner != self.get_sc_address()
+				if auction.kitty_owner != self.blockchain().get_sc_address()
 					&& auction.current_winner != Address::zero()
 				{
 					self.send().direct_egld(

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/src/lib.rs
@@ -14,7 +14,10 @@ pub trait KittyGeneticAlg {
 
 	#[endpoint(generateKittyGenes)]
 	fn generate_kitty_genes(&self, matron: Kitty, sire: Kitty) -> SCResult<KittyGenes> {
-		let mut random = Random::new(*self.get_block_random_seed(), self.get_tx_hash().as_bytes());
+		let mut random = Random::new(
+			*self.blockchain().get_block_random_seed(),
+			self.blockchain().get_tx_hash().as_bytes(),
+		);
 
 		let fur_color_percentage = 1 + random.next_u8() % 99; // val in [1, 100)
 		let matron_fur_color = matron.get_fur_color();

--- a/contracts/examples/egld-esdt-swap/src/lib.rs
+++ b/contracts/examples/egld-esdt-swap/src/lib.rs
@@ -31,7 +31,7 @@ pub trait EgldEsdtSwap {
 			"wrapped egld was already issued"
 		);
 
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		self.issue_started_event(&caller, token_ticker.as_slice(), &initial_supply);
 
@@ -96,7 +96,7 @@ pub trait EgldEsdtSwap {
 
 		let wrapped_egld_token_id = self.wrapped_egld_token_id().get();
 		let esdt_token_id = wrapped_egld_token_id.as_esdt_identifier();
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		self.mint_started_event(&caller, &amount);
 
 		Ok(ESDTSystemSmartContractProxy::new()
@@ -143,7 +143,7 @@ pub trait EgldEsdtSwap {
 		unused_wrapped_egld -= &payment;
 		self.unused_wrapped_egld().set(&unused_wrapped_egld);
 
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		self.send().direct_esdt_via_transf_exec(
 			&caller,
 			self.wrapped_egld_token_id().get().as_esdt_identifier(),
@@ -179,7 +179,7 @@ pub trait EgldEsdtSwap {
 		require!(wrapped_egld_payment > 0, "Must pay more than 0 tokens!");
 		// this should never happen, but we'll check anyway
 		require!(
-			wrapped_egld_payment <= self.get_sc_balance(),
+			wrapped_egld_payment <= self.blockchain().get_sc_balance(),
 			"Contract does not have enough funds"
 		);
 
@@ -187,7 +187,7 @@ pub trait EgldEsdtSwap {
 			.update(|unused_wrapped_egld| *unused_wrapped_egld += &wrapped_egld_payment);
 
 		// 1 wrapped EGLD = 1 EGLD, so we pay back the same amount
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		self.send()
 			.direct_egld(&caller, &wrapped_egld_payment, b"unwrapping");
 
@@ -198,7 +198,7 @@ pub trait EgldEsdtSwap {
 
 	#[view(getLockedEgldBalance)]
 	fn get_locked_egld_balance(&self) -> BigUint {
-		self.get_sc_balance()
+		self.blockchain().get_sc_balance()
 	}
 
 	// storage

--- a/contracts/examples/erc1155-marketplace/src/lib.rs
+++ b/contracts/examples/erc1155-marketplace/src/lib.rs
@@ -62,7 +62,7 @@ pub trait Erc1155Marketplace {
 		args: AuctionArgument<BigUint>,
 	) -> SCResult<()> {
 		require!(
-			self.get_caller() == self.token_ownership_contract_address().get(),
+			self.blockchain().get_caller() == self.token_ownership_contract_address().get(),
 			"Only the token ownership contract may call this function"
 		);
 
@@ -91,7 +91,7 @@ pub trait Erc1155Marketplace {
 		args: AuctionArgument<BigUint>,
 	) -> SCResult<()> {
 		require!(
-			self.get_caller() == self.token_ownership_contract_address().get(),
+			self.blockchain().get_caller() == self.token_ownership_contract_address().get(),
 			"Only the token ownership contract may call this function"
 		);
 		require!(
@@ -122,7 +122,7 @@ pub trait Erc1155Marketplace {
 	fn claim(&self) -> SCResult<()> {
 		only_owner!(self, "Only owner may call this function!");
 
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		let data = self.data_or_empty_if_sc(&caller, b"claim");
 
 		let claimable_funds_mapper = self.get_claimable_funds_mapper();
@@ -154,7 +154,7 @@ pub trait Erc1155Marketplace {
 		only_owner!(self, "Only owner may call this function!");
 		require!(!new_address.is_zero(), "Cannot set to zero address");
 		require!(
-			self.is_smart_contract(&new_address),
+			self.blockchain().is_smart_contract(&new_address),
 			"The provided address is not a smart contract"
 		);
 
@@ -179,7 +179,7 @@ pub trait Erc1155Marketplace {
 			"Token is not up for auction"
 		);
 
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		let mut auction = self.auction_for_token(&type_id, &nft_id).get();
 
 		require!(
@@ -187,7 +187,7 @@ pub trait Erc1155Marketplace {
 			"Can't bid on your own token"
 		);
 		require!(
-			self.get_block_timestamp() < auction.deadline,
+			self.blockchain().get_block_timestamp() < auction.deadline,
 			"Auction ended already"
 		);
 		require!(
@@ -237,7 +237,8 @@ pub trait Erc1155Marketplace {
 		let auction = self.auction_for_token(&type_id, &nft_id).get();
 
 		require!(
-			self.get_block_timestamp() > auction.deadline || auction.current_bid == auction.max_bid,
+			self.blockchain().get_block_timestamp() > auction.deadline
+				|| auction.current_bid == auction.max_bid,
 			"Auction deadline has not passed nor is the current bid equal to max bid"
 		);
 
@@ -328,7 +329,7 @@ pub trait Erc1155Marketplace {
 			"Min bid can't be 0 or higher than max bid"
 		);
 		require!(
-			deadline > self.get_block_timestamp(),
+			deadline > self.blockchain().get_block_timestamp(),
 			"Deadline can't be in the past"
 		);
 
@@ -351,7 +352,7 @@ pub trait Erc1155Marketplace {
 		nft_id: BigUint,
 		to: Address,
 	) -> AsyncCall<BigUint> {
-		let sc_own_address = self.get_sc_address();
+		let sc_own_address = self.blockchain().get_sc_address();
 		let token_ownership_contract_address = self.token_ownership_contract_address().get();
 
 		contract_call!(
@@ -380,7 +381,7 @@ pub trait Erc1155Marketplace {
 	}
 
 	fn data_or_empty_if_sc(&self, dest: &Address, data: &'static [u8]) -> &[u8] {
-		if self.is_smart_contract(dest) {
+		if self.blockchain().is_smart_contract(dest) {
 			&[]
 		} else {
 			data

--- a/contracts/examples/erc20/src/lib.rs
+++ b/contracts/examples/erc20/src/lib.rs
@@ -48,7 +48,7 @@ pub trait SimpleErc20Token {
 	/// Will set the fixed global token supply and give all the supply to the creator.
 	#[init]
 	fn init(&self, total_supply: &BigUint) {
-		let creator = self.get_caller();
+		let creator = self.blockchain().get_caller();
 
 		// save total supply
 		self.set_total_supply(total_supply);
@@ -98,7 +98,7 @@ pub trait SimpleErc20Token {
 	#[endpoint]
 	fn transfer(&self, to: Address, amount: BigUint) -> SCResult<()> {
 		// the sender is the caller
-		let sender = self.get_caller();
+		let sender = self.blockchain().get_caller();
 		self.perform_transfer(sender, to, amount)
 	}
 
@@ -113,7 +113,7 @@ pub trait SimpleErc20Token {
 	#[endpoint(transferFrom)]
 	fn transfer_from(&self, sender: Address, recipient: Address, amount: BigUint) -> SCResult<()> {
 		// get caller
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		// load allowance
 		let mut allowance = self.get_allowance(&sender, &caller);
@@ -142,7 +142,7 @@ pub trait SimpleErc20Token {
 	#[endpoint]
 	fn approve(&self, spender: Address, amount: BigUint) -> SCResult<()> {
 		// sender is the caller
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		// store allowance
 		self.set_allowance(&caller, &spender, &amount);

--- a/contracts/examples/lottery-egld/src/lib.rs
+++ b/contracts/examples/lottery-egld/src/lib.rs
@@ -76,7 +76,7 @@ pub trait Lottery {
 	) -> SCResult<()> {
 		require!(!lottery_name.is_empty(), "Name can't be empty!");
 
-		let timestamp = self.get_block_timestamp();
+		let timestamp = self.blockchain().get_block_timestamp();
 
 		let total_tickets = opt_total_tickets.unwrap_or(MAX_TICKETS);
 		let deadline = opt_deadline.unwrap_or_else(|| timestamp + THIRTY_DAYS_IN_SECONDS);
@@ -168,7 +168,7 @@ pub trait Lottery {
 
 		let info = self.get_lottery_info(&lottery_name);
 
-		if self.get_block_timestamp() > info.deadline || info.tickets_left == 0 {
+		if self.blockchain().get_block_timestamp() > info.deadline || info.tickets_left == 0 {
 			return Status::Ended;
 		}
 
@@ -181,7 +181,7 @@ pub trait Lottery {
 		payment: &BigUint,
 	) -> SCResult<()> {
 		let mut info = self.get_lottery_info(&lottery_name);
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		require!(
 			info.whitelist.is_empty() || info.whitelist.contains(&caller),
@@ -218,7 +218,7 @@ pub trait Lottery {
 		if info.current_ticket_number > 0 {
 			let mut prev_winning_tickets: Vec<u32> = Vec::new();
 
-			let seed = self.get_block_random_seed();
+			let seed = self.blockchain().get_block_random_seed();
 			let mut rand = Random::new(*seed);
 
 			// if there are less tickets that the distributed prize pool,

--- a/contracts/examples/lottery-erc20/src/lib.rs
+++ b/contracts/examples/lottery-erc20/src/lib.rs
@@ -90,7 +90,7 @@ pub trait Lottery {
 	) -> SCResult<()> {
 		require!(!lottery_name.is_empty(), "Name can't be empty!");
 
-		let timestamp = self.get_block_timestamp();
+		let timestamp = self.blockchain().get_block_timestamp();
 
 		let total_tickets = opt_total_tickets.unwrap_or(u32::MAX);
 		let deadline = opt_deadline.unwrap_or_else(|| timestamp + THIRTY_DAYS_IN_SECONDS);
@@ -200,7 +200,7 @@ pub trait Lottery {
 
 		let info = self.get_lottery_info(&lottery_name);
 
-		if self.get_block_timestamp() > info.deadline || info.tickets_left == 0 {
+		if self.blockchain().get_block_timestamp() > info.deadline || info.tickets_left == 0 {
 			return Status::Ended;
 		}
 
@@ -213,7 +213,7 @@ pub trait Lottery {
 		token_amount: &BigUint,
 	) -> SCResult<AsyncCall<BigUint>> {
 		let info = self.get_lottery_info(&lottery_name);
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		require!(
 			info.whitelist.is_empty() || info.whitelist.contains(&caller),
@@ -233,7 +233,7 @@ pub trait Lottery {
 		self.reserve_ticket(lottery_name);
 
 		let erc20_address = self.get_erc20_contract_address();
-		let lottery_contract_address = self.get_sc_address();
+		let lottery_contract_address = self.blockchain().get_sc_address();
 		Ok(contract_call!(self, erc20_address, Erc20Proxy)
 			.transferFrom(&caller, &lottery_contract_address, token_amount)
 			.async_call()
@@ -314,7 +314,7 @@ pub trait Lottery {
 	}
 
 	fn get_random_winning_ticket_id(&self, prev_winners: &[u32], total_tickets: u32) -> u32 {
-		let seed = self.get_block_random_seed();
+		let seed = self.blockchain().get_block_random_seed();
 		let mut rand = Random::new(*seed);
 
 		loop {

--- a/contracts/examples/lottery-esdt/src/lib.rs
+++ b/contracts/examples/lottery-esdt/src/lib.rs
@@ -88,7 +88,7 @@ pub trait Lottery {
 			"Esdt token name can't be empty!"
 		);
 
-		let timestamp = self.get_block_timestamp();
+		let timestamp = self.blockchain().get_block_timestamp();
 
 		let total_tickets = opt_total_tickets.unwrap_or(MAX_TICKETS);
 		let deadline = opt_deadline.unwrap_or_else(|| timestamp + THIRTY_DAYS_IN_SECONDS);
@@ -185,7 +185,7 @@ pub trait Lottery {
 
 		let info = self.get_lottery_info(&lottery_name);
 
-		if self.get_block_timestamp() > info.deadline || info.tickets_left == 0 {
+		if self.blockchain().get_block_timestamp() > info.deadline || info.tickets_left == 0 {
 			return Status::Ended;
 		}
 
@@ -199,7 +199,7 @@ pub trait Lottery {
 		token: TokenIdentifier,
 	) -> SCResult<()> {
 		let mut info = self.get_lottery_info(&lottery_name);
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		require!(
 			info.whitelist.is_empty() || info.whitelist.contains(&caller),
@@ -236,7 +236,7 @@ pub trait Lottery {
 		if info.current_ticket_number > 0 {
 			let mut prev_winning_tickets: Vec<u32> = Vec::new();
 
-			let seed = self.get_block_random_seed();
+			let seed = self.blockchain().get_block_random_seed();
 			let mut rand = Random::new(*seed);
 
 			// if there are less tickets that the distributed prize pool,

--- a/contracts/examples/multisig/src/lib.rs
+++ b/contracts/examples/multisig/src/lib.rs
@@ -87,7 +87,7 @@ pub trait Multisig {
 	fn deposit(&self) {}
 
 	fn propose_action(&self, action: Action<BigUint>) -> SCResult<usize> {
-		let caller_address = self.get_caller();
+		let caller_address = self.blockchain().get_caller();
 		let caller_id = self.user_mapper().get_user_id(&caller_address);
 		let caller_role = self.get_user_id_to_role(caller_id);
 		require!(
@@ -273,7 +273,7 @@ pub trait Multisig {
 			"action does not exist"
 		);
 
-		let caller_address = self.get_caller();
+		let caller_address = self.blockchain().get_caller();
 		let caller_id = self.user_mapper().get_user_id(&caller_address);
 		let caller_role = self.get_user_id_to_role(caller_id);
 		require!(caller_role.can_sign(), "only board members can sign");
@@ -296,7 +296,7 @@ pub trait Multisig {
 			"action does not exist"
 		);
 
-		let caller_address = self.get_caller();
+		let caller_address = self.blockchain().get_caller();
 		let caller_id = self.user_mapper().get_user_id(&caller_address);
 		let caller_role = self.get_user_id_to_role(caller_id);
 		require!(caller_role.can_sign(), "only board members can un-sign");
@@ -402,7 +402,7 @@ pub trait Multisig {
 	/// Proposers and board members use this to launch signed actions.
 	#[endpoint(performAction)]
 	fn perform_action_endpoint(&self, action_id: usize) -> SCResult<PerformActionResult<BigUint>> {
-		let caller_address = self.get_caller();
+		let caller_address = self.blockchain().get_caller();
 		let caller_id = self.user_mapper().get_user_id(&caller_address);
 		let caller_role = self.get_user_id_to_role(caller_id);
 		require!(
@@ -472,7 +472,7 @@ pub trait Multisig {
 				code_metadata,
 				arguments,
 			} => {
-				let gas_left = self.get_gas_left();
+				let gas_left = self.blockchain().get_gas_left();
 				let mut arg_buffer = ArgBuffer::new();
 				for arg in arguments {
 					arg_buffer.push_argument_bytes(arg.as_slice());
@@ -518,7 +518,7 @@ pub trait Multisig {
 	/// Otherwise this endpoint would be prone to abuse.
 	#[endpoint(discardAction)]
 	fn discard_action(&self, action_id: usize) -> SCResult<()> {
-		let caller_address = self.get_caller();
+		let caller_address = self.blockchain().get_caller();
 		let caller_id = self.user_mapper().get_user_id(&caller_address);
 		let caller_role = self.get_user_id_to_role(caller_id);
 		require!(

--- a/contracts/examples/non-fungible-tokens/src/lib.rs
+++ b/contracts/examples/non-fungible-tokens/src/lib.rs
@@ -6,7 +6,7 @@ elrond_wasm::imports!();
 pub trait NonFungibleTokens {
 	#[init]
 	fn init(&self, initial_minted: u64) {
-		let owner = self.get_caller();
+		let owner = self.blockchain().get_caller();
 
 		self.set_owner(&owner);
 		self.perform_mint(initial_minted, &owner);
@@ -19,7 +19,7 @@ pub trait NonFungibleTokens {
 	#[endpoint]
 	fn mint(&self, count: u64, new_token_owner: Address) -> SCResult<()> {
 		require!(
-			self.get_caller() == self.get_owner(),
+			self.blockchain().get_caller() == self.get_owner(),
 			"Only owner can mint new tokens!"
 		);
 
@@ -34,7 +34,7 @@ pub trait NonFungibleTokens {
 	fn approve(&self, token_id: u64, approved_address: Address) -> SCResult<()> {
 		require!(token_id < self.get_total_minted(), "Token does not exist!");
 		require!(
-			self.get_caller() == self.get_token_owner(token_id),
+			self.blockchain().get_caller() == self.get_token_owner(token_id),
 			"Only the token owner can approve!"
 		);
 
@@ -49,7 +49,7 @@ pub trait NonFungibleTokens {
 	fn revoke(&self, token_id: u64) -> SCResult<()> {
 		require!(token_id < self.get_total_minted(), "Token does not exist!");
 		require!(
-			self.get_caller() == self.get_token_owner(token_id),
+			self.blockchain().get_caller() == self.get_token_owner(token_id),
 			"Only the token owner can revoke approval!"
 		);
 
@@ -65,7 +65,7 @@ pub trait NonFungibleTokens {
 	fn transfer(&self, token_id: u64, to: Address) -> SCResult<()> {
 		require!(token_id < self.get_total_minted(), "Token does not exist!");
 
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 		let token_owner = self.get_token_owner(token_id);
 
 		if caller == token_owner {

--- a/contracts/feature-tests/async/forwarder-raw/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder-raw/src/lib.rs
@@ -92,7 +92,7 @@ pub trait ForwarderRaw {
 	) -> TransferEgldExecute<BigUint> {
 		self.forward_contract_call(to, TokenIdentifier::egld(), payment, endpoint_name, args)
 			.transfer_egld_execute()
-			.with_gas_limit(self.get_gas_left() / 2)
+			.with_gas_limit(self.blockchain().get_gas_left() / 2)
 	}
 
 	#[endpoint]
@@ -107,7 +107,7 @@ pub trait ForwarderRaw {
 	) -> TransferEsdtExecute<BigUint> {
 		self.forward_contract_call(to, token, payment, endpoint_name, args)
 			.transfer_esdt_execute()
-			.with_gas_limit(self.get_gas_left() / 2)
+			.with_gas_limit(self.blockchain().get_gas_left() / 2)
 	}
 
 	#[endpoint]
@@ -122,7 +122,7 @@ pub trait ForwarderRaw {
 	) -> TransferExecute<BigUint> {
 		self.forward_contract_call(to, token, payment, endpoint_name, args)
 			.transfer_execute()
-			.with_gas_limit(self.get_gas_left() / 2)
+			.with_gas_limit(self.blockchain().get_gas_left() / 2)
 	}
 
 	#[view]
@@ -177,7 +177,7 @@ pub trait ForwarderRaw {
 		endpoint_name: BoxedBytes,
 		#[var_args] args: VarArgs<BoxedBytes>,
 	) {
-		let half_gas = self.get_gas_left() / 2;
+		let half_gas = self.blockchain().get_gas_left() / 2;
 		let result = self.send().execute_on_dest_context_raw(
 			half_gas,
 			&to,
@@ -198,7 +198,7 @@ pub trait ForwarderRaw {
 		endpoint_name: BoxedBytes,
 		#[var_args] args: VarArgs<BoxedBytes>,
 	) {
-		let one_third_gas = self.get_gas_left() / 3;
+		let one_third_gas = self.blockchain().get_gas_left() / 3;
 		let half_payment = payment / 2u32.into();
 		let arg_buffer = ArgBuffer::from(args.into_vec().as_slice());
 

--- a/contracts/feature-tests/async/forwarder/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder/src/lib.rs
@@ -171,7 +171,7 @@ pub trait Forwarder {
 	#[endpoint]
 	#[payable("*")]
 	fn echo_arguments_sync(&self, to: Address, #[var_args] args: VarArgs<BoxedBytes>) {
-		let half_gas = self.get_gas_left() / 2;
+		let half_gas = self.blockchain().get_gas_left() / 2;
 
 		let result = contract_call!(self, to, VaultProxy)
 			.echo_arguments(&args)
@@ -183,7 +183,7 @@ pub trait Forwarder {
 	#[endpoint]
 	#[payable("*")]
 	fn echo_arguments_sync_twice(&self, to: Address, #[var_args] args: VarArgs<BoxedBytes>) {
-		let one_third_gas = self.get_gas_left() / 3;
+		let one_third_gas = self.blockchain().get_gas_left() / 3;
 
 		let result = contract_call!(self, to.clone(), VaultProxy)
 			.echo_arguments(&args)
@@ -209,7 +209,7 @@ pub trait Forwarder {
 		#[payment_token] token: TokenIdentifier,
 		#[payment] payment: BigUint,
 	) {
-		let half_gas = self.get_gas_left() / 2;
+		let half_gas = self.blockchain().get_gas_left() / 2;
 
 		let () = contract_call!(self, to, VaultProxy)
 			.with_token_transfer(token, payment)

--- a/contracts/feature-tests/async/recursive-caller/src/lib.rs
+++ b/contracts/feature-tests/async/recursive-caller/src/lib.rs
@@ -66,9 +66,13 @@ pub trait RecursiveCaller {
 
 		if counter > 1 {
 			OptionalResult::Some(
-				contract_call!(self, self.get_sc_address(), AlsoRecursiveCallerProxy)
-					.recursive_send_funds(&to, token_identifier, amount, counter - 1)
-					.async_call(),
+				contract_call!(
+					self,
+					self.blockchain().get_sc_address(),
+					AlsoRecursiveCallerProxy
+				)
+				.recursive_send_funds(&to, token_identifier, amount, counter - 1)
+				.async_call(),
 			)
 		} else {
 			OptionalResult::None

--- a/contracts/feature-tests/async/vault/src/lib.rs
+++ b/contracts/feature-tests/async/vault/src/lib.rs
@@ -45,7 +45,7 @@ pub trait Vault {
 			OptionalArg::None => &[],
 		};
 		self.send()
-			.direct_via_async_call(&self.get_caller(), &token, &amount, data);
+			.direct_via_async_call(&self.blockchain().get_caller(), &token, &amount, data);
 	}
 
 	#[event("accept_funds")]

--- a/contracts/feature-tests/basic-features/src/lib.rs
+++ b/contracts/feature-tests/basic-features/src/lib.rs
@@ -709,27 +709,27 @@ pub trait BasicFeatures {
 	// BASIC API
 	#[endpoint(get_caller)]
 	fn get_caller_endpoint(&self) -> Address {
-		self.get_caller()
+		self.blockchain().get_caller()
 	}
 
 	#[endpoint(get_shard_of_address)]
 	fn get_shard_of_address_endpoint(&self, address: &Address) -> u32 {
-		self.get_shard_of_address(address)
+		self.blockchain().get_shard_of_address(address)
 	}
 
 	#[endpoint(is_smart_contract)]
 	fn is_smart_contract_endpoint(&self, address: &Address) -> bool {
-		self.is_smart_contract(address)
+		self.blockchain().is_smart_contract(address)
 	}
 
 	#[endpoint(get_owner_address)]
 	fn get_owner_address_endpoint(&self) -> Address {
-		self.get_owner_address()
+		self.blockchain().get_owner_address()
 	}
 
 	#[endpoint(get_gas_left)]
 	fn get_gas_left_endpoint(&self) -> u64 {
-		self.get_gas_left()
+		self.blockchain().get_gas_left()
 	}
 
 	// EVENTS
@@ -772,52 +772,52 @@ pub trait BasicFeatures {
 
 	#[view(get_block_timestamp)]
 	fn get_block_timestamp_view(&self) -> u64 {
-		self.get_block_timestamp()
+		self.blockchain().get_block_timestamp()
 	}
 
 	#[view(get_block_nonce)]
 	fn get_block_nonce_view(&self) -> u64 {
-		self.get_block_nonce()
+		self.blockchain().get_block_nonce()
 	}
 
 	#[view(get_block_round)]
 	fn get_block_round_view(&self) -> u64 {
-		self.get_block_round()
+		self.blockchain().get_block_round()
 	}
 
 	#[view(get_block_epoch)]
 	fn get_block_epoch_view(&self) -> u64 {
-		self.get_block_epoch()
+		self.blockchain().get_block_epoch()
 	}
 
 	#[view(get_block_random_seed)]
 	fn get_block_random_seed_view(&self) -> Box<[u8; 48]> {
-		self.get_block_random_seed()
+		self.blockchain().get_block_random_seed()
 	}
 
 	#[view(get_prev_block_timestamp)]
 	fn get_prev_block_timestamp_view(&self) -> u64 {
-		self.get_prev_block_timestamp()
+		self.blockchain().get_prev_block_timestamp()
 	}
 
 	#[view(get_prev_block_nonce)]
 	fn get_prev_block_nonce_view(&self) -> u64 {
-		self.get_prev_block_nonce()
+		self.blockchain().get_prev_block_nonce()
 	}
 
 	#[view(get_prev_block_round)]
 	fn get_prev_block_round_view(&self) -> u64 {
-		self.get_prev_block_round()
+		self.blockchain().get_prev_block_round()
 	}
 
 	#[view(get_prev_block_epoch)]
 	fn get_prev_block_epoch_view(&self) -> u64 {
-		self.get_prev_block_epoch()
+		self.blockchain().get_prev_block_epoch()
 	}
 
 	#[view(get_prev_block_random_seed)]
 	fn get_prev_block_random_seed_view(&self) -> Box<[u8; 48]> {
-		self.get_prev_block_random_seed()
+		self.blockchain().get_prev_block_random_seed()
 	}
 
 	// BIG INT OPERATIONS
@@ -1189,29 +1189,29 @@ pub trait BasicFeatures {
 
 	#[endpoint(computeSha256)]
 	fn compute_sha256(&self, input: Vec<u8>) -> H256 {
-		self.sha256(&input)
+		self.crypto().sha256(&input)
 	}
 
 	#[endpoint(computeKeccak256)]
 	fn compute_keccak256(&self, input: Vec<u8>) -> H256 {
-		self.keccak256(&input)
+		self.crypto().keccak256(&input)
 	}
 
 	// Not called, they currently just panic with "Not implemented yet!"
 
 	#[endpoint]
 	fn verify_bls_signature(&self, key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-		self.verify_bls(key, message, signature)
+		self.crypto().verify_bls(key, message, signature)
 	}
 
 	#[endpoint]
 	fn verify_ed25519_signature(&self, key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-		self.verify_ed25519(key, message, signature)
+		self.crypto().verify_ed25519(key, message, signature)
 	}
 
 	#[endpoint]
 	fn verify_secp256k1_signature(&self, key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-		self.verify_secp256k1(key, message, signature)
+		self.crypto().verify_secp256k1(key, message, signature)
 	}
 
 	// MACROS

--- a/contracts/feature-tests/deploy-two-contracts/src/lib.rs
+++ b/contracts/feature-tests/deploy-two-contracts/src/lib.rs
@@ -82,7 +82,7 @@ pub trait DeployTwoContracts {
 
 	fn deploy(&self) -> Address {
 		self.send().deploy_contract(
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			&BigUint::zero(),
 			&BoxedBytes::from(CONTRACT_CODE),
 			CodeMetadata::DEFAULT,

--- a/contracts/feature-tests/esdt-contract-pair/first-contract/src/lib.rs
+++ b/contracts/feature-tests/esdt-contract-pair/first-contract/src/lib.rs
@@ -103,7 +103,7 @@ pub trait FirstContract {
 			&second_contract_address,
 			expected_token_name.as_esdt_identifier(),
 			&esdt_value,
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			SECOND_CONTRACT_REJECT_ESDT_PAYMENT,
 			&ArgBuffer::new(),
 		);
@@ -128,7 +128,7 @@ pub trait FirstContract {
 			&second_contract_address,
 			expected_token_name.as_esdt_identifier(),
 			&esdt_value,
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			SECOND_CONTRACT_ACCEPT_ESDT_PAYMENT,
 			&ArgBuffer::new(),
 		);

--- a/contracts/feature-tests/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
+++ b/contracts/feature-tests/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
@@ -29,7 +29,7 @@ pub trait Parent {
 	#[endpoint(deployChildContract)]
 	fn deploy_child_contract(&self, code: BoxedBytes) {
 		let child_contract_address = self.send().deploy_contract(
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			&BigUint::zero(),
 			&code,
 			CodeMetadata::DEFAULT,

--- a/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
+++ b/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
@@ -28,7 +28,7 @@ pub trait LocalEsdtAndEsdtNft {
 		token_ticker: BoxedBytes,
 		initial_supply: BigUint,
 	) -> AsyncCall<BigUint> {
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		ESDTSystemSmartContractProxy::new()
 			.issue_fungible(
@@ -55,7 +55,7 @@ pub trait LocalEsdtAndEsdtNft {
 	#[endpoint(localMint)]
 	fn local_mint(&self, token_identifier: TokenIdentifier, amount: BigUint) {
 		self.send().esdt_local_mint(
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			token_identifier.as_esdt_identifier(),
 			&amount,
 		);
@@ -64,7 +64,7 @@ pub trait LocalEsdtAndEsdtNft {
 	#[endpoint(localBurn)]
 	fn local_burn(&self, token_identifier: TokenIdentifier, amount: BigUint) {
 		self.send().esdt_local_burn(
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			token_identifier.as_esdt_identifier(),
 			&amount,
 		);
@@ -80,7 +80,7 @@ pub trait LocalEsdtAndEsdtNft {
 		token_display_name: BoxedBytes,
 		token_ticker: BoxedBytes,
 	) -> AsyncCall<BigUint> {
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		ESDTSystemSmartContractProxy::new()
 			.issue_non_fungible(
@@ -112,7 +112,7 @@ pub trait LocalEsdtAndEsdtNft {
 		uri: BoxedBytes,
 	) {
 		self.send().esdt_nft_create::<Color>(
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			token_identifier.as_esdt_identifier(),
 			&amount,
 			&name,
@@ -126,7 +126,7 @@ pub trait LocalEsdtAndEsdtNft {
 	#[endpoint(nftAddQuantity)]
 	fn nft_add_quantity(&self, token_identifier: TokenIdentifier, nonce: u64, amount: BigUint) {
 		self.send().esdt_nft_add_quantity(
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			token_identifier.as_esdt_identifier(),
 			nonce,
 			&amount,
@@ -136,7 +136,7 @@ pub trait LocalEsdtAndEsdtNft {
 	#[endpoint(nftBurn)]
 	fn nft_burn(&self, token_identifier: TokenIdentifier, nonce: u64, amount: BigUint) {
 		self.send().esdt_nft_burn(
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			token_identifier.as_esdt_identifier(),
 			nonce,
 			&amount,
@@ -153,7 +153,7 @@ pub trait LocalEsdtAndEsdtNft {
 		data: BoxedBytes,
 	) {
 		self.send().direct_esdt_nft_via_async_call(
-			&self.get_sc_address(),
+			&self.blockchain().get_sc_address(),
 			&to,
 			token_identifier.as_esdt_identifier(),
 			nonce,
@@ -182,7 +182,7 @@ pub trait LocalEsdtAndEsdtNft {
 			token_identifier.as_esdt_identifier(),
 			nonce,
 			&amount,
-			self.get_gas_left(),
+			self.blockchain().get_gas_left(),
 			function.as_slice(),
 			&arg_buffer,
 		);
@@ -198,7 +198,7 @@ pub trait LocalEsdtAndEsdtNft {
 		token_display_name: BoxedBytes,
 		token_ticker: BoxedBytes,
 	) -> AsyncCall<BigUint> {
-		let caller = self.get_caller();
+		let caller = self.blockchain().get_caller();
 
 		ESDTSystemSmartContractProxy::new()
 			.issue_semi_fungible(
@@ -258,8 +258,8 @@ pub trait LocalEsdtAndEsdtNft {
 
 	#[view(getFungibleEsdtBalance)]
 	fn get_fungible_esdt_balance(&self, token_identifier: &TokenIdentifier) -> BigUint {
-		self.get_esdt_balance(
-			&self.get_sc_address(),
+		self.blockchain().get_esdt_balance(
+			&self.blockchain().get_sc_address(),
 			token_identifier.as_esdt_identifier(),
 			0,
 		)
@@ -267,8 +267,8 @@ pub trait LocalEsdtAndEsdtNft {
 
 	#[view(getNftBalance)]
 	fn get_nft_balance(&self, token_identifier: &TokenIdentifier, nonce: u64) -> BigUint {
-		self.get_esdt_balance(
-			&self.get_sc_address(),
+		self.blockchain().get_esdt_balance(
+			&self.blockchain().get_sc_address(),
 			token_identifier.as_esdt_identifier(),
 			nonce,
 		)

--- a/contracts/modules/elrond-wasm-module-features/src/lib.rs
+++ b/contracts/modules/elrond-wasm-module-features/src/lib.rs
@@ -38,7 +38,7 @@ pub trait FeaturesModule {
 	#[endpoint(setFeatureFlag)]
 	fn set_feature_flag_endpoint(&self, feature_name: Vec<u8>, value: bool) -> SCResult<()> {
 		require!(
-			self.get_caller() == self.get_owner_address(),
+			self.blockchain().get_caller() == self.blockchain().get_owner_address(),
 			"only owner allowed to change features"
 		);
 

--- a/contracts/modules/elrond-wasm-module-pause/src/lib.rs
+++ b/contracts/modules/elrond-wasm-module-pause/src/lib.rs
@@ -25,7 +25,7 @@ pub trait PauseModule {
 	#[endpoint(pause)]
 	fn pause_endpoint(&self) -> SCResult<()> {
 		require!(
-			self.get_caller() == self.get_owner_address(),
+			self.blockchain().get_caller() == self.blockchain().get_owner_address(),
 			"only owner allowed to pause contract"
 		);
 
@@ -37,7 +37,7 @@ pub trait PauseModule {
 	#[endpoint(unpause)]
 	fn unpause_endpoint(&self) -> SCResult<()> {
 		require!(
-			self.get_caller() == self.get_owner_address(),
+			self.blockchain().get_caller() == self.blockchain().get_owner_address(),
 			"only owner allowed to unpause contract"
 		);
 

--- a/elrond-wasm-debug/src/abi_json/contract_abi_json.rs
+++ b/elrond-wasm-debug/src/abi_json/contract_abi_json.rs
@@ -20,10 +20,7 @@ impl From<&ContractAbi> for ContractAbiJson {
 		let mut contract_json = ContractAbiJson {
 			docs: abi.docs.iter().map(|d| d.to_string()).collect(),
 			name: abi.name.to_string(),
-			constructor: abi
-				.constructor
-				.as_ref()
-				.map(ConstructorAbiJson::from),
+			constructor: abi.constructor.as_ref().map(ConstructorAbiJson::from),
 			endpoints: Vec::new(),
 			types: BTreeMap::new(),
 		};

--- a/elrond-wasm-debug/src/api/blockchain_api_mock.rs
+++ b/elrond-wasm-debug/src/api/blockchain_api_mock.rs
@@ -1,4 +1,3 @@
-use super::big_int_api_mock::*;
 use super::big_uint_api_mock::*;
 use crate::TxContext;
 use elrond_wasm::{
@@ -6,26 +5,7 @@ use elrond_wasm::{
 	types::{Address, EsdtTokenData, H256},
 };
 
-impl elrond_wasm::api::ContractHookApi<RustBigInt, RustBigUint> for TxContext {
-	type Storage = Self;
-	type CallValue = Self;
-	type SendApi = Self;
-
-	#[inline]
-	fn get_storage_raw(&self) -> Self::Storage {
-		self.clone()
-	}
-
-	#[inline]
-	fn call_value(&self) -> Self::CallValue {
-		self.clone()
-	}
-
-	#[inline]
-	fn send(&self) -> Self::SendApi {
-		self.clone()
-	}
-
+impl elrond_wasm::api::BlockchainApi<RustBigUint> for TxContext {
 	fn get_sc_address(&self) -> Address {
 		self.tx_input_box.to.clone()
 	}

--- a/elrond-wasm-debug/src/api/contract_self_api_mock.rs
+++ b/elrond-wasm-debug/src/api/contract_self_api_mock.rs
@@ -1,0 +1,36 @@
+use super::big_int_api_mock::*;
+use super::big_uint_api_mock::*;
+use crate::TxContext;
+
+impl elrond_wasm::api::ContractSelfApi<RustBigInt, RustBigUint> for TxContext {
+	type Storage = Self;
+	type CallValue = Self;
+	type SendApi = Self;
+	type BlockchainApi = Self;
+	type CryptoApi = Self;
+
+	#[inline]
+	fn get_storage_raw(&self) -> Self::Storage {
+		self.clone()
+	}
+
+	#[inline]
+	fn call_value(&self) -> Self::CallValue {
+		self.clone()
+	}
+
+	#[inline]
+	fn send(&self) -> Self::SendApi {
+		self.clone()
+	}
+
+	#[inline]
+	fn blockchain(&self) -> Self::BlockchainApi {
+		self.clone()
+	}
+
+	#[inline]
+	fn crypto(&self) -> Self::CryptoApi {
+		self.clone()
+	}
+}

--- a/elrond-wasm-debug/src/api/mod.rs
+++ b/elrond-wasm-debug/src/api/mod.rs
@@ -1,7 +1,8 @@
 mod big_int_api_mock;
 mod big_uint_api_mock;
+mod blockchain_api_mock;
 mod call_value_api_mock;
-mod contract_api_mock;
+mod contract_self_api_mock;
 mod crypto_api_mock;
 mod endpoint_arg_api_mock;
 mod endpoint_finish_api_mock;
@@ -12,8 +13,9 @@ mod storage_api_mock;
 
 pub use big_int_api_mock::*;
 pub use big_uint_api_mock::*;
+pub use blockchain_api_mock::*;
 pub use call_value_api_mock::*;
-pub use contract_api_mock::*;
+pub use contract_self_api_mock::*;
 pub use crypto_api_mock::*;
 pub use endpoint_arg_api_mock::*;
 pub use endpoint_finish_api_mock::*;

--- a/elrond-wasm-debug/src/api/send_api_mock.rs
+++ b/elrond-wasm-debug/src/api/send_api_mock.rs
@@ -1,7 +1,7 @@
 use super::big_uint_api_mock::*;
 use crate::async_data::AsyncCallTxData;
 use crate::{SendBalance, TxContext, TxOutput, TxPanic};
-use elrond_wasm::api::{ContractHookApi, SendApi, StorageReadApi, StorageWriteApi};
+use elrond_wasm::api::{BlockchainApi, ContractSelfApi, SendApi, StorageReadApi, StorageWriteApi};
 use elrond_wasm::types::{Address, ArgBuffer, BoxedBytes, CodeMetadata, TokenIdentifier};
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -121,7 +121,7 @@ impl SendApi<RustBigUint> for TxContext {
 			to: to.clone(),
 			call_value: amount.value(),
 			call_data: data.to_vec(),
-			tx_hash: self.get_tx_hash(),
+			tx_hash: self.blockchain().get_tx_hash(),
 		});
 		std::panic::panic_any(tx_output)
 	}
@@ -171,12 +171,12 @@ impl SendApi<RustBigUint> for TxContext {
 	}
 
 	fn storage_store_tx_hash_key(&self, data: &[u8]) {
-		let tx_hash = self.get_tx_hash();
+		let tx_hash = self.blockchain().get_tx_hash();
 		self.storage_store_slice_u8(tx_hash.as_bytes(), data);
 	}
 
 	fn storage_load_tx_hash_key(&self) -> BoxedBytes {
-		let tx_hash = self.get_tx_hash();
+		let tx_hash = self.blockchain().get_tx_hash();
 		self.storage_load_boxed_bytes(tx_hash.as_bytes())
 	}
 

--- a/elrond-wasm-derive/src/contract_impl.rs
+++ b/elrond-wasm-derive/src/contract_impl.rs
@@ -34,7 +34,7 @@ pub fn contract_implementation(
 	// this definition is common to release and debug mode
 	let main_definition = quote! {
 	  pub trait #trait_name_ident<T, BigInt, BigUint>:
-	  ContractHookApi<BigInt, BigUint>
+	  ContractSelfApi<BigInt, BigUint>
 	  // #( + #supertrait_paths <T, BigInt, BigUint>)* // currently not supported
 	  + Sized
 	  #api_where

--- a/elrond-wasm-derive/src/generate/callback_gen.rs
+++ b/elrond-wasm-derive/src/generate/callback_gen.rs
@@ -89,7 +89,7 @@ fn generate_callback_body_regular(methods: &[Method]) -> proc_macro2::TokenStrea
 		quote! {}
 	} else {
 		quote! {
-			let ___tx_hash___ = self.api.get_tx_hash();
+			let ___tx_hash___ = elrond_wasm::api::BlockchainApi::get_tx_hash(&self.api);
 			let ___cb_data_raw___ = self.api.storage_load_boxed_bytes(&___tx_hash___.as_bytes());
 			self.api.storage_store_slice_u8(&___tx_hash___.as_bytes(), &[]); // cleanup
 			let mut ___cb_data_deserializer___ = elrond_wasm::hex_call_data::HexCallDataDeserializer::new(___cb_data_raw___.as_slice());

--- a/elrond-wasm-derive/src/generate/snippets.rs
+++ b/elrond-wasm-derive/src/generate/snippets.rs
@@ -40,14 +40,16 @@ pub fn api_where() -> proc_macro2::TokenStream {
 
 	quote! {
 	  #bi_where
-		T: elrond_wasm::api::ContractHookApi<BigInt, BigUint>
+		T: elrond_wasm::api::ContractSelfApi<BigInt, BigUint>
 		 + elrond_wasm::api::ErrorApi
+		 + elrond_wasm::api::BlockchainApi<BigUint>
 		 + elrond_wasm::api::CallValueApi<BigUint>
 		 + elrond_wasm::api::SendApi<BigUint>
 		 + elrond_wasm::api::EndpointArgumentApi
 		 + elrond_wasm::api::EndpointFinishApi
 		 + elrond_wasm::api::StorageReadApi
 		 + elrond_wasm::api::StorageWriteApi
+		 + elrond_wasm::api::CryptoApi
 		 + elrond_wasm::api::LogApi
 		 + Clone
 		 + 'static,
@@ -57,12 +59,14 @@ pub fn api_where() -> proc_macro2::TokenStream {
 pub fn contract_trait_api_impl(contract_struct: &syn::Path) -> proc_macro2::TokenStream {
 	let api_where = api_where();
 	quote! {
-		impl <T, BigInt, BigUint> elrond_wasm::api::ContractHookApi<BigInt, BigUint> for #contract_struct<T, BigInt, BigUint>
+		impl <T, BigInt, BigUint> elrond_wasm::api::ContractSelfApi<BigInt, BigUint> for #contract_struct<T, BigInt, BigUint>
 		#api_where
 		{
 			type Storage = T::Storage;
 			type CallValue = T::CallValue;
 			type SendApi = T::SendApi;
+			type BlockchainApi = T::BlockchainApi;
+			type CryptoApi = T::CryptoApi;
 
 			#[inline]
 			fn get_storage_raw(&self) -> Self::Storage {
@@ -80,142 +84,13 @@ pub fn contract_trait_api_impl(contract_struct: &syn::Path) -> proc_macro2::Toke
 			}
 
 			#[inline]
-			fn get_sc_address(&self) -> Address {
-				self.api.get_sc_address()
+			fn blockchain(&self) -> Self::BlockchainApi {
+				self.api.blockchain()
 			}
 
 			#[inline]
-			fn get_owner_address(&self) -> Address {
-				self.api.get_owner_address()
-			}
-
-			#[inline]
-			fn get_shard_of_address(&self, address: &Address) -> u32 {
-				self.api.get_shard_of_address(address)
-			}
-
-			#[inline]
-			fn is_smart_contract(&self, address: &Address) -> bool {
-				self.api.is_smart_contract(address)
-			}
-
-			#[inline]
-			fn get_caller(&self) -> Address {
-				self.api.get_caller()
-			}
-
-			#[inline]
-			fn get_balance(&self, address: &Address) -> BigUint {
-				self.api.get_balance(address)
-			}
-
-			#[inline]
-			fn get_tx_hash(&self) -> H256 {
-				self.api.get_tx_hash()
-			}
-
-			#[inline]
-			fn get_gas_left(&self) -> u64 {
-				self.api.get_gas_left()
-			}
-
-			#[inline]
-			fn get_block_timestamp(&self) -> u64 {
-				self.api.get_block_timestamp()
-			}
-
-			#[inline]
-			fn get_block_nonce(&self) -> u64 {
-				self.api.get_block_nonce()
-			}
-
-			#[inline]
-			fn get_block_round(&self) -> u64 {
-				self.api.get_block_round()
-			}
-
-			#[inline]
-			fn get_block_epoch(&self) -> u64 {
-				self.api.get_block_epoch()
-			}
-
-			#[inline]
-			fn get_block_random_seed(&self) -> Box<[u8; 48]> {
-				self.api.get_block_random_seed()
-			}
-
-			#[inline]
-			fn get_prev_block_timestamp(&self) -> u64 {
-				self.api.get_prev_block_timestamp()
-			}
-
-			#[inline]
-			fn get_prev_block_nonce(&self) -> u64 {
-				self.api.get_prev_block_nonce()
-			}
-
-			#[inline]
-			fn get_prev_block_round(&self) -> u64 {
-				self.api.get_prev_block_round()
-			}
-
-			#[inline]
-			fn get_prev_block_epoch(&self) -> u64 {
-				self.api.get_prev_block_epoch()
-			}
-
-			#[inline]
-			fn get_prev_block_random_seed(&self) -> Box<[u8; 48]> {
-				self.api.get_prev_block_random_seed()
-			}
-
-			#[inline]
-			fn get_current_esdt_nft_nonce(&self, address: &Address, token: &[u8]) -> u64 {
-				self.api.get_current_esdt_nft_nonce(address, token)
-			}
-
-			#[inline]
-			fn get_esdt_balance(&self, address: &Address, token: &[u8], nonce: u64) -> BigUint {
-				self.api.get_esdt_balance(address, token, nonce)
-			}
-
-			#[inline]
-			fn get_esdt_token_data(
-				&self,
-				address: &Address,
-				token: &[u8],
-				nonce: u64,
-			) -> EsdtTokenData<BigUint> {
-				self.api.get_esdt_token_data(address, token, nonce)
-			}
-		}
-
-		impl <T, BigInt, BigUint> elrond_wasm::api::CryptoApi for #contract_struct<T, BigInt, BigUint>
-		#api_where
-		{
-			#[inline]
-			fn sha256(&self, data: &[u8]) -> H256 {
-				self.api.sha256(data)
-			}
-
-			#[inline]
-			fn keccak256(&self, data: &[u8]) -> H256 {
-				self.api.keccak256(data)
-			}
-
-			#[inline]
-			fn verify_bls(&self, key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-				self.api.verify_bls(key, message, signature)
-			}
-
-			#[inline]
-			fn verify_ed25519(&self, key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-				self.api.verify_ed25519(key, message, signature)
-			}
-
-			#[inline]
-			fn verify_secp256k1(&self, key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-				self.api.verify_secp256k1(key, message, signature)
+			fn crypto(&self) -> Self::CryptoApi {
+				self.api.crypto()
 			}
 		}
 	}

--- a/elrond-wasm-node/src/api/blockchain_api_node.rs
+++ b/elrond-wasm-node/src/api/blockchain_api_node.rs
@@ -1,6 +1,6 @@
-use super::{ArwenBigInt, ArwenBigUint};
+use super::ArwenBigUint;
 use crate::ArwenApiImpl;
-use elrond_wasm::api::ContractHookApi;
+use elrond_wasm::api::BlockchainApi;
 use elrond_wasm::types::{Address, Box, BoxedBytes, EsdtTokenData, EsdtTokenType, H256};
 
 extern "C" {
@@ -88,26 +88,7 @@ extern "C" {
 	) -> i32;
 }
 
-impl ContractHookApi<ArwenBigInt, ArwenBigUint> for ArwenApiImpl {
-	type Storage = Self;
-	type CallValue = Self;
-	type SendApi = Self;
-
-	#[inline]
-	fn get_storage_raw(&self) -> Self::Storage {
-		self.clone()
-	}
-
-	#[inline]
-	fn call_value(&self) -> Self::CallValue {
-		self.clone()
-	}
-
-	#[inline]
-	fn send(&self) -> Self::SendApi {
-		self.clone()
-	}
-
+impl BlockchainApi<ArwenBigUint> for ArwenApiImpl {
 	#[inline]
 	fn get_sc_address(&self) -> Address {
 		unsafe {

--- a/elrond-wasm-node/src/api/call_value_api_node.rs
+++ b/elrond-wasm-node/src/api/call_value_api_node.rs
@@ -62,8 +62,6 @@ impl CallValueApi<ArwenBigUint> for ArwenApiImpl {
 	}
 
 	fn esdt_token_type(&self) -> EsdtTokenType {
-		unsafe {
-			(getESDTTokenType() as u8).into()
-		}
+		unsafe { (getESDTTokenType() as u8).into() }
 	}
 }

--- a/elrond-wasm-node/src/api/contract_self_api_node.rs
+++ b/elrond-wasm-node/src/api/contract_self_api_node.rs
@@ -1,0 +1,36 @@
+use super::{ArwenBigInt, ArwenBigUint};
+use crate::ArwenApiImpl;
+use elrond_wasm::api::ContractSelfApi;
+
+impl ContractSelfApi<ArwenBigInt, ArwenBigUint> for ArwenApiImpl {
+	type Storage = Self;
+	type CallValue = Self;
+	type SendApi = Self;
+	type BlockchainApi = Self;
+	type CryptoApi = Self;
+
+	#[inline]
+	fn get_storage_raw(&self) -> Self::Storage {
+		self.clone()
+	}
+
+	#[inline]
+	fn call_value(&self) -> Self::CallValue {
+		self.clone()
+	}
+
+	#[inline]
+	fn send(&self) -> Self::SendApi {
+		self.clone()
+	}
+
+	#[inline]
+	fn blockchain(&self) -> Self::BlockchainApi {
+		self.clone()
+	}
+
+	#[inline]
+	fn crypto(&self) -> Self::CryptoApi {
+		self.clone()
+	}
+}

--- a/elrond-wasm-node/src/api/mod.rs
+++ b/elrond-wasm-node/src/api/mod.rs
@@ -1,7 +1,8 @@
 mod big_int_api_node;
 mod big_uint_api_node;
+mod blockchain_api_node;
 mod call_value_api_node;
-mod contract_api_node;
+mod contract_self_api_node;
 mod crypto_api_node;
 mod endpoint_arg_api_node;
 mod endpoint_finish_api_node;
@@ -13,8 +14,9 @@ mod unsafe_buffer;
 
 pub use big_int_api_node::*;
 pub use big_uint_api_node::*;
+pub use blockchain_api_node::*;
 pub use call_value_api_node::*;
-pub use contract_api_node::*;
+pub use contract_self_api_node::*;
 pub use crypto_api_node::*;
 pub use endpoint_arg_api_node::*;
 pub use endpoint_finish_api_node::*;

--- a/elrond-wasm-node/src/api/send_api_node.rs
+++ b/elrond-wasm-node/src/api/send_api_node.rs
@@ -1,7 +1,7 @@
 use super::ArwenBigUint;
 use crate::ArwenApiImpl;
 use alloc::vec::Vec;
-use elrond_wasm::api::{ContractHookApi, SendApi, StorageReadApi, StorageWriteApi};
+use elrond_wasm::api::{BlockchainApi, SendApi, StorageReadApi, StorageWriteApi};
 use elrond_wasm::types::{Address, ArgBuffer, BoxedBytes, CodeMetadata};
 
 extern "C" {

--- a/elrond-wasm/src/api/blockchain_api.rs
+++ b/elrond-wasm/src/api/blockchain_api.rs
@@ -1,8 +1,4 @@
-use super::{
-	BigIntApi, BigUintApi, CallValueApi, CryptoApi, ErrorApi, SendApi, StorageReadApi,
-	StorageWriteApi,
-};
-use crate::storage;
+use super::BigUintApi;
 use crate::types::{Address, EsdtTokenData, H256};
 use alloc::boxed::Box;
 
@@ -12,33 +8,10 @@ use alloc::boxed::Box;
 /// They simply pass on/retrieve data to/from the protocol.
 /// When mocking the blockchain state, we use the Rc/RefCell pattern
 /// to isolate mock state mutability from the contract interface.
-pub trait ContractHookApi<BigInt, BigUint>: Sized + CryptoApi
+pub trait BlockchainApi<BigUint>: Sized
 where
-	BigInt: BigIntApi<BigUint> + 'static,
 	BigUint: BigUintApi + 'static,
 {
-	/// Abstracts the lower-level storage functionality.
-	type Storage: StorageReadApi + StorageWriteApi + ErrorApi + Clone + 'static;
-
-	/// Abstracts the call value handling at the beginning of a function call.
-	type CallValue: CallValueApi<BigUint> + ErrorApi + Clone + 'static;
-
-	/// Abstracts the sending of EGLD & ESDT transactions, as well as async calls.
-	type SendApi: SendApi<BigUint> + Clone + 'static;
-
-	/// Gateway into the lower-level storage functionality.
-	/// Storage related annotations make use of this.
-	/// Using it directly is not recommended.
-	fn get_storage_raw(&self) -> Self::Storage;
-
-	/// Gateway into the call value retrieval functionality.
-	/// The payment annotations should normally be the ones to handle this,
-	/// but the developer is also given direct access to the API.
-	fn call_value(&self) -> Self::CallValue;
-
-	/// Gateway to the functionality related to sending transactions from the current contract.
-	fn send(&self) -> Self::SendApi;
-
 	fn get_sc_address(&self) -> Address;
 
 	fn get_owner_address(&self) -> Address;
@@ -53,14 +26,6 @@ where
 
 	fn get_sc_balance(&self) -> BigUint {
 		self.get_balance(&self.get_sc_address())
-	}
-
-	#[inline]
-	fn storage_load_cumulated_validator_reward(&self) -> BigUint {
-		storage::storage_get(
-			self.get_storage_raw(),
-			storage::protected_keys::ELROND_REWARD_KEY,
-		)
 	}
 
 	fn get_tx_hash(&self) -> H256;

--- a/elrond-wasm/src/api/contract_self_api.rs
+++ b/elrond-wasm/src/api/contract_self_api.rs
@@ -1,0 +1,59 @@
+use super::{
+	BigIntApi, BigUintApi, BlockchainApi, CallValueApi, CryptoApi, ErrorApi, SendApi,
+	StorageReadApi, StorageWriteApi,
+};
+use crate::storage;
+
+/// Interface to be used by the actual smart contract code.
+///
+/// Note: contracts and the api are not mutable.
+/// They simply pass on/retrieve data to/from the protocol.
+/// When mocking the blockchain state, we use the Rc/RefCell pattern
+/// to isolate mock state mutability from the contract interface.
+pub trait ContractSelfApi<BigInt, BigUint>: Sized
+where
+	BigInt: BigIntApi<BigUint> + 'static,
+	BigUint: BigUintApi + 'static,
+{
+	/// Abstracts the lower-level storage functionality.
+	type Storage: StorageReadApi + StorageWriteApi + ErrorApi + Clone + 'static;
+
+	/// Abstracts the call value handling at the beginning of a function call.
+	type CallValue: CallValueApi<BigUint> + ErrorApi + Clone + 'static;
+
+	/// Abstracts the sending of EGLD & ESDT transactions, as well as async calls.
+	type SendApi: SendApi<BigUint> + Clone + 'static;
+
+	type BlockchainApi: BlockchainApi<BigUint> + Clone + 'static;
+
+	type CryptoApi: CryptoApi + Clone + 'static;
+
+	/// Gateway into the lower-level storage functionality.
+	/// Storage related annotations make use of this.
+	/// Using it directly is not recommended.
+	fn get_storage_raw(&self) -> Self::Storage;
+
+	/// Gateway into the call value retrieval functionality.
+	/// The payment annotations should normally be the ones to handle this,
+	/// but the developer is also given direct access to the API.
+	fn call_value(&self) -> Self::CallValue;
+
+	/// Gateway to the functionality related to sending transactions from the current contract.
+	fn send(&self) -> Self::SendApi;
+
+	/// Gateway blockchain info related to the current transaction and to accounts.
+	fn blockchain(&self) -> Self::BlockchainApi;
+
+	/// Stateless crypto functions provided by the Arwen VM.
+	fn crypto(&self) -> Self::CryptoApi;
+
+	/// Retrieves validator rewards, as set by the protocol.
+	/// TODO: move to the storage API, once BigUint gets refactored
+	#[inline]
+	fn storage_load_cumulated_validator_reward(&self) -> BigUint {
+		storage::storage_get(
+			self.get_storage_raw(),
+			storage::protected_keys::ELROND_REWARD_KEY,
+		)
+	}
+}

--- a/elrond-wasm/src/api/mod.rs
+++ b/elrond-wasm/src/api/mod.rs
@@ -1,9 +1,10 @@
 mod big_int_api;
 mod big_uint_api;
+mod blockchain_api;
 mod call_value_api;
 mod callable_contract_api;
 mod contract_abi_api;
-mod contract_api;
+mod contract_self_api;
 mod crypto_api;
 mod endpoint_arg_api;
 mod endpoint_finish_api;
@@ -14,10 +15,11 @@ mod storage_api;
 
 pub use big_int_api::*;
 pub use big_uint_api::*;
+pub use blockchain_api::*;
 pub use call_value_api::*;
 pub use callable_contract_api::*;
 pub use contract_abi_api::*;
-pub use contract_api::*;
+pub use contract_self_api::*;
 pub use crypto_api::*;
 pub use endpoint_arg_api::*;
 pub use endpoint_finish_api::*;

--- a/elrond-wasm/src/macros.rs
+++ b/elrond-wasm/src/macros.rs
@@ -15,7 +15,9 @@ macro_rules! imports {
 		use core::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
 		use core::ops::{BitAnd, BitOr, BitXor, Shl, Shr};
 		use core::ops::{BitAndAssign, BitOrAssign, BitXorAssign, ShlAssign, ShrAssign};
-		use elrond_wasm::api::{BigIntApi, BigUintApi, CallValueApi, ContractHookApi, SendApi};
+		use elrond_wasm::api::{
+			BigIntApi, BigUintApi, BlockchainApi, CallValueApi, ContractSelfApi, CryptoApi, SendApi,
+		};
 		use elrond_wasm::elrond_codec::{DecodeError, NestedDecode, NestedEncode, TopDecode};
 		use elrond_wasm::err_msg;
 		use elrond_wasm::esdt::*;
@@ -68,14 +70,15 @@ macro_rules! sc_try {
 ///
 /// ```rust
 /// # use elrond_wasm::*;
+/// # use elrond_wasm::api::BlockchainApi;
 /// # use elrond_wasm::types::{*, SCResult::Ok};
-/// # pub trait ExampleContract<BigInt, BigUint>: elrond_wasm::api::ContractHookApi<BigInt, BigUint>
+/// # pub trait ExampleContract<BigInt, BigUint>: elrond_wasm::api::ContractSelfApi<BigInt, BigUint>
 /// # where
 /// #   BigInt: elrond_wasm::api::BigIntApi<BigUint> + 'static,
 /// #   BigUint: elrond_wasm::api::BigUintApi + 'static,
 /// # {
 /// fn only_callable_by_owner(&self) -> SCResult<()> {
-///     require!(self.get_caller() == self.get_owner_address(), "Caller must be owner");
+///     require!(self.blockchain().get_caller() == self.blockchain().get_owner_address(), "Caller must be owner");
 ///     Ok(())
 /// }
 /// # }
@@ -95,8 +98,9 @@ macro_rules! require {
 ///
 /// ```rust
 /// # use elrond_wasm::*;
+/// # use elrond_wasm::api::BlockchainApi;
 /// # use elrond_wasm::types::{*, SCResult::Ok};
-/// # pub trait ExampleContract<BigInt, BigUint>: elrond_wasm::api::ContractHookApi<BigInt, BigUint>
+/// # pub trait ExampleContract<BigInt, BigUint>: elrond_wasm::api::ContractSelfApi<BigInt, BigUint>
 /// # where
 /// #   BigInt: elrond_wasm::api::BigIntApi<BigUint> + 'static,
 /// #   BigUint: elrond_wasm::api::BigUintApi + 'static,
@@ -110,7 +114,7 @@ macro_rules! require {
 #[macro_export]
 macro_rules! only_owner {
 	($trait_self: expr, $error_msg:expr) => {
-		if ($trait_self.get_caller() != $trait_self.get_owner_address()) {
+		if ($trait_self.blockchain().get_caller() != $trait_self.blockchain().get_owner_address()) {
 			return sc_error!($error_msg);
 		}
 	};


### PR DESCRIPTION
These last 2 API traits were still residing in the contract "self". Split them off. This leaves the constract API with just references to the other APIs.