### PR TITLE
Add FromResidual for SCResult from Result

### DIFF
--- a/contracts/feature-tests/basic-features/mandos/sc_result.scen.json
+++ b/contracts/feature-tests/basic-features/mandos/sc_result.scen.json
@@ -250,6 +250,54 @@
                 "gas": "*",
                 "refund": "*"
             }
+        },
+        {
+            "step": "scCall",
+            "txId": "result_echo_2 - option is none",
+            "tx": {
+                "from": "address:an_account",
+                "to": "sc:basic-features",
+                "value": "0",
+                "function": "result_echo_2",
+                "arguments": [
+                    "0"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "4",
+                "message": "str:option argument is none",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "result_echo_2 - ok",
+            "tx": {
+                "from": "address:an_account",
+                "to": "sc:basic-features",
+                "value": "0",
+                "function": "result_echo_2",
+                "arguments": [
+                    "1|nested:str:test string echo 2"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [
+                    "str:test string echo 2"
+                ],
+                "status": "0",
+                "message": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
         }
     ]
 }

--- a/contracts/feature-tests/basic-features/src/macros.rs
+++ b/contracts/feature-tests/basic-features/src/macros.rs
@@ -59,4 +59,10 @@ pub trait Macros {
 		let unwrapped = SCResult::from_result(arg.ok_or("option argument is none"))?;
 		Ok(unwrapped)
 	}
+
+	#[endpoint]
+	fn result_echo_2(&self, arg: Option<String>) -> SCResult<String> {
+		let unwrapped = arg.ok_or("option argument is none")?;
+		Ok(unwrapped)
+	}
 }

--- a/elrond-wasm/src/types/io/sc_result.rs
+++ b/elrond-wasm/src/types/io/sc_result.rs
@@ -3,6 +3,7 @@ use crate::abi::{OutputAbi, TypeAbi, TypeDescriptionContainer};
 use crate::api::EndpointFinishApi;
 use crate::EndpointResult;
 use crate::*;
+use core::convert;
 use core::ops::{ControlFlow, FromResidual, Try};
 
 /// Default way to optionally return an error from a smart contract endpoint.
@@ -75,6 +76,18 @@ impl<T> Try for SCResult<T> {
 impl<T> FromResidual for SCResult<T> {
 	fn from_residual(r: SCError) -> Self {
 		SCResult::Err(r)
+	}
+}
+
+impl<T, E> FromResidual<Result<convert::Infallible, E>> for SCResult<T>
+where
+	E: Into<SCError>,
+{
+	fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
+		match residual {
+			Ok(_) => unreachable!(),
+			Err(e) => SCResult::Err(e.into()),
+		}
 	}
 }
 


### PR DESCRIPTION
This pull request allows the use of `?` on `Result` types inside methods which return `SCResult`.
Some common cases where this would be needed are:
- when calling `Option::ok_or` - usage: `value.ok_or("error message")?;`
Note: there's an implicit conversion of the error message from `&str` to `SCResult`.
- when a function which returns a `Result<T, SCError>`
