### PR TITLE
from_slice optimization

### DIFF
--- a/elrond-wasm/src/types/general/h256.rs
+++ b/elrond-wasm/src/types/general/h256.rs
@@ -60,12 +60,9 @@ impl From<Box<[u8; 32]>> for H256 {
 
 impl H256 {
 	pub fn from_slice(slice: &[u8]) -> Self {
-		let mut i = 0;
 		let mut arr = [0u8; 32];
-		while i < 32 && i < slice.len() {
-			arr[i] = slice[i];
-			i += 1;
-		}
+		let len = core::cmp::min(slice.len(), 32);
+		arr[..len].copy_from_slice(slice);
 		H256(Box::new(arr))
 	}
 }

--- a/elrond-wasm/src/types/general/h256.rs
+++ b/elrond-wasm/src/types/general/h256.rs
@@ -62,7 +62,7 @@ impl H256 {
 	pub fn from_slice(slice: &[u8]) -> Self {
 		let mut arr = [0u8; 32];
 		let len = core::cmp::min(slice.len(), 32);
-		arr[..len].copy_from_slice(slice);
+		arr[..len].copy_from_slice(&slice[..len]);
 		H256(Box::new(arr))
 	}
 }


### PR DESCRIPTION
Optimize from_slice to use copy_from_slice instead of manually copying each element in a while loop.