### PR TITLE
Call proxy redesign - `#[proxy]` getter

### DIFF
--- a/contracts/examples/crowdfunding-erc20/src/lib.rs
+++ b/contracts/examples/crowdfunding-erc20/src/lib.rs
@@ -131,7 +131,7 @@ pub trait Crowdfunding {
 	// proxy
 
 	#[proxy]
-	fn erc20_proxy(&self, to: Address) -> erc20::ProxyObj<Self::SendApi>;
+	fn erc20_proxy(&self, to: Address) -> erc20::Proxy<Self::SendApi>;
 
 	// storage
 

--- a/contracts/examples/crowdfunding-erc20/src/lib.rs
+++ b/contracts/examples/crowdfunding-erc20/src/lib.rs
@@ -12,8 +12,6 @@ pub enum Status {
 	Failed,
 }
 
-use erc20::Proxy as _; // currently needed for contract calls, TODO: better syntax
-
 #[elrond_wasm_derive::contract]
 pub trait Crowdfunding {
 	#[init]
@@ -36,7 +34,8 @@ pub trait Crowdfunding {
 		let erc20_address = self.get_erc20_contract_address();
 		let cf_contract_address = self.blockchain().get_sc_address();
 
-		Ok(erc20::ProxyObj::new_proxy_obj(self.send(), erc20_address)
+		Ok(self
+			.erc20_proxy(erc20_address)
 			.transfer_from(caller.clone(), cf_contract_address, token_amount.clone())
 			.async_call()
 			.with_callback(
@@ -71,7 +70,7 @@ pub trait Crowdfunding {
 
 				let erc20_address = self.get_erc20_contract_address();
 				Ok(OptionalResult::Some(
-					erc20::ProxyObj::new_proxy_obj(self.send(), erc20_address)
+					self.erc20_proxy(erc20_address)
 						.transfer(caller, balance)
 						.async_call(),
 				))
@@ -85,7 +84,7 @@ pub trait Crowdfunding {
 
 					let erc20_address = self.get_erc20_contract_address();
 					Ok(OptionalResult::Some(
-						erc20::ProxyObj::new_proxy_obj(self.send(), erc20_address)
+						self.erc20_proxy(erc20_address)
 							.transfer(caller, deposit)
 							.async_call(),
 					))
@@ -109,7 +108,7 @@ pub trait Crowdfunding {
 				if self.blockchain().get_block_nonce() > self.get_deadline() {
 					let erc20_address = self.get_erc20_contract_address();
 					return OptionalResult::Some(
-						erc20::ProxyObj::new_proxy_obj(self.send(), erc20_address)
+						self.erc20_proxy(erc20_address)
 							.transfer(cb_sender, cb_amount)
 							.async_call(),
 					);
@@ -128,6 +127,11 @@ pub trait Crowdfunding {
 			AsyncCallResult::Err(_) => OptionalResult::None,
 		}
 	}
+
+	// proxy
+
+	#[proxy]
+	fn erc20_proxy(&self, to: Address) -> erc20::ProxyObj<Self::SendApi>;
 
 	// storage
 

--- a/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
@@ -6,8 +6,6 @@ elrond_wasm::imports!();
 pub mod auction;
 use auction::*;
 
-use kitty_ownership::Proxy as _;
-
 #[elrond_wasm_derive::contract]
 pub trait KittyAuction {
 	#[init]
@@ -46,13 +44,11 @@ pub trait KittyAuction {
 		let kitty_ownership_contract_address =
 			self._get_kitty_ownership_contract_address_or_default();
 		if kitty_ownership_contract_address != Address::zero() {
-			Ok(kitty_ownership::ProxyObj::new_proxy_obj(
-				self.send(),
-				kitty_ownership_contract_address,
-			)
-			.create_gen_zero_kitty()
-			.async_call()
-			.with_callback(self.callbacks().create_gen_zero_kitty_callback()))
+			Ok(self
+				.kitty_ownership_proxy(kitty_ownership_contract_address)
+				.create_gen_zero_kitty()
+				.async_call()
+				.with_callback(self.callbacks().create_gen_zero_kitty_callback()))
 		} else {
 			sc_error!("Kitty Ownership contract address not set!")
 		}
@@ -245,20 +241,17 @@ pub trait KittyAuction {
 			self._get_kitty_ownership_contract_address_or_default();
 		if kitty_ownership_contract_address != Address::zero() {
 			OptionalResult::Some(
-				kitty_ownership::ProxyObj::new_proxy_obj(
-					self.send(),
-					kitty_ownership_contract_address,
-				)
-				.allow_auctioning(caller.clone(), kitty_id)
-				.async_call()
-				.with_callback(self.callbacks().allow_auctioning_callback(
-					auction_type,
-					kitty_id,
-					starting_price,
-					ending_price,
-					deadline,
-					caller,
-				)),
+				self.kitty_ownership_proxy(kitty_ownership_contract_address)
+					.allow_auctioning(caller.clone(), kitty_id)
+					.async_call()
+					.with_callback(self.callbacks().allow_auctioning_callback(
+						auction_type,
+						kitty_id,
+						starting_price,
+						ending_price,
+						deadline,
+						caller,
+					)),
 			)
 		} else {
 			OptionalResult::None
@@ -291,13 +284,10 @@ pub trait KittyAuction {
 			self._get_kitty_ownership_contract_address_or_default();
 		if kitty_ownership_contract_address != Address::zero() {
 			OptionalResult::Some(
-				kitty_ownership::ProxyObj::new_proxy_obj(
-					self.send(),
-					kitty_ownership_contract_address,
-				)
-				.transfer(address, kitty_id)
-				.async_call()
-				.with_callback(self.callbacks().transfer_callback(kitty_id)),
+				self.kitty_ownership_proxy(kitty_ownership_contract_address)
+					.transfer(address, kitty_id)
+					.async_call()
+					.with_callback(self.callbacks().transfer_callback(kitty_id)),
 			)
 		} else {
 			OptionalResult::None
@@ -314,14 +304,11 @@ pub trait KittyAuction {
 			self._get_kitty_ownership_contract_address_or_default();
 		if kitty_ownership_contract_address != Address::zero() {
 			OptionalResult::Some(
-				kitty_ownership::ProxyObj::new_proxy_obj(
-					self.send(),
-					kitty_ownership_contract_address,
-				)
-				.approve_siring_and_return_kitty(approved_address, kitty_owner, kitty_id)
-				// not a mistake, same callback for transfer and approveSiringAndReturnKitty
-				.async_call()
-				.with_callback(self.callbacks().transfer_callback(kitty_id)),
+				self.kitty_ownership_proxy(kitty_ownership_contract_address)
+					.approve_siring_and_return_kitty(approved_address, kitty_owner, kitty_id)
+					// not a mistake, same callback for transfer and approveSiringAndReturnKitty
+					.async_call()
+					.with_callback(self.callbacks().transfer_callback(kitty_id)),
 			)
 		} else {
 			OptionalResult::None
@@ -430,6 +417,11 @@ pub trait KittyAuction {
 			},
 		}
 	}
+
+	// proxy
+
+	#[proxy]
+	fn kitty_ownership_proxy(&self, to: Address) -> kitty_ownership::ProxyObj<Self::SendApi>;
 
 	// storage
 

--- a/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
@@ -421,7 +421,7 @@ pub trait KittyAuction {
 	// proxy
 
 	#[proxy]
-	fn kitty_ownership_proxy(&self, to: Address) -> kitty_ownership::ProxyObj<Self::SendApi>;
+	fn kitty_ownership_proxy(&self, to: Address) -> kitty_ownership::Proxy<Self::SendApi>;
 
 	// storage
 

--- a/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
@@ -6,8 +6,6 @@ elrond_wasm::imports!();
 use kitty::{kitty_genes::*, Kitty};
 use random::*;
 
-use kitty_genetic_alg::Proxy as _;
-
 #[elrond_wasm_derive::contract]
 pub trait KittyOwnership {
 	#[init]
@@ -363,16 +361,14 @@ pub trait KittyOwnership {
 
 		let gene_science_contract_address = self._get_gene_science_contract_address_or_default();
 		if gene_science_contract_address != Address::zero() {
-			Ok(kitty_genetic_alg::ProxyObj::new_proxy_obj(
-				self.send(),
-				gene_science_contract_address,
-			)
-			.generate_kitty_genes(matron, sire)
-			.async_call()
-			.with_callback(
-				self.callbacks()
-					.generate_kitty_genes_callback(matron_id, self.blockchain().get_caller()),
-			))
+			Ok(self
+				.kitty_genetic_alg_proxy(gene_science_contract_address)
+				.generate_kitty_genes(matron, sire)
+				.async_call()
+				.with_callback(
+					self.callbacks()
+						.generate_kitty_genes_callback(matron_id, self.blockchain().get_caller()),
+				))
 		} else {
 			sc_error!("Gene science contract address not set!")
 		}
@@ -612,6 +608,11 @@ pub trait KittyOwnership {
 			},
 		}
 	}
+
+	// proxy
+
+	#[proxy]
+	fn kitty_genetic_alg_proxy(&self, to: Address) -> kitty_genetic_alg::ProxyObj<Self::SendApi>;
 
 	// storage - General
 

--- a/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
@@ -612,7 +612,7 @@ pub trait KittyOwnership {
 	// proxy
 
 	#[proxy]
-	fn kitty_genetic_alg_proxy(&self, to: Address) -> kitty_genetic_alg::ProxyObj<Self::SendApi>;
+	fn kitty_genetic_alg_proxy(&self, to: Address) -> kitty_genetic_alg::Proxy<Self::SendApi>;
 
 	// storage - General
 

--- a/contracts/examples/erc1155-marketplace/src/lib.rs
+++ b/contracts/examples/erc1155-marketplace/src/lib.rs
@@ -396,7 +396,7 @@ pub trait Erc1155Marketplace {
 	// proxy
 
 	#[proxy]
-	fn erc1155_proxy(&self, to: Address) -> erc1155::ProxyObj<Self::SendApi>;
+	fn erc1155_proxy(&self, to: Address) -> erc1155::Proxy<Self::SendApi>;
 
 	// storage
 

--- a/contracts/examples/erc1155-marketplace/src/lib.rs
+++ b/contracts/examples/erc1155-marketplace/src/lib.rs
@@ -26,8 +26,6 @@ pub struct AuctionArgument<BigUint: BigUintApi> {
 	pub deadline: u64,
 }
 
-use erc1155::Proxy as _;
-
 #[elrond_wasm_derive::contract]
 pub trait Erc1155Marketplace {
 	/// `bid_cut_percentage` is the cut that the contract takes from any sucessful bid
@@ -360,7 +358,7 @@ pub trait Erc1155Marketplace {
 		let sc_own_address = self.blockchain().get_sc_address();
 		let token_ownership_contract_address = self.token_ownership_contract_address().get();
 
-		erc1155::ProxyObj::new_proxy_obj(self.send(), token_ownership_contract_address)
+		self.erc1155_proxy(token_ownership_contract_address)
 			.safe_transfer_from(sc_own_address, to, type_id, nft_id, &[])
 			.async_call()
 	}
@@ -394,6 +392,11 @@ pub trait Erc1155Marketplace {
 			data
 		}
 	}
+
+	// proxy
+
+	#[proxy]
+	fn erc1155_proxy(&self, to: Address) -> erc1155::ProxyObj<Self::SendApi>;
 
 	// storage
 

--- a/contracts/examples/lottery-erc20/src/lib.rs
+++ b/contracts/examples/lottery-erc20/src/lib.rs
@@ -17,7 +17,7 @@ const THIRTY_DAYS_IN_SECONDS: u64 = 60 * 60 * 24 * 30;
 #[elrond_wasm_derive::contract]
 pub trait Lottery {
 	#[proxy]
-	fn erc20_proxy(&self, to: Address) -> erc20::ProxyObj<Self::SendApi>;
+	fn erc20_proxy(&self, to: Address) -> erc20::Proxy<Self::SendApi>;
 
 	#[init]
 	fn init(&self, erc20_contract_address: Address) {

--- a/contracts/feature-tests/async/async-alice/src/lib.rs
+++ b/contracts/feature-tests/async/async-alice/src/lib.rs
@@ -36,10 +36,10 @@ mod message_me_proxy {
 #[elrond_wasm_derive::contract]
 pub trait Alice {
 	#[proxy]
-	fn pay_me_proxy(&self, to: Address) -> pay_me_proxy::ProxyObj<Self::SendApi>;
+	fn pay_me_proxy(&self, to: Address) -> pay_me_proxy::Proxy<Self::SendApi>;
 
 	#[proxy]
-	fn message_me_proxy(&self, to: Address) -> message_me_proxy::ProxyObj<Self::SendApi>;
+	fn message_me_proxy(&self, to: Address) -> message_me_proxy::Proxy<Self::SendApi>;
 
 	#[storage_get("other_contract")]
 	fn get_other_contract(&self) -> Address;

--- a/contracts/feature-tests/async/forwarder/src/call_async.rs
+++ b/contracts/feature-tests/async/forwarder/src/call_async.rs
@@ -69,7 +69,7 @@ pub trait ForwarderAsyncCallModule {
 		token_identifier: &TokenIdentifier,
 		amount: &Self::BigUint,
 	) -> AsyncCall<Self::SendApi> {
-		vault::ProxyObj::new_proxy_obj(self.send(), to.clone())
+		self.vault_proxy(to.clone())
 			.accept_funds(token_identifier.clone(), amount.clone())
 			.async_call()
 			.with_callback(
@@ -85,7 +85,7 @@ pub trait ForwarderAsyncCallModule {
 		token_identifier: &TokenIdentifier,
 		cb_amount: &Self::BigUint,
 	) -> AsyncCall<Self::SendApi> {
-		vault::ProxyObj::new_proxy_obj(self.send(), to.clone())
+		self.vault_proxy(to.clone())
 			.accept_funds(token_identifier.clone(), cb_amount.clone())
 			.async_call()
 	}

--- a/contracts/feature-tests/async/forwarder/src/call_async.rs
+++ b/contracts/feature-tests/async/forwarder/src/call_async.rs
@@ -2,8 +2,6 @@ elrond_wasm::imports!();
 
 type CallbackDataTuple<BigUint> = (BoxedBytes, TokenIdentifier, BigUint, Vec<BoxedBytes>);
 
-use vault::Proxy as _; // currently needed for contract calls, TODO: better syntax
-
 #[elrond_wasm_derive::module]
 pub trait ForwarderAsyncCallModule {
 	#[proxy]

--- a/contracts/feature-tests/async/forwarder/src/call_async.rs
+++ b/contracts/feature-tests/async/forwarder/src/call_async.rs
@@ -6,6 +6,9 @@ use vault::Proxy as _; // currently needed for contract calls, TODO: better synt
 
 #[elrond_wasm_derive::module]
 pub trait ForwarderAsyncCallModule {
+	#[proxy]
+	fn vault_proxy(&self, to: Address) -> vault::ProxyObj<Self::SendApi>;
+
 	#[endpoint]
 	#[payable("*")]
 	fn forward_async_accept_funds(
@@ -14,7 +17,7 @@ pub trait ForwarderAsyncCallModule {
 		#[payment_token] token: TokenIdentifier,
 		#[payment] payment: Self::BigUint,
 	) -> AsyncCall<Self::SendApi> {
-		vault::ProxyObj::new_proxy_obj(self.send(), to)
+		self.vault_proxy(to)
 			.accept_funds(token, payment)
 			.async_call()
 	}
@@ -28,7 +31,7 @@ pub trait ForwarderAsyncCallModule {
 		#[payment] payment: Self::BigUint,
 	) -> AsyncCall<Self::SendApi> {
 		let half_payment = payment / 2u32.into();
-		vault::ProxyObj::new_proxy_obj(self.send(), to)
+		self.vault_proxy(to)
 			.accept_funds(token, half_payment)
 			.async_call()
 	}
@@ -41,7 +44,7 @@ pub trait ForwarderAsyncCallModule {
 		token: TokenIdentifier,
 		payment: Self::BigUint,
 	) -> AsyncCall<Self::SendApi> {
-		vault::ProxyObj::new_proxy_obj(self.send(), to)
+		self.vault_proxy(to)
 			.retrieve_funds(token, payment, OptionalArg::None)
 			.async_call()
 			.with_callback(self.callbacks().retrieve_funds_callback())

--- a/contracts/feature-tests/async/forwarder/src/call_async.rs
+++ b/contracts/feature-tests/async/forwarder/src/call_async.rs
@@ -5,7 +5,7 @@ type CallbackDataTuple<BigUint> = (BoxedBytes, TokenIdentifier, BigUint, Vec<Box
 #[elrond_wasm_derive::module]
 pub trait ForwarderAsyncCallModule {
 	#[proxy]
-	fn vault_proxy(&self, to: Address) -> vault::ProxyObj<Self::SendApi>;
+	fn vault_proxy(&self, to: Address) -> vault::Proxy<Self::SendApi>;
 
 	#[endpoint]
 	#[payable("*")]

--- a/contracts/feature-tests/async/forwarder/src/call_sync.rs
+++ b/contracts/feature-tests/async/forwarder/src/call_sync.rs
@@ -3,7 +3,7 @@ elrond_wasm::imports!();
 #[elrond_wasm_derive::module]
 pub trait ForwarderSyncCallModule {
 	#[proxy]
-	fn vault_proxy(&self, to: Address) -> vault::ProxyObj<Self::SendApi>;
+	fn vault_proxy(&self, to: Address) -> vault::Proxy<Self::SendApi>;
 
 	#[endpoint]
 	#[payable("*")]

--- a/contracts/feature-tests/async/recursive-caller/src/lib.rs
+++ b/contracts/feature-tests/async/recursive-caller/src/lib.rs
@@ -6,10 +6,10 @@ elrond_wasm::imports!();
 #[elrond_wasm_derive::contract]
 pub trait RecursiveCaller {
 	#[proxy]
-	fn vault_proxy(&self, to: Address) -> vault::ProxyObj<Self::SendApi>;
+	fn vault_proxy(&self, to: Address) -> vault::Proxy<Self::SendApi>;
 
 	#[proxy]
-	fn self_proxy(&self, to: Address) -> self::ProxyObj<Self::SendApi>;
+	fn self_proxy(&self, to: Address) -> self::Proxy<Self::SendApi>;
 
 	#[init]
 	fn init(&self) {}

--- a/contracts/feature-tests/async/recursive-caller/src/lib.rs
+++ b/contracts/feature-tests/async/recursive-caller/src/lib.rs
@@ -2,11 +2,15 @@
 
 elrond_wasm::imports!();
 
-use vault::Proxy as _; // currently needed for contract calls, TODO: better syntax
-
 /// Test contract for investigating async calls.
 #[elrond_wasm_derive::contract]
 pub trait RecursiveCaller {
+	#[proxy]
+	fn vault_proxy(&self, to: Address) -> vault::ProxyObj<Self::SendApi>;
+
+	#[proxy]
+	fn self_proxy(&self, to: Address) -> self::ProxyObj<Self::SendApi>;
+
 	#[init]
 	fn init(&self) {}
 
@@ -20,7 +24,7 @@ pub trait RecursiveCaller {
 	) -> AsyncCall<Self::SendApi> {
 		self.recursive_send_funds_event(to, token_identifier, amount, counter);
 
-		vault::ProxyObj::new_proxy_obj(self.send(), to.clone())
+		self.vault_proxy(to.clone())
 			.accept_funds(token_identifier.clone(), amount.clone())
 			.async_call()
 			.with_callback(self.callbacks().recursive_send_funds_callback(
@@ -43,7 +47,7 @@ pub trait RecursiveCaller {
 
 		if counter > 1 {
 			OptionalResult::Some(
-				self::ProxyObj::new_proxy_obj(self.send(), self.blockchain().get_sc_address())
+				self.self_proxy(self.blockchain().get_sc_address())
 					.recursive_send_funds(&to, token_identifier, amount, counter - 1)
 					.async_call(),
 			)

--- a/contracts/feature-tests/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
+++ b/contracts/feature-tests/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
@@ -9,7 +9,7 @@ const ISSUE_EXPECTED_GAS_COST: u64 = 90_000_000 + 25_000_000;
 #[elrond_wasm_derive::contract]
 pub trait Parent {
 	#[proxy]
-	fn child_proxy(&self, to: Address) -> child::ProxyObj<Self::SendApi>;
+	fn child_proxy(&self, to: Address) -> child::Proxy<Self::SendApi>;
 
 	#[init]
 	fn init(&self) {}

--- a/contracts/feature-tests/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
+++ b/contracts/feature-tests/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
@@ -6,10 +6,11 @@ elrond_wasm::imports!();
 // Base cost for standalone + estimate cost of actual sc call
 const ISSUE_EXPECTED_GAS_COST: u64 = 90_000_000 + 25_000_000;
 
-use child::Proxy as _;
-
 #[elrond_wasm_derive::contract]
 pub trait Parent {
+	#[proxy]
+	fn child_proxy(&self, to: Address) -> child::ProxyObj<Self::SendApi>;
+
 	#[init]
 	fn init(&self) {}
 
@@ -40,7 +41,7 @@ pub trait Parent {
 		#[payment] issue_cost: Self::BigUint,
 	) {
 		let child_contract_adress = self.child_contract_address().get();
-		child::ProxyObj::new_proxy_obj(self.send(), child_contract_adress)
+		self.child_proxy(child_contract_adress)
 			.issue_wrapped_egld(token_display_name, token_ticker, initial_supply, issue_cost)
 			.execute_on_dest_context_ignore_result(ISSUE_EXPECTED_GAS_COST);
 	}

--- a/elrond-wasm-debug/tests/sample_adder.rs
+++ b/elrond-wasm-debug/tests/sample_adder.rs
@@ -186,7 +186,7 @@ mod module_1 {
 		}
 	}
 
-	pub trait Proxy: elrond_wasm::api::ProxyObjApi + Sized {
+	pub trait ProxyTrait: elrond_wasm::api::ProxyObjApi + Sized {
 		fn version(self) -> ContractCall<Self::SendApi, Self::BigInt> {
 			let (___api___, ___address___, ___token___, ___payment___) = self.into_fields();
 			let mut ___contract_call___ = elrond_wasm::types::new_contract_call(
@@ -403,7 +403,7 @@ mod sample_adder {
 		}
 	}
 
-	pub trait Proxy: elrond_wasm::api::ProxyObjApi + super::module_1::Proxy {
+	pub trait ProxyTrait: elrond_wasm::api::ProxyObjApi + super::module_1::ProxyTrait {
 		fn get_sum(self) -> elrond_wasm::types::ContractCall<Self::SendApi, Self::BigInt> {
 			let (___api___, ___address___, ___token___, ___payment___) = self.into_fields();
 			let mut ___contract_call___ = elrond_wasm::types::new_contract_call(
@@ -747,7 +747,7 @@ mod sample_adder {
 		ContractObj { api }
 	}
 
-	pub struct ProxyObj<SA>
+	pub struct Proxy<SA>
 	where
 		SA: elrond_wasm::api::SendApi + 'static,
 	{
@@ -757,12 +757,12 @@ mod sample_adder {
 		pub payment: SA::AmountType,
 	}
 
-	impl<SA> ProxyObj<SA>
+	impl<SA> Proxy<SA>
 	where
 		SA: elrond_wasm::api::SendApi + 'static,
 	{
 		pub fn new_proxy_obj(api: SA, address: Address) -> Self {
-			ProxyObj {
+			Proxy {
 				api,
 				address,
 				token: elrond_wasm::types::TokenIdentifier::egld(),
@@ -771,7 +771,7 @@ mod sample_adder {
 		}
 	}
 
-	impl<SA> elrond_wasm::api::ProxyObjApi for ProxyObj<SA>
+	impl<SA> elrond_wasm::api::ProxyObjApi for Proxy<SA>
 	where
 		SA: elrond_wasm::api::SendApi + 'static,
 	{
@@ -781,7 +781,7 @@ mod sample_adder {
 		type SendApi = SA;
 
 		fn new_proxy_obj(api: SA, address: Address) -> Self {
-			ProxyObj {
+			Proxy {
 				api,
 				address,
 				token: elrond_wasm::types::TokenIdentifier::egld(),
@@ -800,15 +800,15 @@ mod sample_adder {
 		}
 	}
 
-	impl<SA> super::module_1::Proxy for ProxyObj<SA> where SA: elrond_wasm::api::SendApi {}
+	impl<SA> super::module_1::ProxyTrait for Proxy<SA> where SA: elrond_wasm::api::SendApi {}
 
-	impl<SA> Proxy for ProxyObj<SA> where SA: elrond_wasm::api::SendApi {}
+	impl<SA> ProxyTrait for Proxy<SA> where SA: elrond_wasm::api::SendApi {}
 
-	pub fn new_proxy_obj<SA>(api: SA, address: Address) -> impl Proxy
+	pub fn new_proxy_obj<SA>(api: SA, address: Address) -> impl ProxyTrait
 	where
 		SA: elrond_wasm::api::SendApi + 'static,
 	{
-		ProxyObj::new_proxy_obj(api, address)
+		Proxy::new_proxy_obj(api, address)
 	}
 
 	pub struct CallbackProxyObj<SA>
@@ -857,7 +857,7 @@ fn test_add() {
 	use elrond_wasm::api::ContractBase;
 	use elrond_wasm_debug::api::RustBigInt;
 	use elrond_wasm_debug::TxContext;
-	use sample_adder::{Adder, EndpointWrappers, Proxy};
+	use sample_adder::{Adder, EndpointWrappers, ProxyTrait};
 	// use module_1::{VersionModule, EndpointWrappers};
 
 	let tx_context = TxContext::dummy();

--- a/elrond-wasm-derive/src/contract_impl.rs
+++ b/elrond-wasm-derive/src/contract_impl.rs
@@ -1,11 +1,13 @@
 use super::generate::{abi_gen, snippets};
-use crate::generate::auto_impl::generate_auto_impls;
 use crate::generate::callback_gen::*;
 use crate::generate::callback_proxies_gen::*;
 use crate::generate::contract_gen::*;
 use crate::generate::function_selector::generate_function_selector_body;
 use crate::generate::proxy_gen;
 use crate::generate::supertrait_gen;
+use crate::generate::{
+	auto_impl::generate_auto_impls, auto_impl_proxy::generate_all_proxy_trait_imports,
+};
 use crate::model::ContractTrait;
 
 /// Provides the implementation for both modules and contracts.
@@ -14,6 +16,7 @@ pub fn contract_implementation(
 	contract: &ContractTrait,
 	is_contract_main: bool,
 ) -> proc_macro2::TokenStream {
+	let proxy_trait_imports = generate_all_proxy_trait_imports(&contract);
 	let trait_name_ident = contract.trait_name.clone();
 	let method_impls = extract_method_impls(&contract);
 	let call_methods = generate_call_methods(&contract);
@@ -30,6 +33,8 @@ pub fn contract_implementation(
 	// this definition is common to release and debug mode
 	let supertraits_main = supertrait_gen::main_supertrait_decl(contract.supertraits.as_slice());
 	let main_definition = quote! {
+		#(#proxy_trait_imports)*
+
 		pub trait #trait_name_ident:
 		elrond_wasm::api::ContractBase
 		+ Sized

--- a/elrond-wasm-derive/src/generate/auto_impl.rs
+++ b/elrond-wasm-derive/src/generate/auto_impl.rs
@@ -39,7 +39,7 @@ fn generate_auto_impl(m: &Method, auto_impl: &AutoImpl) -> proc_macro2::TokenStr
 		AutoImpl::StorageMapper { identifier } => generate_mapper_impl(m, identifier),
 		AutoImpl::StorageIsEmpty { identifier } => generate_is_empty_impl(m, identifier),
 		AutoImpl::StorageClear { identifier } => generate_clear_impl(m, identifier),
-		AutoImpl::Proxy => generate_proxy_getter_impl(m),
+		AutoImpl::ProxyGetter => generate_proxy_getter_impl(m),
 		AutoImpl::Module { impl_path } => generate_module_getter_impl(m, &impl_path),
 	}
 }

--- a/elrond-wasm-derive/src/generate/auto_impl.rs
+++ b/elrond-wasm-derive/src/generate/auto_impl.rs
@@ -3,6 +3,7 @@ use crate::model::{AutoImpl, ContractTrait, Method, MethodImpl};
 use super::{
 	auto_impl_event::{generate_event_impl, generate_legacy_event_impl},
 	auto_impl_module::generate_module_getter_impl,
+	auto_impl_proxy::generate_proxy_getter_impl,
 	auto_impl_storage::{
 		generate_clear_impl, generate_getter_impl, generate_is_empty_impl, generate_mapper_impl,
 		generate_setter_impl,
@@ -30,14 +31,15 @@ pub fn generate_auto_impls(contract: &ContractTrait) -> Vec<proc_macro2::TokenSt
 fn generate_auto_impl(m: &Method, auto_impl: &AutoImpl) -> proc_macro2::TokenStream {
 	match auto_impl {
 		AutoImpl::LegacyEvent { identifier } => {
-			generate_legacy_event_impl(&m, identifier.as_slice())
+			generate_legacy_event_impl(m, identifier.as_slice())
 		},
-		AutoImpl::Event { identifier } => generate_event_impl(&m, identifier),
-		AutoImpl::StorageGetter { identifier } => generate_getter_impl(&m, identifier),
-		AutoImpl::StorageSetter { identifier } => generate_setter_impl(&m, identifier),
-		AutoImpl::StorageMapper { identifier } => generate_mapper_impl(&m, identifier),
-		AutoImpl::StorageIsEmpty { identifier } => generate_is_empty_impl(&m, identifier),
-		AutoImpl::StorageClear { identifier } => generate_clear_impl(&m, identifier),
-		AutoImpl::Module { impl_path } => generate_module_getter_impl(&m, &impl_path),
+		AutoImpl::Event { identifier } => generate_event_impl(m, identifier),
+		AutoImpl::StorageGetter { identifier } => generate_getter_impl(m, identifier),
+		AutoImpl::StorageSetter { identifier } => generate_setter_impl(m, identifier),
+		AutoImpl::StorageMapper { identifier } => generate_mapper_impl(m, identifier),
+		AutoImpl::StorageIsEmpty { identifier } => generate_is_empty_impl(m, identifier),
+		AutoImpl::StorageClear { identifier } => generate_clear_impl(m, identifier),
+		AutoImpl::Proxy => generate_proxy_getter_impl(m),
+		AutoImpl::Module { impl_path } => generate_module_getter_impl(m, &impl_path),
 	}
 }

--- a/elrond-wasm-derive/src/generate/auto_impl_proxy.rs
+++ b/elrond-wasm-derive/src/generate/auto_impl_proxy.rs
@@ -51,7 +51,7 @@ pub fn generate_proxy_getter_impl(m: &Method) -> proc_macro2::TokenStream {
 
 	quote! {
 		#msig {
-			#module_path ProxyObj::new_proxy_obj(self.send(), #address_arg_name)
+			#module_path Proxy::new_proxy_obj(self.send(), #address_arg_name)
 		}
 	}
 }
@@ -60,11 +60,11 @@ pub fn generate_all_proxy_trait_imports(c: &ContractTrait) -> Vec<proc_macro2::T
 	c.methods
 		.iter()
 		.filter_map(|m| {
-			if let MethodImpl::Generated(AutoImpl::Proxy) = &m.implementation {
+			if let MethodImpl::Generated(AutoImpl::ProxyGetter) = &m.implementation {
 				let parsed_return_type = proxy_getter_return_type(m);
 				let module_path = &parsed_return_type.module_path;
 				Some(quote! {
-					use #module_path Proxy as _;
+					use #module_path ProxyTrait as _;
 				})
 			} else {
 				None

--- a/elrond-wasm-derive/src/generate/auto_impl_proxy.rs
+++ b/elrond-wasm-derive/src/generate/auto_impl_proxy.rs
@@ -1,0 +1,53 @@
+use crate::{generate::method_gen, model::Method, parse::split_path_last};
+use syn::punctuated::Punctuated;
+use syn::token::Colon2;
+
+/// Path to a Rust module containing a contract call proxy.
+pub type ProxyModulePath = Punctuated<syn::PathSegment, Colon2>;
+
+pub struct ProxyGetterReturnType {
+	pub module_path: ProxyModulePath,
+	pub proxy_obj_name: syn::PathSegment,
+}
+
+/// Return type of the proxy getter method, split into module and type segment.
+pub fn proxy_getter_return_type(m: &Method) -> ProxyGetterReturnType {
+	match &m.return_type {
+		syn::ReturnType::Default => panic!(
+			"Missing return type from proxy getter `{}`",
+			m.name.to_string()
+		),
+		syn::ReturnType::Type(_, ty) => {
+			if let syn::Type::Path(type_path) = ty.as_ref() {
+				if let Some((leading_segments, last_segment)) = split_path_last(&type_path.path) {
+					ProxyGetterReturnType {
+						module_path: leading_segments,
+						proxy_obj_name: last_segment,
+					}
+				} else {
+					panic!("Proxy getter return type must be specfied with some module specifier (e.g. `path::to::module::Proxy`)");
+				}
+			} else {
+				panic!("Invalid proxy getter return type")
+			}
+		},
+	}
+}
+
+pub fn generate_proxy_getter_impl(m: &Method) -> proc_macro2::TokenStream {
+	assert!(
+		m.method_args.len() == 1,
+		"Proxy getter must have 1 argument, which is the target address"
+	);
+
+	let msig = method_gen::generate_sig(&m);
+	let address_arg_name = &m.method_args[0].pat;
+	let parsed_return_type = proxy_getter_return_type(m);
+	let module_path = &parsed_return_type.module_path;
+
+	quote! {
+		#msig {
+			#module_path ProxyObj::new_proxy_obj(self.send(), #address_arg_name)
+		}
+	}
+}

--- a/elrond-wasm-derive/src/generate/mod.rs
+++ b/elrond-wasm-derive/src/generate/mod.rs
@@ -4,6 +4,7 @@ pub mod arg_str_serialize;
 pub mod auto_impl;
 pub mod auto_impl_event;
 pub mod auto_impl_module;
+pub mod auto_impl_proxy;
 pub mod auto_impl_storage;
 pub mod callback_gen;
 pub mod callback_proxies_gen;

--- a/elrond-wasm-derive/src/generate/proxy_gen.rs
+++ b/elrond-wasm-derive/src/generate/proxy_gen.rs
@@ -107,7 +107,7 @@ pub fn proxy_trait(contract: &ContractTrait) -> proc_macro2::TokenStream {
 		supertrait_gen::proxy_supertrait_decl(contract.supertraits.as_slice());
 	let proxy_methods_impl = generate_method_impl(&contract);
 	quote! {
-		pub trait Proxy:
+		pub trait ProxyTrait:
 			elrond_wasm::api::ProxyObjApi
 			+ Sized
 			#(#proxy_supertrait_decl)*

--- a/elrond-wasm-derive/src/generate/snippets.rs
+++ b/elrond-wasm-derive/src/generate/snippets.rs
@@ -249,7 +249,7 @@ pub fn impl_callable_contract() -> proc_macro2::TokenStream {
 
 pub fn proxy_object_def() -> proc_macro2::TokenStream {
 	quote! {
-		pub struct ProxyObj<SA>
+		pub struct Proxy<SA>
 		where
 			SA: elrond_wasm::api::SendApi + 'static,
 		{
@@ -259,7 +259,7 @@ pub fn proxy_object_def() -> proc_macro2::TokenStream {
 			pub payment: SA::AmountType,
 		}
 
-		impl<SA> elrond_wasm::api::ProxyObjApi for ProxyObj<SA>
+		impl<SA> elrond_wasm::api::ProxyObjApi for Proxy<SA>
 		where
 			SA: elrond_wasm::api::SendApi + 'static,
 		{
@@ -269,7 +269,7 @@ pub fn proxy_object_def() -> proc_macro2::TokenStream {
 			type SendApi = SA;
 
 			fn new_proxy_obj(api: SA, address: Address) -> Self {
-				ProxyObj {
+				Proxy {
 					api,
 					address,
 					token: elrond_wasm::types::TokenIdentifier::egld(),

--- a/elrond-wasm-derive/src/generate/supertrait_gen.rs
+++ b/elrond-wasm-derive/src/generate/supertrait_gen.rs
@@ -42,7 +42,7 @@ pub fn proxy_supertrait_decl(supertraits: &[Supertrait]) -> Vec<proc_macro2::Tok
 		.map(|supertrait| {
 			let module_path = &supertrait.module_path;
 			quote! {
-				+ #module_path Proxy
+				+ #module_path ProxyTrait
 			}
 		})
 		.collect()
@@ -145,7 +145,7 @@ pub fn function_selector_module_calls(supertraits: &[Supertrait]) -> Vec<proc_ma
 
 fn impl_proxy_trait(module_path: &ModulePath) -> proc_macro2::TokenStream {
 	quote! {
-		impl<SA> #module_path Proxy for ProxyObj<SA> where SA: elrond_wasm::api::SendApi {}
+		impl<SA> #module_path ProxyTrait for Proxy<SA> where SA: elrond_wasm::api::SendApi {}
 	}
 }
 

--- a/elrond-wasm-derive/src/model/method.rs
+++ b/elrond-wasm-derive/src/model/method.rs
@@ -10,7 +10,7 @@ pub enum AutoImpl {
 	StorageMapper { identifier: String },
 	StorageIsEmpty { identifier: String },
 	StorageClear { identifier: String },
-	Proxy,
+	ProxyGetter,
 	Module { impl_path: proc_macro2::TokenTree },
 }
 #[derive(Clone, Debug)]

--- a/elrond-wasm-derive/src/model/method.rs
+++ b/elrond-wasm-derive/src/model/method.rs
@@ -10,6 +10,7 @@ pub enum AutoImpl {
 	StorageMapper { identifier: String },
 	StorageIsEmpty { identifier: String },
 	StorageClear { identifier: String },
+	Proxy,
 	Module { impl_path: proc_macro2::TokenTree },
 }
 #[derive(Clone, Debug)]

--- a/elrond-wasm-derive/src/parse/attributes/attr_names.rs
+++ b/elrond-wasm-derive/src/parse/attributes/attr_names.rs
@@ -19,3 +19,4 @@ pub(super) static ATTR_STORAGE_MAPPER: &str = "storage_mapper";
 pub(super) static ATTR_STORAGE_IS_EMPTY: &str = "storage_is_empty";
 pub(super) static ATTR_STORAGE_CLEAR: &str = "storage_clear";
 pub(super) static ATTR_MODULE: &str = "module";
+pub(super) static ATTR_PROXY: &str = "proxy";

--- a/elrond-wasm-derive/src/parse/attributes/endpoint_attr.rs
+++ b/elrond-wasm-derive/src/parse/attributes/endpoint_attr.rs
@@ -1,12 +1,16 @@
 use super::attr_names::*;
 use super::util::*;
 
+pub fn is_init(m: &syn::TraitItemMethod) -> bool {
+	has_attribute(&m.attrs, ATTR_INIT)
+}
+
 pub fn is_callback_raw_decl(m: &syn::TraitItemMethod) -> bool {
 	has_attribute(&m.attrs, ATTR_CALLBACK_RAW_DECL)
 }
 
-pub fn is_init(m: &syn::TraitItemMethod) -> bool {
-	has_attribute(&m.attrs, ATTR_INIT)
+pub fn is_proxy(m: &syn::TraitItemMethod) -> bool {
+	has_attribute(&m.attrs, ATTR_PROXY)
 }
 
 pub fn is_var_args(pat: &syn::PatType) -> bool {

--- a/elrond-wasm-derive/src/parse/method_impl_parse.rs
+++ b/elrond-wasm-derive/src/parse/method_impl_parse.rs
@@ -95,8 +95,7 @@ fn extract_auto_impl(m: &syn::TraitItemMethod) -> Option<AutoImpl> {
 
 	if is_proxy {
 		assert_no_other_auto_impl(&result);
-		// panic!("Hello proxy");
-		result = Some(AutoImpl::Proxy);
+		result = Some(AutoImpl::ProxyGetter);
 	}
 
 	if let Some(module_attr) = module_opt {

--- a/elrond-wasm-derive/src/parse/method_impl_parse.rs
+++ b/elrond-wasm-derive/src/parse/method_impl_parse.rs
@@ -19,12 +19,13 @@ pub fn process_method_impl(m: &syn::TraitItemMethod) -> MethodImpl {
 fn assert_no_other_auto_impl(auto_impl: &Option<AutoImpl>) {
 	assert!(
 		auto_impl.is_none(),
-		"Only one auto-implementation can be specified at one time. Auto-implementations are: {}{}{}{}{}{}{}{}",
+		"Only one auto-implementation can be specified at one time. Auto-implementations are: {}{}{}{}{}{}{}{}{}",
 		"`#[storage_get]`, ",
 		"`#[storage_set]`, ",
 		"`#[storage_mapper]`, ",
 		"`#[storage_is_empty]`, ",
 		"`#[storage_clear]`, ",
+		"`#[proxy]`, ",
 		"`#[module]`, ",
 		"`#[event]`, ",
 		"`#[legacy-event]`."
@@ -39,6 +40,7 @@ fn extract_auto_impl(m: &syn::TraitItemMethod) -> Option<AutoImpl> {
 	let storage_mapper_opt = StorageMapperAttribute::parse(m);
 	let storage_is_empty_opt = StorageIsEmptyAttribute::parse(m);
 	let storage_clear_opt = StorageClearAttribute::parse(m);
+	let is_proxy = is_proxy(m);
 	let module_opt = ModuleAttribute::parse(m);
 
 	let mut result = None;
@@ -89,6 +91,12 @@ fn extract_auto_impl(m: &syn::TraitItemMethod) -> Option<AutoImpl> {
 		result = Some(AutoImpl::StorageClear {
 			identifier: storage_clear.identifier,
 		});
+	}
+
+	if is_proxy {
+		assert_no_other_auto_impl(&result);
+		// panic!("Hello proxy");
+		result = Some(AutoImpl::Proxy);
 	}
 
 	if let Some(module_attr) = module_opt {

--- a/elrond-wasm-derive/src/parse/mod.rs
+++ b/elrond-wasm-derive/src/parse/mod.rs
@@ -7,6 +7,7 @@ mod method_impl_parse;
 mod method_parse;
 mod parse_util;
 mod payable_parse;
+mod split_path;
 mod supertrait_parse;
 
 pub use argument_parse::*;
@@ -14,4 +15,5 @@ pub use contract_trait_parse::*;
 pub use endpoint_parse::*;
 pub use method_parse::*;
 pub use payable_parse::*;
+pub use split_path::*;
 pub use supertrait_parse::*;

--- a/elrond-wasm-derive/src/parse/split_path.rs
+++ b/elrond-wasm-derive/src/parse/split_path.rs
@@ -1,0 +1,19 @@
+use syn::punctuated::Punctuated;
+use syn::token::Colon2;
+
+/// Splits off the last part of a path from the rest.
+/// e.g. `some::module::Item` will be split into `some::module::` and `Item`.
+/// Note that the last `::` is retained in the first part of the result.
+/// Returns none if no module is specified.
+/// The method is designed for contexts where explicit module specification is required.
+pub fn split_path_last(
+	path: &syn::Path,
+) -> Option<(Punctuated<syn::PathSegment, Colon2>, syn::PathSegment)> {
+	if path.segments.len() >= 2 {
+		let mut leading_segments = path.segments.clone();
+		let last_segment = leading_segments.pop().unwrap().into_value();
+		Some((leading_segments, last_segment))
+	} else {
+		None
+	}
+}

--- a/elrond-wasm-derive/src/parse/supertrait_parse.rs
+++ b/elrond-wasm-derive/src/parse/supertrait_parse.rs
@@ -1,19 +1,20 @@
-use crate::model::Supertrait;
+use crate::{model::Supertrait, parse::split_path_last};
 
 pub fn parse_supertrait(supertrait: &syn::TypeParamBound) -> Supertrait {
 	match supertrait {
 		syn::TypeParamBound::Trait(t) => {
-			assert!(t.path.segments.len() >= 2, "All contract module supertraits must be specfied with some module specifier (e.g. `path::to::module::ContractName`)");
-			let mut remaining_segments = t.path.segments.clone();
-			let last_segment = remaining_segments.pop().unwrap().into_value();
-			assert!(
-				last_segment.arguments.is_empty(),
-				"No generics allowed when specifying contract supertraits."
-			);
-			Supertrait {
-				full_path: t.path.clone(),
-				trait_name: last_segment,
-				module_path: remaining_segments,
+			if let Some((leading_segments, last_segment)) = split_path_last(&t.path) {
+				assert!(
+					last_segment.arguments.is_empty(),
+					"No generics allowed when specifying contract supertraits."
+				);
+				Supertrait {
+					full_path: t.path.clone(),
+					trait_name: last_segment,
+					module_path: leading_segments,
+				}
+			} else {
+				panic!("All contract module supertraits must be specfied with some module specifier (e.g. `path::to::module::ContractName`)");
 			}
 		},
 		_ => panic!("Contract trait can only extend other traits."),


### PR DESCRIPTION
Added `#[proxy]` getter syntax.
It has 2 roles:
- makes the syntax look cleaner
- automatically takes care of the `use module::ProxyTrait as _` imports

Note:
Avoid importing them from modules, the syntax will work but the import will not come automatically.