### PR TITLE
Framework functions cleanup

### DIFF
--- a/contracts/examples/crowdfunding-esdt/src/lib.rs
+++ b/contracts/examples/crowdfunding-esdt/src/lib.rs
@@ -58,8 +58,7 @@ pub trait Crowdfunding {
 		if token.is_egld() {
 			self.blockchain().get_sc_balance()
 		} else {
-			self.blockchain()
-				.get_esdt_balance(&sc_address, &token, 0)
+			self.blockchain().get_esdt_balance(&sc_address, &token, 0)
 		}
 	}
 

--- a/contracts/examples/crowdfunding-esdt/src/lib.rs
+++ b/contracts/examples/crowdfunding-esdt/src/lib.rs
@@ -59,7 +59,7 @@ pub trait Crowdfunding {
 			self.blockchain().get_sc_balance()
 		} else {
 			self.blockchain()
-				.get_esdt_balance(&sc_address, token.as_esdt_identifier(), 0)
+				.get_esdt_balance(&sc_address, &token, 0)
 		}
 	}
 

--- a/contracts/examples/egld-esdt-swap/src/lib.rs
+++ b/contracts/examples/egld-esdt-swap/src/lib.rs
@@ -95,12 +95,12 @@ pub trait EgldEsdtSwap {
 		);
 
 		let wrapped_egld_token_id = self.wrapped_egld_token_id().get();
-		let esdt_token_id = wrapped_egld_token_id.as_esdt_identifier();
+		let esdt_token_id = wrapped_egld_token_id;
 		let caller = self.blockchain().get_caller();
 		self.mint_started_event(&caller, &amount);
 
 		Ok(ESDTSystemSmartContractProxy::new_proxy_obj(self.send())
-			.mint(esdt_token_id, &amount)
+			.mint(&esdt_token_id, &amount)
 			.async_call()
 			.with_callback(self.callbacks().esdt_mint_callback(&caller, &amount)))
 	}
@@ -144,9 +144,9 @@ pub trait EgldEsdtSwap {
 		self.unused_wrapped_egld().set(&unused_wrapped_egld);
 
 		let caller = self.blockchain().get_caller();
-		let _ = self.send().direct_esdt_via_transf_exec(
+		let _ = self.send().direct(
 			&caller,
-			self.wrapped_egld_token_id().get().as_esdt_identifier(),
+			&self.wrapped_egld_token_id().get(),
 			&payment,
 			b"wrapping",
 		);

--- a/contracts/examples/esdt-nft-marketplace/src/lib.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/lib.rs
@@ -229,18 +229,18 @@ pub trait EsdtNftMarketplace {
 			);
 
 			// send NFT to auction winner
-			let _ = self.send().direct_esdt_nft_via_transfer_exec(
+			let _ = self.send().direct_nft(
 				&auction.current_winner,
-				nft_type.as_esdt_identifier(),
+				&nft_type,
 				nft_nonce,
 				&Self::BigUint::from(NFT_AMOUNT),
 				self.data_or_empty_if_sc(&auction.current_winner, b"bought token at auction"),
 			);
 		} else {
 			// return to original owner
-			let _ = self.send().direct_esdt_nft_via_transfer_exec(
+			let _ = self.send().direct_nft(
 				&auction.original_owner,
-				nft_type.as_esdt_identifier(),
+				&nft_type,
 				nft_nonce,
 				&Self::BigUint::from(NFT_AMOUNT),
 				self.data_or_empty_if_sc(&auction.original_owner, b"returned token"),
@@ -271,9 +271,9 @@ pub trait EsdtNftMarketplace {
 
 		self.auction_for_token(&nft_type, nft_nonce).clear();
 
-		let _ = self.send().direct_esdt_nft_via_transfer_exec(
+		let _ = self.send().direct_nft(
 			&caller,
-			nft_type.as_esdt_identifier(),
+			&nft_type,
 			nft_nonce,
 			&Self::BigUint::from(NFT_AMOUNT),
 			self.data_or_empty_if_sc(&caller, b"returned token"),
@@ -418,9 +418,9 @@ pub trait EsdtNftMarketplace {
 			self.send()
 				.direct(to, &token_id, amount, self.data_or_empty_if_sc(to, data));
 		} else {
-			let _ = self.send().direct_esdt_nft_via_transfer_exec(
+			let _ = self.send().direct_nft(
 				to,
-				token_id.as_esdt_identifier(),
+				&token_id,
 				nonce,
 				amount,
 				self.data_or_empty_if_sc(to, data),
@@ -443,7 +443,7 @@ pub trait EsdtNftMarketplace {
 	) -> EsdtTokenData<Self::BigUint> {
 		self.blockchain().get_esdt_token_data(
 			&self.blockchain().get_sc_address(),
-			nft_type.as_esdt_identifier(),
+			&nft_type,
 			nft_nonce,
 		)
 	}

--- a/contracts/examples/lottery-esdt/src/lib.rs
+++ b/contracts/examples/lottery-esdt/src/lib.rs
@@ -132,7 +132,7 @@ pub trait Lottery {
 
 				let roles = self
 					.blockchain()
-					.get_esdt_local_roles(token_name.as_esdt_identifier());
+					.get_esdt_local_roles(&token_name);
 				require!(
 					roles.contains(&EsdtLocalRole::Burn),
 					"The contract can't burn the selected token!"
@@ -264,11 +264,11 @@ pub trait Lottery {
 			// The tokens will simply remain locked forever
 			let roles = self
 				.blockchain()
-				.get_esdt_local_roles(info.token_name.as_esdt_identifier());
+				.get_esdt_local_roles(&info.token_name);
 			if roles.contains(&EsdtLocalRole::Burn) {
 				self.send().esdt_local_burn(
 					self.blockchain().get_gas_left(),
-					info.token_name.as_esdt_identifier(),
+					&info.token_name,
 					&burn_amount,
 				);
 			}

--- a/contracts/examples/lottery-esdt/src/lib.rs
+++ b/contracts/examples/lottery-esdt/src/lib.rs
@@ -262,11 +262,7 @@ pub trait Lottery {
 			// The tokens will simply remain locked forever
 			let roles = self.blockchain().get_esdt_local_roles(&info.token_name);
 			if roles.contains(&EsdtLocalRole::Burn) {
-				self.send().esdt_local_burn(
-					self.blockchain().get_gas_left(),
-					&info.token_name,
-					&burn_amount,
-				);
+				self.send().esdt_local_burn(&info.token_name, &burn_amount);
 			}
 
 			info.prize_pool -= burn_amount;

--- a/contracts/examples/lottery-esdt/src/lib.rs
+++ b/contracts/examples/lottery-esdt/src/lib.rs
@@ -130,9 +130,7 @@ pub trait Lottery {
 			OptionalArg::Some(burn_percentage) => {
 				require!(!token_name.is_egld(), "EGLD can't be burned!");
 
-				let roles = self
-					.blockchain()
-					.get_esdt_local_roles(&token_name);
+				let roles = self.blockchain().get_esdt_local_roles(&token_name);
 				require!(
 					roles.contains(&EsdtLocalRole::Burn),
 					"The contract can't burn the selected token!"
@@ -262,9 +260,7 @@ pub trait Lottery {
 
 			// Prevent crashing if the role was unset while the lottery was running
 			// The tokens will simply remain locked forever
-			let roles = self
-				.blockchain()
-				.get_esdt_local_roles(&info.token_name);
+			let roles = self.blockchain().get_esdt_local_roles(&info.token_name);
 			if roles.contains(&EsdtLocalRole::Burn) {
 				self.send().esdt_local_burn(
 					self.blockchain().get_gas_left(),

--- a/contracts/feature-tests/async/forwarder-raw/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder-raw/src/lib.rs
@@ -35,12 +35,7 @@ pub trait ForwarderRaw {
 		#[payment_token] token: TokenIdentifier,
 		#[payment] payment: Self::BigUint,
 	) {
-		let _ = self.send().direct(
-			&to,
-			&token,
-			&payment,
-			&[],
-		);
+		let _ = self.send().direct(&to, &token, &payment, &[]);
 	}
 
 	fn forward_contract_call(

--- a/contracts/feature-tests/async/forwarder-raw/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder-raw/src/lib.rs
@@ -92,7 +92,8 @@ pub trait ForwarderRaw {
 		#[var_args] args: VarArgs<BoxedBytes>,
 	) {
 		self.forward_contract_call(to, TokenIdentifier::egld(), payment, endpoint_name, args)
-			.transfer_execute(self.blockchain().get_gas_left() / 2);
+			.with_gas_limit(self.blockchain().get_gas_left() / 2)
+			.transfer_execute();
 	}
 
 	#[endpoint]
@@ -106,7 +107,8 @@ pub trait ForwarderRaw {
 		#[var_args] args: VarArgs<BoxedBytes>,
 	) {
 		self.forward_contract_call(to, token, payment, endpoint_name, args)
-			.transfer_execute(self.blockchain().get_gas_left() / 2);
+			.with_gas_limit(self.blockchain().get_gas_left() / 2)
+			.transfer_execute();
 	}
 
 	#[endpoint]
@@ -120,7 +122,8 @@ pub trait ForwarderRaw {
 		#[var_args] args: VarArgs<BoxedBytes>,
 	) {
 		self.forward_contract_call(to, token, payment, endpoint_name, args)
-			.transfer_execute(self.blockchain().get_gas_left() / 2);
+			.with_gas_limit(self.blockchain().get_gas_left() / 2)
+			.transfer_execute();
 	}
 
 	#[view]

--- a/contracts/feature-tests/async/forwarder-raw/src/lib.rs
+++ b/contracts/feature-tests/async/forwarder-raw/src/lib.rs
@@ -35,9 +35,9 @@ pub trait ForwarderRaw {
 		#[payment_token] token: TokenIdentifier,
 		#[payment] payment: Self::BigUint,
 	) {
-		let _ = self.send().direct_esdt_via_transf_exec(
+		let _ = self.send().direct(
 			&to,
-			&token.as_esdt_identifier(),
+			&token,
 			&payment,
 			&[],
 		);

--- a/contracts/feature-tests/async/forwarder/src/call_sync.rs
+++ b/contracts/feature-tests/async/forwarder/src/call_sync.rs
@@ -13,7 +13,8 @@ pub trait ForwarderSyncCallModule {
 		let result = self
 			.vault_proxy(to)
 			.echo_arguments(args)
-			.execute_on_dest_context(half_gas);
+			.with_gas_limit(half_gas)
+			.execute_on_dest_context();
 
 		self.execute_on_dest_context_result_event(result.as_slice());
 	}
@@ -32,7 +33,8 @@ pub trait ForwarderSyncCallModule {
 		let result = self
 			.vault_proxy(to)
 			.echo_arguments(args)
-			.execute_on_dest_context_custom_range(half_gas, |_, _| (start, end));
+			.with_gas_limit(half_gas)
+			.execute_on_dest_context_custom_range(|_, _| (start, end));
 
 		self.execute_on_dest_context_result_event(result.as_slice());
 	}
@@ -45,14 +47,16 @@ pub trait ForwarderSyncCallModule {
 		let result = self
 			.vault_proxy(to.clone())
 			.echo_arguments(args.clone())
-			.execute_on_dest_context(one_third_gas);
+			.with_gas_limit(one_third_gas)
+			.execute_on_dest_context();
 
 		self.execute_on_dest_context_result_event(result.as_slice());
 
 		let result = self
 			.vault_proxy(to)
 			.echo_arguments(args)
-			.execute_on_dest_context(one_third_gas);
+			.with_gas_limit(one_third_gas)
+			.execute_on_dest_context();
 
 		self.execute_on_dest_context_result_event(result.as_slice());
 	}
@@ -75,7 +79,9 @@ pub trait ForwarderSyncCallModule {
 			.vault_proxy(to)
 			.with_nft_nonce(token_nonce)
 			.accept_funds_echo_payment(token, payment)
-			.execute_on_dest_context(half_gas);
+			.with_gas_limit(half_gas)
+			.execute_on_dest_context();
+
 		let (token_identifier, token_type_str, token_payment, token_nonce) = result.into_tuple();
 		self.accept_funds_sync_result_event(
 			&token_identifier,
@@ -108,10 +114,10 @@ pub trait ForwarderSyncCallModule {
 			.vault_proxy(to.clone())
 			.with_nft_nonce(token_nonce)
 			.accept_funds(token, payment)
-			.execute_on_dest_context(self.blockchain().get_gas_left());
+			.execute_on_dest_context();
 
 		self.vault_proxy(to)
 			.call_counts(b"accept_funds")
-			.execute_on_dest_context(self.blockchain().get_gas_left())
+			.execute_on_dest_context()
 	}
 }

--- a/contracts/feature-tests/async/forwarder/src/call_transf_exec.rs
+++ b/contracts/feature-tests/async/forwarder/src/call_transf_exec.rs
@@ -17,7 +17,8 @@ pub trait ForwarderTransferExecuteModule {
 		self.vault_proxy(to)
 			.accept_funds(token, payment)
 			.with_nft_nonce(token_nonce)
-			.transfer_execute(self.blockchain().get_gas_left());
+			.with_gas_limit(self.blockchain().get_gas_left())
+			.transfer_execute();
 	}
 
 	#[endpoint]
@@ -35,11 +36,13 @@ pub trait ForwarderTransferExecuteModule {
 		self.vault_proxy(to.clone())
 			.accept_funds(token.clone(), half_payment.clone())
 			.with_nft_nonce(token_nonce)
-			.transfer_execute(half_gas);
+			.with_gas_limit(half_gas)
+			.transfer_execute();
 
 		self.vault_proxy(to)
 			.accept_funds(token, half_payment)
 			.with_nft_nonce(token_nonce)
-			.transfer_execute(half_gas);
+			.with_gas_limit(half_gas)
+			.transfer_execute();
 	}
 }

--- a/contracts/feature-tests/async/forwarder/src/esdt.rs
+++ b/contracts/feature-tests/async/forwarder/src/esdt.rs
@@ -8,7 +8,7 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
 	fn get_fungible_esdt_balance(&self, token_identifier: &TokenIdentifier) -> Self::BigUint {
 		self.blockchain().get_esdt_balance(
 			&self.blockchain().get_sc_address(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			0,
 		)
 	}
@@ -17,7 +17,7 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
 	fn send_esdt(
 		&self,
 		to: &Address,
-		token_id: BoxedBytes,
+		token_id: TokenIdentifier,
 		amount: &Self::BigUint,
 		#[var_args] opt_data: OptionalArg<BoxedBytes>,
 	) {
@@ -25,16 +25,14 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
 			OptionalArg::Some(data) => data.as_slice(),
 			OptionalArg::None => &[],
 		};
-		let _ = self
-			.send()
-			.direct_esdt_via_transf_exec(to, token_id.as_slice(), amount, data);
+		let _ = self.send().direct(to, &token_id, amount, data);
 	}
 
 	#[endpoint]
 	fn send_esdt_twice(
 		&self,
 		to: &Address,
-		token_id: BoxedBytes,
+		token_id: TokenIdentifier,
 		amount_first_time: &Self::BigUint,
 		amount_second_time: &Self::BigUint,
 		#[var_args] opt_data: OptionalArg<BoxedBytes>,
@@ -43,18 +41,8 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
 			OptionalArg::Some(data) => data.as_slice(),
 			OptionalArg::None => &[],
 		};
-		let _ = self.send().direct_esdt_via_transf_exec(
-			to,
-			token_id.as_slice(),
-			amount_first_time,
-			data,
-		);
-		let _ = self.send().direct_esdt_via_transf_exec(
-			to,
-			token_id.as_slice(),
-			amount_second_time,
-			data,
-		);
+		let _ = self.send().direct(to, &token_id, amount_first_time, data);
+		let _ = self.send().direct(to, &token_id, amount_second_time, data);
 	}
 
 	#[payable("EGLD")]
@@ -118,19 +106,13 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
 
 	#[endpoint]
 	fn local_mint(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send().esdt_local_mint(
-			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
-			&amount,
-		);
+		self.send()
+			.esdt_local_mint(self.blockchain().get_gas_left(), &token_identifier, &amount);
 	}
 
 	#[endpoint]
 	fn local_burn(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send().esdt_local_burn(
-			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
-			&amount,
-		);
+		self.send()
+			.esdt_local_burn(self.blockchain().get_gas_left(), &token_identifier, &amount);
 	}
 }

--- a/contracts/feature-tests/async/forwarder/src/esdt.rs
+++ b/contracts/feature-tests/async/forwarder/src/esdt.rs
@@ -106,13 +106,11 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
 
 	#[endpoint]
 	fn local_mint(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send()
-			.esdt_local_mint(self.blockchain().get_gas_left(), &token_identifier, &amount);
+		self.send().esdt_local_mint(&token_identifier, &amount);
 	}
 
 	#[endpoint]
 	fn local_burn(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send()
-			.esdt_local_burn(self.blockchain().get_gas_left(), &token_identifier, &amount);
+		self.send().esdt_local_burn(&token_identifier, &amount);
 	}
 }

--- a/contracts/feature-tests/async/forwarder/src/nft.rs
+++ b/contracts/feature-tests/async/forwarder/src/nft.rs
@@ -85,7 +85,6 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 		uri: BoxedBytes,
 	) {
 		self.send().esdt_nft_create::<Color>(
-			self.blockchain().get_gas_left(),
 			&token_identifier,
 			&amount,
 			&name,
@@ -103,22 +102,13 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 		nonce: u64,
 		amount: Self::BigUint,
 	) {
-		self.send().esdt_nft_add_quantity(
-			self.blockchain().get_gas_left(),
-			&token_identifier,
-			nonce,
-			&amount,
-		);
+		self.send()
+			.esdt_nft_add_quantity(&token_identifier, nonce, &amount);
 	}
 
 	#[endpoint]
 	fn nft_burn(&self, token_identifier: TokenIdentifier, nonce: u64, amount: Self::BigUint) {
-		self.send().esdt_nft_burn(
-			self.blockchain().get_gas_left(),
-			&token_identifier,
-			nonce,
-			&amount,
-		);
+		self.send().esdt_nft_burn(&token_identifier, nonce, &amount);
 	}
 
 	#[endpoint]

--- a/contracts/feature-tests/async/forwarder/src/nft.rs
+++ b/contracts/feature-tests/async/forwarder/src/nft.rs
@@ -17,7 +17,7 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 	fn get_nft_balance(&self, token_identifier: &TokenIdentifier, nonce: u64) -> Self::BigUint {
 		self.blockchain().get_esdt_balance(
 			&self.blockchain().get_sc_address(),
-			token_identifier.as_esdt_identifier(),
+			token_identifier,
 			nonce,
 		)
 	}
@@ -86,7 +86,7 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 	) {
 		self.send().esdt_nft_create::<Color>(
 			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			&amount,
 			&name,
 			&royalties,
@@ -105,7 +105,7 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 	) {
 		self.send().esdt_nft_add_quantity(
 			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			nonce,
 			&amount,
 		);
@@ -115,7 +115,7 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 	fn nft_burn(&self, token_identifier: TokenIdentifier, nonce: u64, amount: Self::BigUint) {
 		self.send().esdt_nft_burn(
 			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			nonce,
 			&amount,
 		);
@@ -130,10 +130,10 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 		amount: Self::BigUint,
 		data: BoxedBytes,
 	) {
-		self.send().direct_esdt_nft_via_async_call(
+		self.send().transfer_esdt_nft_via_async_call(
 			&self.blockchain().get_sc_address(),
 			&to,
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			nonce,
 			&amount,
 			data.as_slice(),
@@ -157,7 +157,7 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 
 		let _ = self.send().direct_esdt_nft_execute(
 			&to,
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			nonce,
 			&amount,
 			self.blockchain().get_gas_left(),

--- a/contracts/feature-tests/async/forwarder/src/roles.rs
+++ b/contracts/feature-tests/async/forwarder/src/roles.rs
@@ -12,11 +12,7 @@ pub trait ForwarderRolesModule: storage::ForwarderStorageModule {
 		#[var_args] roles: VarArgs<EsdtLocalRole>,
 	) -> AsyncCall<Self::SendApi> {
 		ESDTSystemSmartContractProxy::new_proxy_obj(self.send())
-			.set_special_roles(
-				&address,
-				token_identifier.as_esdt_identifier(),
-				roles.as_slice(),
-			)
+			.set_special_roles(&address, &token_identifier, roles.as_slice())
 			.async_call()
 			.with_callback(self.callbacks().change_roles_callback())
 	}
@@ -29,11 +25,7 @@ pub trait ForwarderRolesModule: storage::ForwarderStorageModule {
 		#[var_args] roles: VarArgs<EsdtLocalRole>,
 	) -> AsyncCall<Self::SendApi> {
 		ESDTSystemSmartContractProxy::new_proxy_obj(self.send())
-			.unset_special_roles(
-				&address,
-				token_identifier.as_esdt_identifier(),
-				roles.as_slice(),
-			)
+			.unset_special_roles(&address, &token_identifier, roles.as_slice())
 			.async_call()
 			.with_callback(self.callbacks().change_roles_callback())
 	}

--- a/contracts/feature-tests/async/vault/src/lib.rs
+++ b/contracts/feature-tests/async/vault/src/lib.rs
@@ -82,12 +82,18 @@ pub trait Vault {
 	) {
 		self.retrieve_funds_event(&token, &amount);
 
+		let caller = self.blockchain().get_caller();
 		let data = match &return_message {
 			OptionalArg::Some(data) => data.as_slice(),
 			OptionalArg::None => &[],
 		};
-		self.send()
-			.direct_via_async_call(&self.blockchain().get_caller(), &token, &amount, data);
+
+		if token.is_egld() {
+			self.send().direct_egld(&caller, &amount, data);
+		} else {
+			self.send()
+				.transfer_esdt_via_async_call(&caller, &token, &amount, data);
+		}
 	}
 
 	#[event("accept_funds")]

--- a/contracts/feature-tests/basic-features/src/blockchain_api_features.rs
+++ b/contracts/feature-tests/basic-features/src/blockchain_api_features.rs
@@ -37,7 +37,7 @@ pub trait BlockchainApiFeatures {
 	fn get_esdt_local_roles(&self, token_id: TokenIdentifier) -> MultiResultVec<BoxedBytes> {
 		let roles = self
 			.blockchain()
-			.get_esdt_local_roles(token_id.as_esdt_identifier());
+			.get_esdt_local_roles(&token_id);
 		let role_names: Vec<BoxedBytes> = roles
 			.iter()
 			.map(|role| BoxedBytes::from(role.as_role_name()))

--- a/contracts/feature-tests/basic-features/src/blockchain_api_features.rs
+++ b/contracts/feature-tests/basic-features/src/blockchain_api_features.rs
@@ -35,9 +35,7 @@ pub trait BlockchainApiFeatures {
 
 	#[endpoint]
 	fn get_esdt_local_roles(&self, token_id: TokenIdentifier) -> MultiResultVec<BoxedBytes> {
-		let roles = self
-			.blockchain()
-			.get_esdt_local_roles(&token_id);
+		let roles = self.blockchain().get_esdt_local_roles(&token_id);
 		let role_names: Vec<BoxedBytes> = roles
 			.iter()
 			.map(|role| BoxedBytes::from(role.as_role_name()))

--- a/contracts/feature-tests/esdt-contract-pair/first-contract/src/lib.rs
+++ b/contracts/feature-tests/esdt-contract-pair/first-contract/src/lib.rs
@@ -101,7 +101,7 @@ pub trait FirstContract {
 
 		let _ = self.send().direct_esdt_execute(
 			&second_contract_address,
-			expected_token_name.as_esdt_identifier(),
+			&expected_token_name,
 			&esdt_value,
 			self.blockchain().get_gas_left(),
 			SECOND_CONTRACT_REJECT_ESDT_PAYMENT,
@@ -126,7 +126,7 @@ pub trait FirstContract {
 
 		let _ = self.send().direct_esdt_execute(
 			&second_contract_address,
-			expected_token_name.as_esdt_identifier(),
+			&expected_token_name,
 			&esdt_value,
 			self.blockchain().get_gas_left(),
 			SECOND_CONTRACT_ACCEPT_ESDT_PAYMENT,

--- a/contracts/feature-tests/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
+++ b/contracts/feature-tests/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
@@ -43,7 +43,8 @@ pub trait Parent {
 		let child_contract_adress = self.child_contract_address().get();
 		self.child_proxy(child_contract_adress)
 			.issue_wrapped_egld(token_display_name, token_ticker, initial_supply, issue_cost)
-			.execute_on_dest_context_ignore_result(ISSUE_EXPECTED_GAS_COST);
+			.with_gas_limit(ISSUE_EXPECTED_GAS_COST)
+			.execute_on_dest_context_ignore_result();
 	}
 
 	// storage

--- a/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
+++ b/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
@@ -54,14 +54,12 @@ pub trait LocalEsdtAndEsdtNft {
 
 	#[endpoint(localMint)]
 	fn local_mint(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send()
-			.esdt_local_mint(self.blockchain().get_gas_left(), &token_identifier, &amount);
+		self.send().esdt_local_mint(&token_identifier, &amount);
 	}
 
 	#[endpoint(localBurn)]
 	fn local_burn(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send()
-			.esdt_local_burn(self.blockchain().get_gas_left(), &token_identifier, &amount);
+		self.send().esdt_local_burn(&token_identifier, &amount);
 	}
 
 	// Non-Fungible Tokens
@@ -106,7 +104,6 @@ pub trait LocalEsdtAndEsdtNft {
 		uri: BoxedBytes,
 	) {
 		self.send().esdt_nft_create::<Color>(
-			self.blockchain().get_gas_left(),
 			&token_identifier,
 			&amount,
 			&name,
@@ -124,22 +121,13 @@ pub trait LocalEsdtAndEsdtNft {
 		nonce: u64,
 		amount: Self::BigUint,
 	) {
-		self.send().esdt_nft_add_quantity(
-			self.blockchain().get_gas_left(),
-			&token_identifier,
-			nonce,
-			&amount,
-		);
+		self.send()
+			.esdt_nft_add_quantity(&token_identifier, nonce, &amount);
 	}
 
 	#[endpoint(nftBurn)]
 	fn nft_burn(&self, token_identifier: TokenIdentifier, nonce: u64, amount: Self::BigUint) {
-		self.send().esdt_nft_burn(
-			self.blockchain().get_gas_left(),
-			&token_identifier,
-			nonce,
-			&amount,
-		);
+		self.send().esdt_nft_burn(&token_identifier, nonce, &amount);
 	}
 
 	#[endpoint(transferNftViaAsyncCall)]

--- a/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
+++ b/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
@@ -56,7 +56,7 @@ pub trait LocalEsdtAndEsdtNft {
 	fn local_mint(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
 		self.send().esdt_local_mint(
 			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			&amount,
 		);
 	}
@@ -65,7 +65,7 @@ pub trait LocalEsdtAndEsdtNft {
 	fn local_burn(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
 		self.send().esdt_local_burn(
 			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			&amount,
 		);
 	}
@@ -113,7 +113,7 @@ pub trait LocalEsdtAndEsdtNft {
 	) {
 		self.send().esdt_nft_create::<Color>(
 			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			&amount,
 			&name,
 			&royalties,
@@ -132,7 +132,7 @@ pub trait LocalEsdtAndEsdtNft {
 	) {
 		self.send().esdt_nft_add_quantity(
 			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			nonce,
 			&amount,
 		);
@@ -142,7 +142,7 @@ pub trait LocalEsdtAndEsdtNft {
 	fn nft_burn(&self, token_identifier: TokenIdentifier, nonce: u64, amount: Self::BigUint) {
 		self.send().esdt_nft_burn(
 			self.blockchain().get_gas_left(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			nonce,
 			&amount,
 		);
@@ -157,10 +157,10 @@ pub trait LocalEsdtAndEsdtNft {
 		amount: Self::BigUint,
 		data: BoxedBytes,
 	) {
-		self.send().direct_esdt_nft_via_async_call(
+		self.send().transfer_esdt_nft_via_async_call(
 			&self.blockchain().get_sc_address(),
 			&to,
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			nonce,
 			&amount,
 			data.as_slice(),
@@ -184,7 +184,7 @@ pub trait LocalEsdtAndEsdtNft {
 
 		let _ = self.send().direct_esdt_nft_execute(
 			&to,
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			nonce,
 			&amount,
 			self.blockchain().get_gas_left(),
@@ -235,7 +235,7 @@ pub trait LocalEsdtAndEsdtNft {
 		ESDTSystemSmartContractProxy::new_proxy_obj(self.send())
 			.set_special_roles(
 				&address,
-				token_identifier.as_esdt_identifier(),
+				&token_identifier,
 				roles.as_slice(),
 			)
 			.async_call()
@@ -252,7 +252,7 @@ pub trait LocalEsdtAndEsdtNft {
 		ESDTSystemSmartContractProxy::new_proxy_obj(self.send())
 			.unset_special_roles(
 				&address,
-				token_identifier.as_esdt_identifier(),
+				&token_identifier,
 				roles.as_slice(),
 			)
 			.async_call()
@@ -265,7 +265,7 @@ pub trait LocalEsdtAndEsdtNft {
 	fn get_fungible_esdt_balance(&self, token_identifier: &TokenIdentifier) -> Self::BigUint {
 		self.blockchain().get_esdt_balance(
 			&self.blockchain().get_sc_address(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			0,
 		)
 	}
@@ -274,7 +274,7 @@ pub trait LocalEsdtAndEsdtNft {
 	fn get_nft_balance(&self, token_identifier: &TokenIdentifier, nonce: u64) -> Self::BigUint {
 		self.blockchain().get_esdt_balance(
 			&self.blockchain().get_sc_address(),
-			token_identifier.as_esdt_identifier(),
+			&token_identifier,
 			nonce,
 		)
 	}

--- a/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
+++ b/contracts/feature-tests/local-esdt-and-nft/src/lib.rs
@@ -54,20 +54,14 @@ pub trait LocalEsdtAndEsdtNft {
 
 	#[endpoint(localMint)]
 	fn local_mint(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send().esdt_local_mint(
-			self.blockchain().get_gas_left(),
-			&token_identifier,
-			&amount,
-		);
+		self.send()
+			.esdt_local_mint(self.blockchain().get_gas_left(), &token_identifier, &amount);
 	}
 
 	#[endpoint(localBurn)]
 	fn local_burn(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send().esdt_local_burn(
-			self.blockchain().get_gas_left(),
-			&token_identifier,
-			&amount,
-		);
+		self.send()
+			.esdt_local_burn(self.blockchain().get_gas_left(), &token_identifier, &amount);
 	}
 
 	// Non-Fungible Tokens
@@ -233,11 +227,7 @@ pub trait LocalEsdtAndEsdtNft {
 		#[var_args] roles: VarArgs<EsdtLocalRole>,
 	) -> AsyncCall<Self::SendApi> {
 		ESDTSystemSmartContractProxy::new_proxy_obj(self.send())
-			.set_special_roles(
-				&address,
-				&token_identifier,
-				roles.as_slice(),
-			)
+			.set_special_roles(&address, &token_identifier, roles.as_slice())
 			.async_call()
 			.with_callback(self.callbacks().change_roles_callback())
 	}
@@ -250,11 +240,7 @@ pub trait LocalEsdtAndEsdtNft {
 		#[var_args] roles: VarArgs<EsdtLocalRole>,
 	) -> AsyncCall<Self::SendApi> {
 		ESDTSystemSmartContractProxy::new_proxy_obj(self.send())
-			.unset_special_roles(
-				&address,
-				&token_identifier,
-				roles.as_slice(),
-			)
+			.unset_special_roles(&address, &token_identifier, roles.as_slice())
 			.async_call()
 			.with_callback(self.callbacks().change_roles_callback())
 	}

--- a/elrond-wasm-debug/src/api/blockchain_api_mock.rs
+++ b/elrond-wasm-debug/src/api/blockchain_api_mock.rs
@@ -2,7 +2,7 @@ use super::big_uint_api_mock::*;
 use crate::TxContext;
 use elrond_wasm::{
 	api::BigUintApi,
-	types::{Address, EsdtTokenData, H256, TokenIdentifier},
+	types::{Address, EsdtTokenData, TokenIdentifier, H256},
 };
 
 impl elrond_wasm::api::BlockchainApi for TxContext {
@@ -108,14 +108,23 @@ impl elrond_wasm::api::BlockchainApi for TxContext {
 	}
 
 	// TODO: Include nonce and create a map like: TokenId -> Nonce -> Amount
-	fn get_esdt_balance(&self, address: &Address, token: &TokenIdentifier, _nonce: u64) -> RustBigUint {
+	fn get_esdt_balance(
+		&self,
+		address: &Address,
+		token: &TokenIdentifier,
+		_nonce: u64,
+	) -> RustBigUint {
 		if address != &self.get_sc_address() {
 			panic!(
 				"get_esdt_balance not yet implemented for accounts other than the contract itself"
 			);
 		}
 
-		match self.blockchain_info_box.contract_esdt.get(&token.as_esdt_identifier().to_vec()) {
+		match self
+			.blockchain_info_box
+			.contract_esdt
+			.get(&token.as_esdt_identifier().to_vec())
+		{
 			Some(value) => value.clone().into(),
 			None => RustBigUint::zero(),
 		}

--- a/elrond-wasm-debug/src/api/blockchain_api_mock.rs
+++ b/elrond-wasm-debug/src/api/blockchain_api_mock.rs
@@ -2,7 +2,7 @@ use super::big_uint_api_mock::*;
 use crate::TxContext;
 use elrond_wasm::{
 	api::BigUintApi,
-	types::{Address, EsdtTokenData, H256},
+	types::{Address, EsdtTokenData, H256, TokenIdentifier},
 };
 
 impl elrond_wasm::api::BlockchainApi for TxContext {
@@ -102,20 +102,20 @@ impl elrond_wasm::api::BlockchainApi for TxContext {
 			.clone()
 	}
 
-	fn get_current_esdt_nft_nonce(&self, _address: &Address, _token: &[u8]) -> u64 {
+	fn get_current_esdt_nft_nonce(&self, _address: &Address, _token: &TokenIdentifier) -> u64 {
 		// TODO: Implement
 		0u64
 	}
 
 	// TODO: Include nonce and create a map like: TokenId -> Nonce -> Amount
-	fn get_esdt_balance(&self, address: &Address, token: &[u8], _nonce: u64) -> RustBigUint {
+	fn get_esdt_balance(&self, address: &Address, token: &TokenIdentifier, _nonce: u64) -> RustBigUint {
 		if address != &self.get_sc_address() {
 			panic!(
 				"get_esdt_balance not yet implemented for accounts other than the contract itself"
 			);
 		}
 
-		match self.blockchain_info_box.contract_esdt.get(&token.to_vec()) {
+		match self.blockchain_info_box.contract_esdt.get(&token.as_esdt_identifier().to_vec()) {
 			Some(value) => value.clone().into(),
 			None => RustBigUint::zero(),
 		}
@@ -124,7 +124,7 @@ impl elrond_wasm::api::BlockchainApi for TxContext {
 	fn get_esdt_token_data(
 		&self,
 		_address: &Address,
-		_token: &[u8],
+		_token: &TokenIdentifier,
 		_nonce: u64,
 	) -> EsdtTokenData<RustBigUint> {
 		panic!("get_esdt_token_data not yet implemented")

--- a/elrond-wasm-debug/src/api/send_api_mock.rs
+++ b/elrond-wasm-debug/src/api/send_api_mock.rs
@@ -88,7 +88,7 @@ impl SendApi for TxContext {
 	fn direct_esdt_execute(
 		&self,
 		to: &Address,
-		token: &[u8],
+		token: &TokenIdentifier,
 		amount: &RustBigUint,
 		_gas: u64,
 		_function: &[u8],
@@ -113,7 +113,7 @@ impl SendApi for TxContext {
 	fn direct_esdt_nft_execute(
 		&self,
 		_to: &Address,
-		_token: &[u8],
+		_token: &TokenIdentifier,
 		_nonce: u64,
 		_amount: &RustBigUint,
 		_gas_limit: u64,

--- a/elrond-wasm-debug/src/api/send_api_mock.rs
+++ b/elrond-wasm-debug/src/api/send_api_mock.rs
@@ -94,7 +94,7 @@ impl SendApi for TxContext {
 		_function: &[u8],
 		_arg_buffer: &ArgBuffer,
 	) -> Result<(), &'static [u8]> {
-		if amount.value() > self.get_available_esdt_balance(token) {
+		if amount.value() > self.get_available_esdt_balance(token.as_esdt_identifier()) {
 			std::panic::panic_any(TxPanic {
 				status: 10,
 				message: b"insufficient funds".to_vec(),
@@ -104,7 +104,7 @@ impl SendApi for TxContext {
 		let mut tx_output = self.tx_output_cell.borrow_mut();
 		tx_output.send_balance_list.push(SendBalance {
 			recipient: to.clone(),
-			token: TokenIdentifier::from(token),
+			token: token.clone(),
 			amount: amount.value(),
 		});
 		Ok(())

--- a/elrond-wasm-debug/src/api/send_api_mock.rs
+++ b/elrond-wasm-debug/src/api/send_api_mock.rs
@@ -58,6 +58,10 @@ impl SendApi for TxContext {
 		BlockchainApi::get_sc_address(self)
 	}
 
+	fn get_gas_left(&self) -> u64 {
+		BlockchainApi::get_gas_left(self)
+	}
+
 	fn direct_egld(&self, to: &Address, amount: &RustBigUint, _data: &[u8]) {
 		if amount.value() > self.get_available_egld_balance() {
 			std::panic::panic_any(TxPanic {

--- a/elrond-wasm-node/src/api/blockchain_api_node.rs
+++ b/elrond-wasm-node/src/api/blockchain_api_node.rs
@@ -1,7 +1,9 @@
 use super::ArwenBigUint;
 use crate::ArwenApiImpl;
 use elrond_wasm::api::BlockchainApi;
-use elrond_wasm::types::{Address, Box, BoxedBytes, EsdtTokenData, EsdtTokenType, H256};
+use elrond_wasm::types::{
+	Address, Box, BoxedBytes, EsdtTokenData, EsdtTokenType, TokenIdentifier, H256,
+};
 
 extern "C" {
 	fn getSCAddress(resultOffset: *mut u8);
@@ -220,7 +222,12 @@ impl BlockchainApi for ArwenApiImpl {
 	}
 
 	#[inline]
-	fn get_esdt_balance(&self, address: &Address, token: &TokenIdentifier, nonce: u64) -> ArwenBigUint {
+	fn get_esdt_balance(
+		&self,
+		address: &Address,
+		token: &TokenIdentifier,
+		nonce: u64,
+	) -> ArwenBigUint {
 		unsafe {
 			let result = bigIntNew(0);
 			bigIntGetESDTExternalBalance(

--- a/elrond-wasm-node/src/api/blockchain_api_node.rs
+++ b/elrond-wasm-node/src/api/blockchain_api_node.rs
@@ -209,7 +209,7 @@ impl BlockchainApi for ArwenApiImpl {
 	}
 
 	#[inline]
-	fn get_current_esdt_nft_nonce(&self, address: &Address, token: &[u8]) -> u64 {
+	fn get_current_esdt_nft_nonce(&self, address: &Address, token: &TokenIdentifier) -> u64 {
 		unsafe {
 			getCurrentESDTNFTNonce(
 				address.as_ref().as_ptr(),
@@ -220,7 +220,7 @@ impl BlockchainApi for ArwenApiImpl {
 	}
 
 	#[inline]
-	fn get_esdt_balance(&self, address: &Address, token: &[u8], nonce: u64) -> ArwenBigUint {
+	fn get_esdt_balance(&self, address: &Address, token: &TokenIdentifier, nonce: u64) -> ArwenBigUint {
 		unsafe {
 			let result = bigIntNew(0);
 			bigIntGetESDTExternalBalance(
@@ -235,17 +235,11 @@ impl BlockchainApi for ArwenApiImpl {
 		}
 	}
 
-	///////////////////////////////////////////
-	// ----------------- TODO -----------------
-	// Hash is currently ignored, fix when hash gets a getHashLength function
-	// Hash is not limited to 32 bytes, so also fix EsdtTokenData struct when that happens
-	// Also fix in mandos.
-	///////////////////////////////////////////
 	#[inline]
 	fn get_esdt_token_data(
 		&self,
 		address: &Address,
-		token: &[u8],
+		token: &TokenIdentifier,
 		nonce: u64,
 	) -> EsdtTokenData<ArwenBigUint> {
 		unsafe {

--- a/elrond-wasm-node/src/api/send_api_node.rs
+++ b/elrond-wasm-node/src/api/send_api_node.rs
@@ -2,7 +2,7 @@ use super::{ArwenBigInt, ArwenBigUint};
 use crate::ArwenApiImpl;
 use alloc::vec::Vec;
 use elrond_wasm::api::{BlockchainApi, SendApi, StorageReadApi, StorageWriteApi};
-use elrond_wasm::types::{Address, ArgBuffer, BoxedBytes, CodeMetadata};
+use elrond_wasm::types::{Address, ArgBuffer, BoxedBytes, CodeMetadata, TokenIdentifier};
 
 extern "C" {
 	fn transferValue(

--- a/elrond-wasm-node/src/api/send_api_node.rs
+++ b/elrond-wasm-node/src/api/send_api_node.rs
@@ -160,7 +160,7 @@ impl SendApi for ArwenApiImpl {
 	fn direct_esdt_execute(
 		&self,
 		to: &Address,
-		token: &[u8],
+		token: &TokenIdentifier,
 		amount: &ArwenBigUint,
 		gas_limit: u64,
 		function: &[u8],
@@ -191,7 +191,7 @@ impl SendApi for ArwenApiImpl {
 	fn direct_esdt_nft_execute(
 		&self,
 		to: &Address,
-		token: &[u8],
+		token: &TokenIdentifier,
 		nonce: u64,
 		amount: &ArwenBigUint,
 		gas_limit: u64,

--- a/elrond-wasm-node/src/api/send_api_node.rs
+++ b/elrond-wasm-node/src/api/send_api_node.rs
@@ -117,6 +117,11 @@ impl SendApi for ArwenApiImpl {
 		BlockchainApi::get_sc_address(self)
 	}
 
+	#[inline]
+	fn get_gas_left(&self) -> u64 {
+		BlockchainApi::get_gas_left(self)
+	}
+
 	fn direct_egld(&self, to: &Address, amount: &ArwenBigUint, data: &[u8]) {
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);

--- a/elrond-wasm/src/api/blockchain_api.rs
+++ b/elrond-wasm/src/api/blockchain_api.rs
@@ -1,6 +1,6 @@
 use super::{BigUintApi, ErrorApi, StorageReadApi};
 use crate::storage;
-use crate::types::{Address, BoxedBytes, EsdtLocalRole, EsdtTokenData, H256, TokenIdentifier, Vec};
+use crate::types::{Address, BoxedBytes, EsdtLocalRole, EsdtTokenData, TokenIdentifier, Vec, H256};
 use alloc::boxed::Box;
 
 /// Interface to be used by the actual smart contract code.
@@ -56,7 +56,12 @@ pub trait BlockchainApi: StorageReadApi + ErrorApi + Clone + Sized + 'static {
 
 	fn get_current_esdt_nft_nonce(&self, address: &Address, token_id: &TokenIdentifier) -> u64;
 
-	fn get_esdt_balance(&self, address: &Address, token_id: &TokenIdentifier, nonce: u64) -> Self::BalanceType;
+	fn get_esdt_balance(
+		&self,
+		address: &Address,
+		token_id: &TokenIdentifier,
+		nonce: u64,
+	) -> Self::BalanceType;
 
 	fn get_esdt_token_data(
 		&self,

--- a/elrond-wasm/src/api/blockchain_api.rs
+++ b/elrond-wasm/src/api/blockchain_api.rs
@@ -1,6 +1,6 @@
 use super::{BigUintApi, ErrorApi, StorageReadApi};
 use crate::storage;
-use crate::types::{Address, BoxedBytes, EsdtLocalRole, EsdtTokenData, Vec, H256};
+use crate::types::{Address, BoxedBytes, EsdtLocalRole, EsdtTokenData, H256, TokenIdentifier, Vec};
 use alloc::boxed::Box;
 
 /// Interface to be used by the actual smart contract code.
@@ -54,14 +54,14 @@ pub trait BlockchainApi: StorageReadApi + ErrorApi + Clone + Sized + 'static {
 
 	fn get_prev_block_random_seed(&self) -> Box<[u8; 48]>;
 
-	fn get_current_esdt_nft_nonce(&self, address: &Address, token: &[u8]) -> u64;
+	fn get_current_esdt_nft_nonce(&self, address: &Address, token_id: &TokenIdentifier) -> u64;
 
-	fn get_esdt_balance(&self, address: &Address, token: &[u8], nonce: u64) -> Self::BalanceType;
+	fn get_esdt_balance(&self, address: &Address, token_id: &TokenIdentifier, nonce: u64) -> Self::BalanceType;
 
 	fn get_esdt_token_data(
 		&self,
 		address: &Address,
-		token: &[u8],
+		token_id: &TokenIdentifier,
 		nonce: u64,
 	) -> EsdtTokenData<Self::BalanceType>;
 
@@ -74,12 +74,12 @@ pub trait BlockchainApi: StorageReadApi + ErrorApi + Clone + Sized + 'static {
 
 	/// Retrieves local roles for the token, by reading protected storage.
 	#[inline]
-	fn get_esdt_local_roles(&self, token_id: &[u8]) -> Vec<EsdtLocalRole> {
+	fn get_esdt_local_roles(&self, token_id: &TokenIdentifier) -> Vec<EsdtLocalRole> {
 		let mut roles = Vec::new();
 
 		let key = [
 			storage::protected_keys::ELROND_ESDT_LOCAL_ROLES_KEY,
-			token_id,
+			token_id.as_esdt_identifier(),
 		]
 		.concat();
 		let raw_storage = storage::storage_get::<Self, BoxedBytes>(self.clone(), &key);

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -1,7 +1,6 @@
 use elrond_codec::TopEncode;
 
 use super::{BigIntApi, BigUintApi, ErrorApi, StorageReadApi, StorageWriteApi};
-use crate::hex_call_data::HexCallDataSerializer;
 use crate::types::{Address, ArgBuffer, AsyncCall, BoxedBytes, CodeMetadata, TokenIdentifier, Vec};
 
 pub const ESDT_TRANSFER_STRING: &[u8] = b"ESDTTransfer";
@@ -38,25 +37,11 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 		arg_buffer: &ArgBuffer,
 	) -> Result<(), &'static [u8]>;
 
-	/// Sends an ESDT token to a given address, directly.
-	/// Used especially for sending ESDT to regular accounts.
-	///
-	/// Unlike sending ESDT via async call, this method can be called multiple times per transaction.
-	fn direct_esdt_via_transf_exec(
-		&self,
-		to: &Address,
-		token: &[u8],
-		amount: &Self::AmountType,
-		data: &[u8],
-	) -> Result<(), &'static [u8]> {
-		self.direct_esdt_execute(to, token, amount, 0, data, &ArgBuffer::new())
-	}
-
 	/// Sends ESDT to an address and executes like an async call, but without callback.
 	fn direct_esdt_execute(
 		&self,
 		to: &Address,
-		token: &[u8],
+		token: &TokenIdentifier,
 		amount: &Self::AmountType,
 		gas_limit: u64,
 		function: &[u8],
@@ -67,7 +52,7 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 	fn direct_esdt_nft_execute(
 		&self,
 		to: &Address,
-		token: &[u8],
+		token: &TokenIdentifier,
 		nonce: u64,
 		amount: &Self::AmountType,
 		gas_limit: u64,
@@ -87,67 +72,7 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 		if token.is_egld() {
 			self.direct_egld(to, amount, data);
 		} else {
-			let _ = self.direct_esdt_via_transf_exec(to, token.as_esdt_identifier(), amount, data);
-		}
-	}
-
-	/// Sends ESDT tokens to the target address. Handles any type of ESDT.
-	/// Note: this does not work with EGLD, use only with ESDT.
-	fn transfer_tokens(
-		&self,
-		token: &TokenIdentifier,
-		nonce: u64,
-		amount: &Self::AmountType,
-		to: &Address,
-	) {
-		if amount > &0 {
-			if nonce == 0 {
-				let _ =
-					self.direct_esdt_via_transf_exec(to, token.as_esdt_identifier(), amount, &[]);
-			} else {
-				let _ = self.direct_esdt_nft_via_transfer_exec(
-					to,
-					token.as_esdt_identifier(),
-					nonce,
-					amount,
-					&[],
-				);
-			}
-		}
-	}
-
-	/// Performs a simple ESDT transfer, but via async call.
-	/// This is the preferred way to send ESDT.
-	fn direct_esdt_via_async_call(
-		&self,
-		to: &Address,
-		esdt_token_name: &[u8],
-		amount: &Self::AmountType,
-		data: &[u8],
-	) -> ! {
-		let mut serializer = HexCallDataSerializer::new(ESDT_TRANSFER_STRING);
-		serializer.push_argument_bytes(esdt_token_name);
-		serializer.push_argument_bytes(amount.to_bytes_be().as_slice());
-		if !data.is_empty() {
-			serializer.push_argument_bytes(data);
-		}
-		self.async_call_raw(&to, &Self::AmountType::zero(), serializer.as_slice())
-	}
-
-	/// Sends either EGLD or an ESDT token to the target address,
-	/// depending on what token identifier was specified.
-	/// In case of ESDT it performs an async call.
-	fn direct_via_async_call(
-		&self,
-		to: &Address,
-		token: &TokenIdentifier,
-		amount: &Self::AmountType,
-		data: &[u8],
-	) {
-		if token.is_egld() {
-			let _ = self.direct_egld(to, amount, data);
-		} else {
-			self.direct_esdt_via_async_call(to, token.as_esdt_identifier(), amount, data);
+			let _ = self.direct_esdt_execute(to, token, amount, 0, data, &ArgBuffer::new());
 		}
 	}
 
@@ -241,18 +166,18 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 	fn call_local_esdt_built_in_function(&self, gas: u64, function: &[u8], arg_buffer: &ArgBuffer);
 
 	/// Allows synchronous minting of ESDT tokens. Execution is resumed afterwards.
-	fn esdt_local_mint(&self, gas: u64, token: &[u8], amount: &Self::AmountType) {
+	fn esdt_local_mint(&self, gas: u64, token: &TokenIdentifier, amount: &Self::AmountType) {
 		let mut arg_buffer = ArgBuffer::new();
-		arg_buffer.push_argument_bytes(token);
+		arg_buffer.push_argument_bytes(token.as_esdt_identifier());
 		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
 
 		self.call_local_esdt_built_in_function(gas, b"ESDTLocalMint", &arg_buffer);
 	}
 
 	/// Allows synchronous burning of ESDT tokens. Execution is resumed afterwards.
-	fn esdt_local_burn(&self, gas: u64, token: &[u8], amount: &Self::AmountType) {
+	fn esdt_local_burn(&self, gas: u64, token: &TokenIdentifier, amount: &Self::AmountType) {
 		let mut arg_buffer = ArgBuffer::new();
-		arg_buffer.push_argument_bytes(token);
+		arg_buffer.push_argument_bytes(token.as_esdt_identifier());
 		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
 
 		self.call_local_esdt_built_in_function(gas, b"ESDTLocalBurn", &arg_buffer);
@@ -264,7 +189,7 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 	fn esdt_nft_create<T: elrond_codec::TopEncode>(
 		&self,
 		gas: u64,
-		token: &[u8],
+		token: &TokenIdentifier,
 		amount: &Self::AmountType,
 		name: &BoxedBytes,
 		royalties: &Self::AmountType,
@@ -273,7 +198,7 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 		uris: &[BoxedBytes],
 	) {
 		let mut arg_buffer = ArgBuffer::new();
-		arg_buffer.push_argument_bytes(token);
+		arg_buffer.push_argument_bytes(token.as_esdt_identifier());
 		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
 		arg_buffer.push_argument_bytes(name.as_slice());
 		arg_buffer.push_argument_bytes(royalties.to_bytes_be().as_slice());
@@ -297,9 +222,15 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 
 	/// Adds quantity for an Non-Fungible Token. (which makes it a Semi-Fungible Token by definition)  
 	/// This is a built-in function, so the smart contract execution is resumed after.
-	fn esdt_nft_add_quantity(&self, gas: u64, token: &[u8], nonce: u64, amount: &Self::AmountType) {
+	fn esdt_nft_add_quantity(
+		&self,
+		gas: u64,
+		token: &TokenIdentifier,
+		nonce: u64,
+		amount: &Self::AmountType,
+	) {
 		let mut arg_buffer = ArgBuffer::new();
-		arg_buffer.push_argument_bytes(token);
+		arg_buffer.push_argument_bytes(token.as_esdt_identifier());
 		arg_buffer.push_argument_bytes(&nonce.to_be_bytes()[..]);
 		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
 
@@ -308,68 +239,18 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 
 	/// The reverse operation of `esdt_nft_add_quantity`, this locally decreases
 	/// This is a built-in function, so the smart contract execution is resumed after.
-	fn esdt_nft_burn(&self, gas: u64, token: &[u8], nonce: u64, amount: &Self::AmountType) {
+	fn esdt_nft_burn(
+		&self,
+		gas: u64,
+		token: &TokenIdentifier,
+		nonce: u64,
+		amount: &Self::AmountType,
+	) {
 		let mut arg_buffer = ArgBuffer::new();
-		arg_buffer.push_argument_bytes(token);
+		arg_buffer.push_argument_bytes(token.as_esdt_identifier());
 		arg_buffer.push_argument_bytes(&nonce.to_be_bytes()[..]);
 		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
 
 		self.call_local_esdt_built_in_function(gas, b"ESDTNFTBurn", &arg_buffer);
-	}
-
-	/// Burns ESDT tokens. Handles any type of ESDT.
-	/// Note: this does not work with EGLD, use only with ESDT.
-	fn burn_tokens(
-		&self,
-		token: &TokenIdentifier,
-		nonce: u64,
-		amount: &Self::AmountType,
-		gas: u64,
-	) {
-		if amount > &0 {
-			if nonce == 0 {
-				self.esdt_local_burn(gas, token.as_esdt_identifier(), amount);
-			} else {
-				self.esdt_nft_burn(gas, token.as_esdt_identifier(), nonce, amount);
-			}
-		}
-	}
-
-	/// Performs a simple ESDT NFT transfer, but via async call.
-	/// This is the preferred way to send ESDT.
-	/// Note: call is done to the SC itself, so `from` should be the SCs own address
-	fn direct_esdt_nft_via_async_call(
-		&self,
-		from: &Address,
-		to: &Address,
-		token: &[u8],
-		nonce: u64,
-		amount: &Self::AmountType,
-		data: &[u8],
-	) {
-		let mut serializer = HexCallDataSerializer::new(ESDT_NFT_TRANSFER_STRING);
-		serializer.push_argument_bytes(token);
-		serializer.push_argument_bytes(&nonce.to_be_bytes()[..]);
-		serializer.push_argument_bytes(amount.to_bytes_be().as_slice());
-		serializer.push_argument_bytes(to.as_bytes());
-		if !data.is_empty() {
-			serializer.push_argument_bytes(data);
-		}
-		self.async_call_raw(&from, &Self::AmountType::zero(), serializer.as_slice());
-	}
-
-	/// Sends an ESDT NFT to a given address, directly.
-	/// Used especially for sending ESDT to regular accounts.
-	///
-	/// Unlike sending ESDT via async call, this method can be called multiple times per transaction.
-	fn direct_esdt_nft_via_transfer_exec(
-		&self,
-		to: &Address,
-		token: &[u8],
-		nonce: u64,
-		amount: &Self::AmountType,
-		data: &[u8],
-	) -> Result<(), &'static [u8]> {
-		self.direct_esdt_nft_execute(to, token, nonce, amount, 0, data, &ArgBuffer::new())
 	}
 }

--- a/elrond-wasm/src/api/uncallable/send_api_uncallable.rs
+++ b/elrond-wasm/src/api/uncallable/send_api_uncallable.rs
@@ -1,6 +1,6 @@
 use super::{BigIntUncallable, BigUintUncallable};
 use crate::api::SendApi;
-use crate::types::{Address, ArgBuffer, BoxedBytes, CodeMetadata};
+use crate::types::{Address, ArgBuffer, BoxedBytes, CodeMetadata, TokenIdentifier};
 use alloc::vec::Vec;
 
 impl SendApi for super::UncallableApi {
@@ -30,7 +30,7 @@ impl SendApi for super::UncallableApi {
 	fn direct_esdt_execute(
 		&self,
 		_to: &Address,
-		_token: &[u8],
+		_token: &TokenIdentifier,
 		_amount: &BigUintUncallable,
 		_gas: u64,
 		_function: &[u8],
@@ -42,7 +42,7 @@ impl SendApi for super::UncallableApi {
 	fn direct_esdt_nft_execute(
 		&self,
 		_to: &Address,
-		_token: &[u8],
+		_token: &TokenIdentifier,
 		_nonce: u64,
 		_amount: &BigUintUncallable,
 		_gas_limit: u64,

--- a/elrond-wasm/src/api/uncallable/send_api_uncallable.rs
+++ b/elrond-wasm/src/api/uncallable/send_api_uncallable.rs
@@ -12,6 +12,10 @@ impl SendApi for super::UncallableApi {
 		unreachable!()
 	}
 
+	fn get_gas_left(&self) -> u64 {
+		unreachable!()
+	}
+
 	fn direct_egld(&self, _to: &Address, _amount: &BigUintUncallable, _data: &[u8]) {
 		unreachable!()
 	}

--- a/elrond-wasm/src/esdt/system_sc_proxy.rs
+++ b/elrond-wasm/src/esdt/system_sc_proxy.rs
@@ -185,10 +185,10 @@ where
 	/// Produces a contract call to the ESDT system SC,
 	/// which causes it to mint more fungible ESDT tokens.
 	/// It will fail if the SC is not the owner of the token.
-	pub fn mint(self, token_identifier: &[u8], amount: &SA::AmountType) -> ContractCall<SA, ()> {
+	pub fn mint(self, token_identifier: &TokenIdentifier, amount: &SA::AmountType) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"mint");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 		contract_call.push_argument_raw_bytes(&amount.to_bytes_be());
 
 		contract_call
@@ -196,10 +196,10 @@ where
 
 	/// Produces a contract call to the ESDT system SC,
 	/// which causes it to burn fungible ESDT tokens owned by the SC.
-	pub fn burn(self, token_identifier: &[u8], amount: &SA::AmountType) -> ContractCall<SA, ()> {
+	pub fn burn(self, token_identifier: &TokenIdentifier, amount: &SA::AmountType) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"ESDTBurn");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 		contract_call.push_argument_raw_bytes(&amount.to_bytes_be());
 
 		contract_call
@@ -207,19 +207,19 @@ where
 
 	/// The manager of an ESDT token may choose to suspend all transactions of the token,
 	/// except minting, freezing/unfreezing and wiping.
-	pub fn pause(self, token_identifier: &[u8]) -> ContractCall<SA, ()> {
+	pub fn pause(self, token_identifier: &TokenIdentifier) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"pause");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 
 		contract_call
 	}
 
 	/// The reverse operation of `pause`.
-	pub fn unpause(self, token_identifier: &[u8]) -> ContractCall<SA, ()> {
+	pub fn unpause(self, token_identifier: &TokenIdentifier) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"unPause");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 
 		contract_call
 	}
@@ -227,20 +227,20 @@ where
 	/// The manager of an ESDT token may freeze the tokens held by a specific account.
 	/// As a consequence, no tokens may be transferred to or from the frozen account.
 	/// Freezing and unfreezing the tokens of an account are operations designed to help token managers to comply with regulations.
-	pub fn freeze(self, token_identifier: &[u8], address: &Address) -> ContractCall<SA, ()> {
+	pub fn freeze(self, token_identifier: &TokenIdentifier, address: &Address) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"freeze");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 		contract_call.push_argument_raw_bytes(address.as_bytes());
 
 		contract_call
 	}
 
 	/// The reverse operation of `freeze`, unfreezing, will allow further transfers to and from the account.
-	pub fn unfreeze(self, token_identifier: &[u8], address: &Address) -> ContractCall<SA, ()> {
+	pub fn unfreeze(self, token_identifier: &TokenIdentifier, address: &Address) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"unFreeze");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 		contract_call.push_argument_raw_bytes(address.as_bytes());
 
 		contract_call
@@ -250,10 +250,10 @@ where
 	/// This operation is similar to burning the tokens, but the account must have been frozen beforehand,
 	/// and it must be done by the token manager.
 	/// Wiping the tokens of an account is an operation designed to help token managers to comply with regulations.
-	pub fn wipe(self, token_identifier: &[u8], address: &Address) -> ContractCall<SA, ()> {
+	pub fn wipe(self, token_identifier: &TokenIdentifier, address: &Address) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"wipe");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 		contract_call.push_argument_raw_bytes(address.as_bytes());
 
 		contract_call
@@ -266,12 +266,12 @@ where
 	pub fn set_special_roles(
 		self,
 		address: &Address,
-		token_identifier: &[u8],
+		token_identifier: &TokenIdentifier,
 		roles: &[EsdtLocalRole],
 	) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"setSpecialRole");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 		contract_call.push_argument_raw_bytes(address.as_bytes());
 		for role in roles {
 			if role != &EsdtLocalRole::None {
@@ -289,12 +289,12 @@ where
 	pub fn unset_special_roles(
 		self,
 		address: &Address,
-		token_identifier: &[u8],
+		token_identifier: &TokenIdentifier,
 		roles: &[EsdtLocalRole],
 	) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"unSetSpecialRole");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 		contract_call.push_argument_raw_bytes(address.as_bytes());
 		for role in roles {
 			if role != &EsdtLocalRole::None {
@@ -307,12 +307,12 @@ where
 
 	pub fn transfer_ownership(
 		self,
-		token_identifier: &[u8],
+		token_identifier: &TokenIdentifier,
 		new_owner: &Address,
 	) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"transferOwnership");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 		contract_call.push_argument_raw_bytes(new_owner.as_bytes());
 
 		contract_call
@@ -320,13 +320,13 @@ where
 
 	pub fn transfer_nft_create_role(
 		self,
-		token_identifier: &[u8],
+		token_identifier: &TokenIdentifier,
 		old_creator: &Address,
 		new_creator: &Address,
 	) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"transferNFTCreateRole");
 
-		contract_call.push_argument_raw_bytes(token_identifier);
+		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
 		contract_call.push_argument_raw_bytes(old_creator.as_bytes());
 		contract_call.push_argument_raw_bytes(new_creator.as_bytes());
 

--- a/elrond-wasm/src/esdt/system_sc_proxy.rs
+++ b/elrond-wasm/src/esdt/system_sc_proxy.rs
@@ -185,7 +185,11 @@ where
 	/// Produces a contract call to the ESDT system SC,
 	/// which causes it to mint more fungible ESDT tokens.
 	/// It will fail if the SC is not the owner of the token.
-	pub fn mint(self, token_identifier: &TokenIdentifier, amount: &SA::AmountType) -> ContractCall<SA, ()> {
+	pub fn mint(
+		self,
+		token_identifier: &TokenIdentifier,
+		amount: &SA::AmountType,
+	) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"mint");
 
 		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
@@ -196,7 +200,11 @@ where
 
 	/// Produces a contract call to the ESDT system SC,
 	/// which causes it to burn fungible ESDT tokens owned by the SC.
-	pub fn burn(self, token_identifier: &TokenIdentifier, amount: &SA::AmountType) -> ContractCall<SA, ()> {
+	pub fn burn(
+		self,
+		token_identifier: &TokenIdentifier,
+		amount: &SA::AmountType,
+	) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"ESDTBurn");
 
 		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
@@ -227,7 +235,11 @@ where
 	/// The manager of an ESDT token may freeze the tokens held by a specific account.
 	/// As a consequence, no tokens may be transferred to or from the frozen account.
 	/// Freezing and unfreezing the tokens of an account are operations designed to help token managers to comply with regulations.
-	pub fn freeze(self, token_identifier: &TokenIdentifier, address: &Address) -> ContractCall<SA, ()> {
+	pub fn freeze(
+		self,
+		token_identifier: &TokenIdentifier,
+		address: &Address,
+	) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"freeze");
 
 		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
@@ -237,7 +249,11 @@ where
 	}
 
 	/// The reverse operation of `freeze`, unfreezing, will allow further transfers to and from the account.
-	pub fn unfreeze(self, token_identifier: &TokenIdentifier, address: &Address) -> ContractCall<SA, ()> {
+	pub fn unfreeze(
+		self,
+		token_identifier: &TokenIdentifier,
+		address: &Address,
+	) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"unFreeze");
 
 		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());
@@ -250,7 +266,11 @@ where
 	/// This operation is similar to burning the tokens, but the account must have been frozen beforehand,
 	/// and it must be done by the token manager.
 	/// Wiping the tokens of an account is an operation designed to help token managers to comply with regulations.
-	pub fn wipe(self, token_identifier: &TokenIdentifier, address: &Address) -> ContractCall<SA, ()> {
+	pub fn wipe(
+		self,
+		token_identifier: &TokenIdentifier,
+		address: &Address,
+	) -> ContractCall<SA, ()> {
 		let mut contract_call = self.esdt_system_sc_call_no_args(b"wipe");
 
 		contract_call.push_argument_raw_bytes(token_identifier.as_esdt_identifier());

--- a/elrond-wasm/src/types/general/token_identifier.rs
+++ b/elrond-wasm/src/types/general/token_identifier.rs
@@ -60,6 +60,11 @@ impl TokenIdentifier {
 	}
 
 	#[inline]
+	pub fn as_ptr(&self) -> *const u8 {
+		self.0.as_ptr()
+	}
+
+	#[inline]
 	pub fn as_name(&self) -> &[u8] {
 		if self.is_egld() {
 			TokenIdentifier::EGLD_REPRESENTATION

--- a/elrond-wasm/src/types/general/token_identifier.rs
+++ b/elrond-wasm/src/types/general/token_identifier.rs
@@ -42,6 +42,11 @@ impl TokenIdentifier {
 	}
 
 	#[inline]
+	pub fn len(&self) -> usize {
+		self.0.len()
+	}
+
+	#[inline]
 	pub fn into_boxed_bytes(self) -> BoxedBytes {
 		self.0
 	}

--- a/elrond-wasm/src/types/general/token_identifier.rs
+++ b/elrond-wasm/src/types/general/token_identifier.rs
@@ -33,7 +33,7 @@ impl TokenIdentifier {
 
 	#[inline]
 	pub fn is_egld(&self) -> bool {
-		self.0.is_empty()
+		self.is_empty()
 	}
 
 	#[inline]
@@ -44,6 +44,11 @@ impl TokenIdentifier {
 	#[inline]
 	pub fn len(&self) -> usize {
 		self.0.len()
+	}
+
+	#[inline]
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
 	}
 
 	#[inline]

--- a/elrond-wasm/src/types/interaction/contract_call.rs
+++ b/elrond-wasm/src/types/interaction/contract_call.rs
@@ -6,6 +6,11 @@ use crate::{
 use crate::{hex_call_data::HexCallDataSerializer, ArgId};
 use core::marker::PhantomData;
 
+/// Using max u64 to represent maximum possible gas,
+/// so that the value zero is not reserved and can be specified explicitly.
+/// Leaving the gas limit unspecified will replace it with `api.get_gas_left()`.
+const UNSPECIFIED_GAS_LIMIT: u64 = u64::MAX;
+
 /// Represents metadata for calling another contract.
 /// Can transform into either an async call, transfer call or other types of calls.
 #[must_use]
@@ -19,6 +24,7 @@ where
 	payment_amount: SA::AmountType,
 	payment_nonce: u64,
 	endpoint_name: BoxedBytes,
+	explicit_gas_limit: u64,
 	pub arg_buffer: ArgBuffer, // TODO: make private and find a better way to serialize
 	_return_type: PhantomData<R>,
 }
@@ -54,6 +60,7 @@ where
 			payment_token: TokenIdentifier::egld(),
 			payment_amount: SA::AmountType::zero(),
 			payment_nonce: 0,
+			explicit_gas_limit: UNSPECIFIED_GAS_LIMIT,
 			endpoint_name,
 			arg_buffer: ArgBuffer::new(),
 			_return_type: PhantomData,
@@ -72,6 +79,11 @@ where
 
 	pub fn with_nft_nonce(mut self, payment_nonce: u64) -> Self {
 		self.payment_nonce = payment_nonce;
+		self
+	}
+
+	pub fn with_gas_limit(mut self, gas_limit: u64) -> Self {
+		self.explicit_gas_limit = gas_limit;
 		self
 	}
 
@@ -102,6 +114,7 @@ where
 				payment_token: TokenIdentifier::egld(),
 				payment_amount: SA::AmountType::zero(),
 				payment_nonce: 0,
+				explicit_gas_limit: self.explicit_gas_limit,
 				endpoint_name: BoxedBytes::from(ESDT_TRANSFER_STRING),
 				arg_buffer: new_arg_buffer.concat(self.arg_buffer),
 				_return_type: PhantomData,
@@ -131,10 +144,19 @@ where
 				payment_token: TokenIdentifier::egld(),
 				payment_amount: SA::AmountType::zero(),
 				payment_nonce: 0,
+				explicit_gas_limit: self.explicit_gas_limit,
 				endpoint_name: BoxedBytes::from(ESDT_NFT_TRANSFER_STRING),
 				arg_buffer: new_arg_buffer.concat(self.arg_buffer),
 				_return_type: PhantomData,
 			}
+		}
+	}
+
+	fn resolve_gas_limit(&self) -> u64 {
+		if self.explicit_gas_limit == UNSPECIFIED_GAS_LIMIT {
+			self.api.get_gas_left()
+		} else {
+			self.explicit_gas_limit
 		}
 	}
 
@@ -160,10 +182,10 @@ where
 {
 	/// Executes immediately, synchronously, and returns contract call result.
 	/// Only works if the target contract is in the same shard.
-	pub fn execute_on_dest_context(mut self, gas: u64) -> R {
+	pub fn execute_on_dest_context(mut self) -> R {
 		self = self.convert_to_esdt_transfer_call();
 		let raw_result = self.api.execute_on_dest_context_raw(
-			gas,
+			self.resolve_gas_limit(),
 			&self.to,
 			&self.payment_amount,
 			self.endpoint_name.as_slice(),
@@ -181,13 +203,13 @@ where
 	/// Will be eliminated after some future Arwen hook redesign.
 	/// `range_closure` takes the number of results before, the number of results after,
 	/// and is expected to return the start index (inclusive) and end index (exclusive).
-	pub fn execute_on_dest_context_custom_range<F>(mut self, gas: u64, range_closure: F) -> R
+	pub fn execute_on_dest_context_custom_range<F>(mut self, range_closure: F) -> R
 	where
 		F: FnOnce(usize, usize) -> (usize, usize),
 	{
 		self = self.convert_to_esdt_transfer_call();
 		let raw_result = self.api.execute_on_dest_context_raw_custom_result_range(
-			gas,
+			self.resolve_gas_limit(),
 			&self.to,
 			&self.payment_amount,
 			self.endpoint_name.as_slice(),
@@ -207,10 +229,10 @@ where
 	/// Executes immediately, synchronously.
 	/// The result (if any) is ignored.
 	/// Only works if the target contract is in the same shard.
-	pub fn execute_on_dest_context_ignore_result(mut self, gas: u64) {
+	pub fn execute_on_dest_context_ignore_result(mut self) {
 		self = self.convert_to_esdt_transfer_call();
 		let _ = self.api.execute_on_dest_context_raw(
-			gas,
+			self.resolve_gas_limit(),
 			&self.to,
 			&self.payment_amount,
 			self.endpoint_name.as_slice(),
@@ -221,7 +243,8 @@ where
 	/// Immediately launches a transfer-execute call.
 	/// This is similar to an async call, but there is no callback
 	/// and there can be more than one such call per transaction.
-	pub fn transfer_execute(self, gas_limit: u64) {
+	pub fn transfer_execute(self) {
+		let gas_limit = self.resolve_gas_limit();
 		let result = if self.payment_token.is_egld() {
 			self.api.direct_egld_execute(
 				&self.to,

--- a/elrond-wasm/src/types/interaction/contract_call.rs
+++ b/elrond-wasm/src/types/interaction/contract_call.rs
@@ -234,7 +234,7 @@ where
 			// fungible ESDT
 			self.api.direct_esdt_execute(
 				&self.to,
-				self.payment_token.as_esdt_identifier(),
+				&self.payment_token,
 				&self.payment_amount,
 				gas_limit,
 				self.endpoint_name.as_slice(),
@@ -244,7 +244,7 @@ where
 			// non-fungible/semi-fungible ESDT
 			self.api.direct_esdt_nft_execute(
 				&self.to,
-				self.payment_token.as_esdt_identifier(),
+				&self.payment_token,
 				self.payment_nonce,
 				&self.payment_amount,
 				gas_limit,

--- a/elrond-wasm/src/types/interaction/send_esdt.rs
+++ b/elrond-wasm/src/types/interaction/send_esdt.rs
@@ -1,7 +1,7 @@
 use crate::abi::{OutputAbi, TypeAbi, TypeDescriptionContainer};
 use crate::api::SendApi;
 use crate::io::EndpointResult;
-use crate::types::{Address, BoxedBytes};
+use crate::types::{Address, BoxedBytes, TokenIdentifier};
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -24,9 +24,9 @@ where
 
 	#[inline]
 	fn finish<FA>(&self, _api: FA) {
-		self.api.direct_esdt_via_async_call(
+		self.api.transfer_esdt_via_async_call(
 			&self.to,
-			&self.token_name.as_slice(),
+			&TokenIdentifier::from(self.token_name.clone()),
 			&self.amount,
 			self.data.as_slice(),
 		);

--- a/elrond-wasm/src/types/interaction/send_token.rs
+++ b/elrond-wasm/src/types/interaction/send_token.rs
@@ -24,8 +24,17 @@ where
 
 	#[inline]
 	fn finish<FA>(&self, _api: FA) {
-		self.api
-			.direct_via_async_call(&self.to, &self.token, &self.amount, self.data.as_slice());
+		if self.token.is_egld() {
+			self.api
+				.direct_egld(&self.to, &self.amount, self.data.as_slice());
+		} else {
+			self.api.transfer_esdt_via_async_call(
+				&self.to,
+				&self.token,
+				&self.amount,
+				self.data.as_slice(),
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
Using built-in TokenIdentifier instead of &[u8] slice everywhere.

Removing some functions from send-api that just mask other functions.

Fixing contracts accordingly.