### PR TITLE
added esdt transfer and send functions for any ESDT

### DIFF
--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -77,7 +77,8 @@ where
 	}
 
 	/// Sends ESDT tokens to the target address. Handles any type of ESDT.
-	fn transfer_esdt(&self, token: &TokenIdentifier, nonce: u64, amount: &BigUint, to: &Address) {
+	/// Note: this does not work with EGLD, use only with ESDT.
+	fn transfer_tokens(&self, token: &TokenIdentifier, nonce: u64, amount: &BigUint, to: &Address) {
 		if amount > &0 {
 			if nonce == 0 {
 				let _ =
@@ -296,7 +297,8 @@ where
 	}
 
 	/// Burns ESDT tokens. Handles any type of ESDT.
-	fn burn_esdt(&self, token: &TokenIdentifier, nonce: u64, amount: &BigUint, gas: u64) {
+	/// Note: this does not work with EGLD, use only with ESDT.
+	fn burn_tokens(&self, token: &TokenIdentifier, nonce: u64, amount: &BigUint, gas: u64) {
 		if amount > &0 {
 			if nonce == 0 {
 				self.esdt_local_burn(gas, token.as_esdt_identifier(), amount);

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -76,6 +76,24 @@ where
 		}
 	}
 
+	/// Sends ESDT tokens to the target address. Handles any type of ESDT.
+	fn transfer_esdt(&self, token: &TokenIdentifier, nonce: u64, amount: &BigUint, to: &Address) {
+		if amount > &0 {
+			if nonce == 0 {
+				let _ =
+					self.direct_esdt_via_transf_exec(to, token.as_esdt_identifier(), amount, &[]);
+			} else {
+				let _ = self.direct_esdt_nft_via_transfer_exec(
+					to,
+					token.as_esdt_identifier(),
+					nonce,
+					amount,
+					&[],
+				);
+			}
+		}
+	}
+
 	/// Performs a simple ESDT transfer, but via async call.
 	/// This is the preferred way to send ESDT.
 	fn direct_esdt_via_async_call(
@@ -275,6 +293,17 @@ where
 		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
 
 		self.call_local_esdt_built_in_function(gas, b"ESDTNFTBurn", &arg_buffer);
+	}
+
+	/// Burns ESDT tokens. Handles any type of ESDT.
+	fn burn_esdt(&self, token: &TokenIdentifier, nonce: u64, amount: &BigUint, gas: u64) {
+		if amount > &0 {
+			if nonce == 0 {
+				self.esdt_local_burn(gas, token.as_esdt_identifier(), amount);
+			} else {
+				self.esdt_nft_burn(gas, token.as_esdt_identifier(), nonce, amount);
+			}
+		}
 	}
 
 	/// Performs a simple ESDT NFT transfer, but via async call.


### PR DESCRIPTION
Identified this as being a case where a lot of contracts might do the handle independently, each on their own.
Think it's best we do the handling in the framework.