### PR TITLE
make nft hash variable length

### DIFF
--- a/contracts/feature-tests/async/forwarder/src/nft.rs
+++ b/contracts/feature-tests/async/forwarder/src/nft.rs
@@ -80,7 +80,7 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 		amount: Self::BigUint,
 		name: BoxedBytes,
 		royalties: Self::BigUint,
-		hash: H256,
+		hash: BoxedBytes,
 		color: Color,
 		uri: BoxedBytes,
 	) {

--- a/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
+++ b/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
@@ -107,7 +107,7 @@ pub trait LocalEsdtAndEsdtNft {
 		amount: Self::BigUint,
 		name: BoxedBytes,
 		royalties: Self::BigUint,
-		hash: H256,
+		hash: BoxedBytes,
 		color: Color,
 		uri: BoxedBytes,
 	) {

--- a/elrond-wasm-node/src/api/blockchain_api_node.rs
+++ b/elrond-wasm-node/src/api/blockchain_api_node.rs
@@ -251,7 +251,7 @@ impl BlockchainApi for ArwenApiImpl {
 		unsafe {
 			let value = bigIntNew(0);
 			let mut properties = [0u8; 2]; // always 2 bytes
-			let mut hash = [0u8; 128];
+			let mut hash = BoxedBytes::allocate(128);
 
 			let name_len = getESDTNFTNameLength(
 				address.as_ref().as_ptr(),
@@ -317,7 +317,7 @@ impl BlockchainApi for ArwenApiImpl {
 				token_type,
 				amount: ArwenBigUint { handle: value },
 				frozen,
-				hash: H256::zero(),
+				hash,
 				name: name_buffer,
 				attributes: attr_buffer,
 				creator,

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -2,9 +2,7 @@ use elrond_codec::TopEncode;
 
 use super::{BigIntApi, BigUintApi, ErrorApi, StorageReadApi, StorageWriteApi};
 use crate::hex_call_data::HexCallDataSerializer;
-use crate::types::{
-	Address, ArgBuffer, AsyncCall, BoxedBytes, CodeMetadata, TokenIdentifier, Vec, H256,
-};
+use crate::types::{Address, ArgBuffer, AsyncCall, BoxedBytes, CodeMetadata, TokenIdentifier, Vec};
 
 pub const ESDT_TRANSFER_STRING: &[u8] = b"ESDTTransfer";
 pub const ESDT_NFT_TRANSFER_STRING: &[u8] = b"ESDTNFTTransfer";
@@ -270,7 +268,7 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 		amount: &Self::AmountType,
 		name: &BoxedBytes,
 		royalties: &Self::AmountType,
-		hash: &H256,
+		hash: &BoxedBytes,
 		attributes: &T,
 		uris: &[BoxedBytes],
 	) {
@@ -279,7 +277,7 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
 		arg_buffer.push_argument_bytes(name.as_slice());
 		arg_buffer.push_argument_bytes(royalties.to_bytes_be().as_slice());
-		arg_buffer.push_argument_bytes(hash.as_bytes());
+		arg_buffer.push_argument_bytes(hash.as_slice());
 
 		let mut top_encoded_attributes = Vec::new();
 		let _ = attributes.top_encode(&mut top_encoded_attributes);

--- a/elrond-wasm/src/types/general/esdt_token_data.rs
+++ b/elrond-wasm/src/types/general/esdt_token_data.rs
@@ -2,13 +2,13 @@ use crate::{abi::TypeAbi, api::BigUintApi};
 use alloc::string::String;
 use elrond_codec::*;
 
-use super::{Address, BoxedBytes, EsdtTokenType, H256};
+use super::{Address, BoxedBytes, EsdtTokenType};
 
 pub struct EsdtTokenData<BigUint: BigUintApi> {
 	pub token_type: EsdtTokenType,
 	pub amount: BigUint,
 	pub frozen: bool,
-	pub hash: H256,
+	pub hash: BoxedBytes,
 	pub name: BoxedBytes,
 	pub attributes: BoxedBytes,
 	pub creator: Address,
@@ -81,7 +81,7 @@ impl<BigUint: BigUintApi> NestedDecode for EsdtTokenData<BigUint> {
 		let token_type = EsdtTokenType::dep_decode(input)?;
 		let amount = BigUint::dep_decode(input)?;
 		let frozen = bool::dep_decode(input)?;
-		let hash = H256::dep_decode(input)?;
+		let hash = BoxedBytes::dep_decode(input)?;
 		let name = BoxedBytes::dep_decode(input)?;
 		let attributes = BoxedBytes::dep_decode(input)?;
 		let creator = Address::dep_decode(input)?;
@@ -109,7 +109,7 @@ impl<BigUint: BigUintApi> NestedDecode for EsdtTokenData<BigUint> {
 		let token_type = EsdtTokenType::dep_decode_or_exit(input, c.clone(), exit);
 		let amount = BigUint::dep_decode_or_exit(input, c.clone(), exit);
 		let frozen = bool::dep_decode_or_exit(input, c.clone(), exit);
-		let hash = H256::dep_decode_or_exit(input, c.clone(), exit);
+		let hash = BoxedBytes::dep_decode_or_exit(input, c.clone(), exit);
 		let name = BoxedBytes::dep_decode_or_exit(input, c.clone(), exit);
 		let attributes = BoxedBytes::dep_decode_or_exit(input, c.clone(), exit);
 		let creator = Address::dep_decode_or_exit(input, c.clone(), exit);


### PR DESCRIPTION
Hash is now 128 bytes length.
SCs will have to know the hash length to make use of this and take the appropriate slice.