### PR TITLE
Nft marketplace sft support

### DIFF
--- a/contracts/examples/esdt-nft-marketplace/mandos/auction_end_deadline.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/auction_end_deadline.scen.json
@@ -22,10 +22,9 @@
                 "value": "0",
                 "function": "endAuction",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "9,000,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -87,7 +86,8 @@
                     "balance": "0",
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:NFT-123456|u64:1": ""
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|nested:str:NFT-123456|u64:1": ""
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"
                 },

--- a/contracts/examples/esdt-nft-marketplace/mandos/auction_end_max_bid.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/auction_end_max_bid.scen.json
@@ -15,10 +15,9 @@
                 "value": "0",
                 "function": "endAuction",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "9,000,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -80,7 +79,8 @@
                     "balance": "0",
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:NFT-123456|u64:1": ""
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|nested:str:NFT-123456|u64:1": ""
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"
                 },

--- a/contracts/examples/esdt-nft-marketplace/mandos/auction_sell_all_end_deadline.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/auction_sell_all_end_deadline.scen.json
@@ -1,0 +1,98 @@
+{
+    "name": "end auction by reaching the deadline",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "bid_sft_sell_all_second.scen.json"
+        },
+        {
+            "step": "setState",
+            "comment": "set current block timestamp",
+            "currentBlockInfo": {
+                "blockTimestamp": "234,567"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "auction end deadline",
+            "comment": "owner, creator and seller will receive part of the final bid",
+            "tx": {
+                "from": "address:second_bidder",
+                "to": "sc:marketplace",
+                "value": "0",
+                "function": "endAuction",
+                "arguments": [
+                    "1"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:owner": {
+                    "nonce": "1",
+                    "balance": "20",
+                    "storage": {}
+                },
+                "address:nft_creator": {
+                    "nonce": "0",
+                    "balance": "40",
+                    "esdt": {
+                        "str:NFT-123456": {
+                            "roles": [
+                                "ESDTRoleNFTCreate"
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "address:seller": {
+                    "nonce": "1",
+                    "balance": "140",
+                    "storage": {}
+                },
+                "address:first_bidder": {
+                    "nonce": "1",
+                    "balance": "1000",
+                    "storage": {}
+                },
+                "address:second_bidder": {
+                    "nonce": "2",
+                    "balance": "800",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "10",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|nested:str:NFT-123456|u64:1": ""
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/mandos/auction_sell_one_by_one_end_deadline.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/auction_sell_one_by_one_end_deadline.scen.json
@@ -1,0 +1,125 @@
+{
+    "name": "end auction by reaching the deadline",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "bid_sft_sell_one_by_one_second.scen.json"
+        },
+        {
+            "step": "setState",
+            "comment": "set current block timestamp",
+            "currentBlockInfo": {
+                "blockTimestamp": "234,567"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "auction end deadline",
+            "comment": "owner, creator and seller will receive part of the final bid",
+            "tx": {
+                "from": "address:second_bidder",
+                "to": "sc:marketplace",
+                "value": "0",
+                "function": "endAuction",
+                "arguments": [
+                    "1"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:owner": {
+                    "nonce": "1",
+                    "balance": "20",
+                    "storage": {}
+                },
+                "address:nft_creator": {
+                    "nonce": "0",
+                    "balance": "40",
+                    "esdt": {
+                        "str:NFT-123456": {
+                            "roles": [
+                                "ESDTRoleNFTCreate"
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "address:seller": {
+                    "nonce": "1",
+                    "balance": "140",
+                    "storage": {}
+                },
+                "address:first_bidder": {
+                    "nonce": "1",
+                    "balance": "1000",
+                    "storage": {}
+                },
+                "address:second_bidder": {
+                    "nonce": "2",
+                    "balance": "800",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "9",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:SFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:9",
+                            "02-auction_type": "u8:3",
+                            "03-auction_status": "u8:2",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:200",
+                            "11-current_winner": "address:second_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
+                        }
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/mandos/auction_sft_sell_all.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/auction_sft_sell_all.scen.json
@@ -1,0 +1,99 @@
+{
+    "name": "auction sft sell all",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "init.scen.json"
+        },
+        {
+            "step": "setState",
+            "comment": "set current block timestamp",
+            "currentBlockInfo": {
+                "blockTimestamp": "123,000"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "auctionToken",
+            "comment": "arguments are: min_bid, max_bid, deadline, payment token. Nonce is skipped, since EGLD has no nonce",
+            "tx": {
+                "from": "address:seller",
+                "to": "sc:marketplace",
+                "value": "0",
+                "esdt": {
+                    "tokenIdentifier": "str:SFT-123456",
+                    "nonce": "1",
+                    "value": "10"
+                },
+                "function": "auctionToken",
+                "arguments": [
+                    "100",
+                    "1,000",
+                    "123,456",
+                    "str:EGLD"
+                ],
+                "gasLimit": "20,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:seller": {
+                    "nonce": "1",
+                    "balance": "0",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": []
+                        }
+                    },
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "10",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:SFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:10",
+                            "02-auction_type": "u8:2",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:0",
+                            "11-current_winner": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
+                        }
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/mandos/auction_sft_sell_one_by_one.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/auction_sft_sell_one_by_one.scen.json
@@ -1,0 +1,101 @@
+{
+    "name": "auction sft sell all",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "init.scen.json"
+        },
+        {
+            "step": "setState",
+            "comment": "set current block timestamp",
+            "currentBlockInfo": {
+                "blockTimestamp": "123,000"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "auctionToken",
+            "comment": "arguments are: min_bid, max_bid, deadline, payment token, nonce 0, and true to flag only one token per user",
+            "tx": {
+                "from": "address:seller",
+                "to": "sc:marketplace",
+                "value": "0",
+                "esdt": {
+                    "tokenIdentifier": "str:SFT-123456",
+                    "nonce": "1",
+                    "value": "10"
+                },
+                "function": "auctionToken",
+                "arguments": [
+                    "100",
+                    "1,000",
+                    "123,456",
+                    "str:EGLD",
+                    "0",
+                    "true"
+                ],
+                "gasLimit": "20,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:seller": {
+                    "nonce": "1",
+                    "balance": "0",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": []
+                        }
+                    },
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "10",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:SFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:10",
+                            "02-auction_type": "u8:3",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:0",
+                            "11-current_winner": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
+                        }
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/mandos/auction_token.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/auction_token.scen.json
@@ -32,7 +32,7 @@
                     "123,456",
                     "str:EGLD"
                 ],
-                "gasLimit": "13,500,000",
+                "gasLimit": "20,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -72,17 +72,22 @@
                     },
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:NFT-123456|u64:1": {
-                            "0-payment_token": "nested:str:EGLD|u64:0",
-                            "1-min_bid": "biguint:100",
-                            "2-max_bid": "biguint:1000",
-                            "3-start_time": "u64:123,000",
-                            "4-deadline": "u64:123,456",
-                            "5-original_owner": "address:seller",
-                            "6-current_bid": "biguint:0",
-                            "7-current_winner": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                            "8-marketplace_cut_percentage": "biguint:1000",
-                            "9-creator_royalties_percentage": "biguint:2000"
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:NFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:1",
+                            "02-auction_type": "u8:1",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:0",
+                            "11-current_winner": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
                         }
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"

--- a/contracts/examples/esdt-nft-marketplace/mandos/auction_with_start_time.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/auction_with_start_time.scen.json
@@ -31,10 +31,11 @@
                     "1,000",
                     "123,456",
                     "str:EGLD",
+                    "false",
                     "0",
                     "123,333"
                 ],
-                "gasLimit": "13,500,000",
+                "gasLimit": "20,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -74,17 +75,22 @@
                     },
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:NFT-123456|u64:1": {
-                            "0-payment_token": "nested:str:EGLD|u64:0",
-                            "1-min_bid": "biguint:100",
-                            "2-max_bid": "biguint:1000",
-                            "3-start_time": "u64:123,333",
-                            "4-deadline": "u64:123,456",
-                            "5-original_owner": "address:seller",
-                            "6-current_bid": "biguint:0",
-                            "7-current_winner": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                            "8-marketplace_cut_percentage": "biguint:1000",
-                            "9-creator_royalties_percentage": "biguint:2000"
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:NFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:1",
+                            "02-auction_type": "u8:1",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,333",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:0",
+                            "11-current_winner": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
                         }
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"
@@ -101,6 +107,7 @@
                 "value": "100",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
@@ -130,10 +137,11 @@
                 "value": "100",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -168,19 +176,22 @@
                     },
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:NFT-123456|u64:1": {
-                            "str:auctionForToken|nested:str:NFT-123456|u64:1": {
-                                "0-payment_token": "nested:str:EGLD|u64:0",
-                                "1-min_bid": "biguint:100",
-                                "2-max_bid": "biguint:1000",
-                                "3-start_time": "u64:123,333",
-                                "4-deadline": "u64:123,456",
-                                "5-original_owner": "address:seller",
-                                "6-current_bid": "biguint:100",
-                                "7-current_winner": "address:first_bidder",
-                                "8-marketplace_cut_percentage": "biguint:1000",
-                                "9-creator_royalties_percentage": "biguint:2000"
-                            }
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:NFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:1",
+                            "02-auction_type": "u8:1",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,333",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:100",
+                            "11-current_winner": "address:first_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
                         }
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"

--- a/contracts/examples/esdt-nft-marketplace/mandos/bid_first.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/bid_first.scen.json
@@ -14,10 +14,11 @@
                 "value": "100",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -52,19 +53,22 @@
                     },
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:NFT-123456|u64:1": {
-                            "str:auctionForToken|nested:str:NFT-123456|u64:1": {
-                                "0-payment_token": "nested:str:EGLD|u64:0",
-                                "1-min_bid": "biguint:100",
-                                "2-max_bid": "biguint:1000",
-                                "3-start_time": "u64:123,000",
-                                "4-deadline": "u64:123,456",
-                                "5-original_owner": "address:seller",
-                                "6-current_bid": "biguint:100",
-                                "7-current_winner": "address:first_bidder",
-                                "8-marketplace_cut_percentage": "biguint:1000",
-                                "9-creator_royalties_percentage": "biguint:2000"
-                            }
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:NFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:1",
+                            "02-auction_type": "u8:1",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:100",
+                            "11-current_winner": "address:first_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
                         }
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"

--- a/contracts/examples/esdt-nft-marketplace/mandos/bid_max.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/bid_max.scen.json
@@ -14,10 +14,11 @@
                 "value": "1000",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "9,000,000",
+                "gasLimit": "11,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -57,17 +58,22 @@
                     },
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:NFT-123456|u64:1": {
-                            "0-payment_token": "nested:str:EGLD|u64:0",
-                            "1-min_bid": "biguint:100",
-                            "2-max_bid": "biguint:1000",
-                            "3-start_time": "u64:123,000",
-                            "4-deadline": "u64:123,456",
-                            "5-original_owner": "address:seller",
-                            "6-current_bid": "biguint:1000",
-                            "7-current_winner": "address:first_bidder",
-                            "8-marketplace_cut_percentage": "biguint:1000",
-                            "9-creator_royalties_percentage": "biguint:2000"
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:NFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:1",
+                            "02-auction_type": "u8:1",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:1000",
+                            "11-current_winner": "address:first_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
                         }
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"

--- a/contracts/examples/esdt-nft-marketplace/mandos/bid_second.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/bid_second.scen.json
@@ -14,10 +14,11 @@
                 "value": "200",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -57,17 +58,22 @@
                     },
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:NFT-123456|u64:1": {
-                            "0-payment_token": "nested:str:EGLD|u64:0",
-                            "1-min_bid": "biguint:100",
-                            "2-max_bid": "biguint:1000",
-                            "3-start_time": "u64:123,000",
-                            "4-deadline": "u64:123,456",
-                            "5-original_owner": "address:seller",
-                            "6-current_bid": "biguint:200",
-                            "7-current_winner": "address:second_bidder",
-                            "8-marketplace_cut_percentage": "biguint:1000",
-                            "9-creator_royalties_percentage": "biguint:2000"
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:NFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:1",
+                            "02-auction_type": "u8:1",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:200",
+                            "11-current_winner": "address:second_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
                         }
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"

--- a/contracts/examples/esdt-nft-marketplace/mandos/bid_sft_sell_all_first.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/bid_sft_sell_all_first.scen.json
@@ -1,0 +1,80 @@
+{
+    "name": "first bid",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "auction_sft_sell_all.scen.json"
+        },
+        {
+            "step": "scCall",
+            "txId": "first bid",
+            "tx": {
+                "from": "address:first_bidder",
+                "to": "sc:marketplace",
+                "value": "100",
+                "function": "bid",
+                "arguments": [
+                    "1",
+                    "str:SFT-123456",
+                    "1"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:first_bidder": {
+                    "nonce": "1",
+                    "balance": "900",
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "100",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "10",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:SFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:10",
+                            "02-auction_type": "u8:2",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:100",
+                            "11-current_winner": "address:first_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
+                        }
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/mandos/bid_sft_sell_all_second.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/bid_sft_sell_all_second.scen.json
@@ -1,0 +1,85 @@
+{
+    "name": "second bid",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "bid_sft_sell_all_first.scen.json"
+        },
+        {
+            "step": "scCall",
+            "txId": "second bid",
+            "tx": {
+                "from": "address:second_bidder",
+                "to": "sc:marketplace",
+                "value": "200",
+                "function": "bid",
+                "arguments": [
+                    "1",
+                    "str:SFT-123456",
+                    "1"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:first_bidder": {
+                    "nonce": "1",
+                    "balance": "1000",
+                    "storage": {}
+                },
+                "address:second_bidder": {
+                    "nonce": "1",
+                    "balance": "800",
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "200",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "10",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:SFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:10",
+                            "02-auction_type": "u8:2",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:200",
+                            "11-current_winner": "address:second_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
+                        }
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/mandos/bid_sft_sell_one_by_one_first.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/bid_sft_sell_one_by_one_first.scen.json
@@ -1,0 +1,80 @@
+{
+    "name": "first bid",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "auction_sft_sell_one_by_one.scen.json"
+        },
+        {
+            "step": "scCall",
+            "txId": "first bid",
+            "tx": {
+                "from": "address:first_bidder",
+                "to": "sc:marketplace",
+                "value": "100",
+                "function": "bid",
+                "arguments": [
+                    "1",
+                    "str:SFT-123456",
+                    "1"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:first_bidder": {
+                    "nonce": "1",
+                    "balance": "900",
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "100",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "10",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:SFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:10",
+                            "02-auction_type": "u8:3",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:100",
+                            "11-current_winner": "address:first_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
+                        }
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/mandos/bid_sft_sell_one_by_one_second.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/bid_sft_sell_one_by_one_second.scen.json
@@ -1,0 +1,85 @@
+{
+    "name": "second bid",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "bid_sft_sell_one_by_one_first.scen.json"
+        },
+        {
+            "step": "scCall",
+            "txId": "second bid",
+            "tx": {
+                "from": "address:second_bidder",
+                "to": "sc:marketplace",
+                "value": "200",
+                "function": "bid",
+                "arguments": [
+                    "1",
+                    "str:SFT-123456",
+                    "1"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:first_bidder": {
+                    "nonce": "1",
+                    "balance": "1000",
+                    "storage": {}
+                },
+                "address:second_bidder": {
+                    "nonce": "1",
+                    "balance": "800",
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "200",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "10",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:SFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:10",
+                            "02-auction_type": "u8:3",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:200",
+                            "11-current_winner": "address:second_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
+                        }
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/mandos/buy_sft_after_end_auction.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/buy_sft_after_end_auction.scen.json
@@ -1,0 +1,131 @@
+{
+    "name": "buy sft after end auction - only for sell ony by one type of auction",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "auction_sell_one_by_one_end_deadline.scen.json"
+        },
+        {
+            "step": "scCall",
+            "txId": "first-bidder-buy-after-end",
+            "tx": {
+                "from": "address:first_bidder",
+                "to": "sc:marketplace",
+                "value": "200",
+                "function": "buySftAfterEndAuction",
+                "arguments": [
+                    "1",
+                    "str:SFT-123456",
+                    "1"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:owner": {
+                    "nonce": "1",
+                    "balance": "40",
+                    "storage": {}
+                },
+                "address:nft_creator": {
+                    "nonce": "0",
+                    "balance": "80",
+                    "esdt": {
+                        "str:NFT-123456": {
+                            "roles": [
+                                "ESDTRoleNFTCreate"
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "address:seller": {
+                    "nonce": "1",
+                    "balance": "280",
+                    "storage": {}
+                },
+                "address:first_bidder": {
+                    "nonce": "2",
+                    "balance": "800",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "address:second_bidder": {
+                    "nonce": "2",
+                    "balance": "800",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "8",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:SFT-123456|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:8",
+                            "02-auction_type": "u8:3",
+                            "03-auction_status": "u8:2",
+                            "04-payment_token": "nested:str:EGLD|u64:0",
+                            "05-min_bid": "biguint:100",
+                            "06-max_bid": "biguint:1000",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:123,456",
+                            "09-original_owner": "address:seller",
+                            "10-current_bid": "biguint:200",
+                            "11-current_winner": "address:first_bidder",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:2000"
+                        }
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/mandos/init.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/init.scen.json
@@ -34,6 +34,16 @@
                                     "royalties": "2000"
                                 }
                             ]
+                        },
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "10",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
                         }
                     },
                     "storage": {}

--- a/contracts/examples/esdt-nft-marketplace/mandos/init.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/init.scen.json
@@ -68,7 +68,7 @@
                 "arguments": [
                     "1000"
                 ],
-                "gasLimit": "6,500,000",
+                "gasLimit": "8,000,000",
                 "gasPrice": "0"
             },
             "expect": {

--- a/contracts/examples/esdt-nft-marketplace/mandos/invalid_bids.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/invalid_bids.scen.json
@@ -14,15 +14,16 @@
                 "value": "500",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:ANOTHERNFT-123456",
                     "5"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
                 "status": "4",
-                "message": "str:Token is not up for auction",
+                "message": "str:Auction ID does not match the token",
                 "gas": "*",
                 "refund": "*"
             }
@@ -36,10 +37,11 @@
                 "value": "0",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -65,10 +67,11 @@
                 "value": "500",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -108,10 +111,11 @@
                 },
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -130,10 +134,11 @@
                 "value": "300",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -152,10 +157,11 @@
                 "value": "50",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -174,10 +180,11 @@
                 "value": "150",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -196,10 +203,11 @@
                 "value": "1500",
                 "function": "bid",
                 "arguments": [
+                    "1",
                     "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "8,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {

--- a/contracts/examples/esdt-nft-marketplace/mandos/specific_token_auctioned.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/specific_token_auctioned.scen.json
@@ -42,7 +42,7 @@
         {
             "step": "scCall",
             "txId": "auctionToken",
-            "comment": "arguments are: min_bid, max_bid, deadline, payment token. Nonce is skipped, since EGLD has no nonce",
+            "comment": "arguments are: min_bid, max_bid, deadline, payment token. Nonce is skipped, since token is fungible.",
             "tx": {
                 "from": "address:other_seller",
                 "to": "sc:marketplace",
@@ -59,7 +59,7 @@
                     "0x60C63784",
                     "str:BUSD-123456"
                 ],
-                "gasLimit": "14,000,000",
+                "gasLimit": "20,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -104,17 +104,22 @@
                     },
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:BBIT-1b9bb6|u64:1": {
-                            "0-payment_token": "nested:str:BUSD-123456|u64:0",
-                            "1-min_bid": "biguint:0x01",
-                            "2-max_bid": "biguint:0x46",
-                            "3-start_time": "u64:123,000",
-                            "4-deadline": "u64:0x60C63784",
-                            "5-original_owner": "address:other_seller",
-                            "6-current_bid": "biguint:0",
-                            "7-current_winner": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                            "8-marketplace_cut_percentage": "biguint:1000",
-                            "9-creator_royalties_percentage": "biguint:1000"
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": {
+                            "00-auctioned_token": "nested:str:BBIT-1b9bb6|u64:1",
+                            "01-nr_auctioned_tokens": "biguint:1",
+                            "02-auction_type": "u8:1",
+                            "03-auction_status": "u8:1",
+                            "04-payment_token": "nested:str:BUSD-123456|u64:0",
+                            "05-min_bid": "biguint:0x01",
+                            "06-max_bid": "biguint:0x46",
+                            "07-start_time": "u64:123,000",
+                            "08-deadline": "u64:0x60C63784",
+                            "09-original_owner": "address:other_seller",
+                            "10-current_bid": "biguint:0",
+                            "11-current_winner": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "12-marketplace_cut_percentage": "biguint:1000",
+                            "13-creator_royalties_percentage": "biguint:1000"
                         }
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"

--- a/contracts/examples/esdt-nft-marketplace/mandos/view_functions.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/view_functions.scen.json
@@ -7,12 +7,11 @@
         },
         {
             "step": "scQuery",
-            "txId": "isAlreadyUpForAuction",
+            "txId": "doesAuctionExist",
             "tx": {
                 "to": "sc:marketplace",
-                "function": "isAlreadyUpForAuction",
+                "function": "doesAuctionExist",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ]
             },
@@ -26,12 +25,11 @@
         },
         {
             "step": "scQuery",
-            "txId": "isAlreadyUpForAuction",
+            "txId": "doesAuctionExist",
             "tx": {
                 "to": "sc:marketplace",
-                "function": "isAlreadyUpForAuction",
+                "function": "doesAuctionExist",
                 "arguments": [
-                    "str:ANOTHERNFT-123456",
                     "5"
                 ]
             },
@@ -45,12 +43,67 @@
         },
         {
             "step": "scQuery",
-            "txId": "getPaymentTokenForAuctionedNft",
+            "txId": "getAuctionedToken",
             "tx": {
                 "to": "sc:marketplace",
-                "function": "getPaymentTokenForAuctionedNft",
+                "function": "getAuctionedToken",
                 "arguments": [
+                    "1"
+                ]
+            },
+            "expect": {
+                "out": [
                     "str:NFT-123456",
+                    "1",
+                    "1"
+                ],
+                "status": "0",
+                "message": ""
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "getAuctionType",
+            "tx": {
+                "to": "sc:marketplace",
+                "function": "getAuctionType",
+                "arguments": [
+                    "1"
+                ]
+            },
+            "expect": {
+                "out": [
+                    "1"
+                ],
+                "status": "0",
+                "message": ""
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "getAuctionStatus",
+            "tx": {
+                "to": "sc:marketplace",
+                "function": "getAuctionStatus",
+                "arguments": [
+                    "1"
+                ]
+            },
+            "expect": {
+                "out": [
+                    "1"
+                ],
+                "status": "0",
+                "message": ""
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "getPaymentTokenForAuction",
+            "tx": {
+                "to": "sc:marketplace",
+                "function": "getPaymentTokenForAuction",
+                "arguments": [
                     "1"
                 ]
             },
@@ -70,7 +123,6 @@
                 "to": "sc:marketplace",
                 "function": "getMinMaxBid",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ]
             },
@@ -90,7 +142,6 @@
                 "to": "sc:marketplace",
                 "function": "getDeadline",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ]
             },
@@ -109,7 +160,6 @@
                 "to": "sc:marketplace",
                 "function": "getOriginalOwner",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ]
             },
@@ -128,7 +178,6 @@
                 "to": "sc:marketplace",
                 "function": "getCurrentWinningBid",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ]
             },
@@ -147,7 +196,6 @@
                 "to": "sc:marketplace",
                 "function": "getCurrentWinner",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ]
             },
@@ -166,23 +214,26 @@
                 "to": "sc:marketplace",
                 "function": "getFullAuctionData",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ]
             },
             "expect": {
                 "out": [
                     {
-                        "0-payment_token": "nested:str:EGLD|u64:0",
-                        "1-min_bid": "biguint:100",
-                        "2-max_bid": "biguint:1000",
-                        "3-start_time": "u64:123,000",
-                        "4-deadline": "u64:123,456",
-                        "5-original_owner": "address:seller",
-                        "6-current_bid": "biguint:200",
-                        "7-current_winner": "address:second_bidder",
-                        "8-marketplace_cut_percentage": "biguint:1000",
-                        "9-creator_royalties_percentage": "biguint:2000"
+                        "00-auctioned_token": "nested:str:NFT-123456|u64:1",
+                        "01-nr_auctioned_tokens": "biguint:1",
+                        "02-auction_type": "u8:1",
+                        "03-auction_status": "u8:1",
+                        "04-payment_token": "nested:str:EGLD|u64:0",
+                        "05-min_bid": "biguint:100",
+                        "06-max_bid": "biguint:1000",
+                        "07-start_time": "u64:123,000",
+                        "08-deadline": "u64:123,456",
+                        "09-original_owner": "address:seller",
+                        "10-current_bid": "biguint:200",
+                        "11-current_winner": "address:second_bidder",
+                        "12-marketplace_cut_percentage": "biguint:1000",
+                        "13-creator_royalties_percentage": "biguint:2000"
                     }
                 ],
                 "status": "0",

--- a/contracts/examples/esdt-nft-marketplace/mandos/withdraw.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/withdraw.scen.json
@@ -14,10 +14,9 @@
                 "value": "0",
                 "function": "withdraw",
                 "arguments": [
-                    "str:NFT-123456",
                     "1"
                 ],
-                "gasLimit": "7,500,000",
+                "gasLimit": "10,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -52,7 +51,8 @@
                     "balance": "0",
                     "storage": {
                         "str:bidCutPerecentage": "1000",
-                        "str:auctionForToken|nested:str:NFT-123456|u64:1": ""
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|nested:str:NFT-123456|u64:1": ""
                     },
                     "code": "file:../output/esdt-nft-marketplace.wasm"
                 },

--- a/contracts/examples/esdt-nft-marketplace/mandos/withdraw_after_end_auction.scen.json
+++ b/contracts/examples/esdt-nft-marketplace/mandos/withdraw_after_end_auction.scen.json
@@ -1,0 +1,114 @@
+{
+    "name": "seller withdraw after end auction",
+    "steps": [
+        {
+            "step": "externalSteps",
+            "path": "buy_sft_after_end_auction.scen.json"
+        },
+        {
+            "step": "scCall",
+            "txId": "withdraw-after-end",
+            "tx": {
+                "from": "address:seller",
+                "to": "sc:marketplace",
+                "value": "0",
+                "function": "withdraw",
+                "arguments": [
+                    "1"
+                ],
+                "gasLimit": "10,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:owner": {
+                    "nonce": "1",
+                    "balance": "40",
+                    "storage": {}
+                },
+                "address:nft_creator": {
+                    "nonce": "0",
+                    "balance": "80",
+                    "esdt": {
+                        "str:NFT-123456": {
+                            "roles": [
+                                "ESDTRoleNFTCreate"
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "address:seller": {
+                    "nonce": "2",
+                    "balance": "280",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "8",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "address:first_bidder": {
+                    "nonce": "2",
+                    "balance": "800",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "address:second_bidder": {
+                    "nonce": "2",
+                    "balance": "800",
+                    "esdt": {
+                        "str:SFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "address:nft_creator",
+                                    "royalties": "2000"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "sc:marketplace": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "storage": {
+                        "str:bidCutPerecentage": "1000",
+                        "str:lastValidAuctionId": "1",
+                        "str:auctionById|u64:1": ""
+                    },
+                    "code": "file:../output/esdt-nft-marketplace.wasm"
+                },
+                "+": {}
+            }
+        }
+    ]
+}

--- a/contracts/examples/esdt-nft-marketplace/src/auction.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/auction.rs
@@ -21,7 +21,7 @@ pub struct Auction<BigUint: BigUintApi> {
 	pub creator_royalties_percentage: BigUint,
 }
 
-#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi)]
+#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, PartialEq)]
 pub enum AuctionType {
     None,
     Nft,
@@ -29,7 +29,7 @@ pub enum AuctionType {
     SftOnePerUser
 }
 
-#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi)]
+#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, PartialEq)]
 pub enum AuctionStatus {
     None,
     Running,

--- a/contracts/examples/esdt-nft-marketplace/src/auction.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/auction.rs
@@ -5,8 +5,8 @@ elrond_wasm::derive_imports!();
 pub struct Auction<BigUint: BigUintApi> {
 	pub auctioned_token: EsdtToken,
 	pub nr_auctioned_tokens: BigUint,
-    pub auction_type: AuctionType,
-    pub auction_status: AuctionStatus,
+	pub auction_type: AuctionType,
+	pub auction_status: AuctionStatus,
 
 	pub payment_token: EsdtToken,
 	pub min_bid: BigUint,
@@ -23,17 +23,17 @@ pub struct Auction<BigUint: BigUintApi> {
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, PartialEq)]
 pub enum AuctionType {
-    None,
-    Nft,
-    SftAll,
-    SftOnePerUser
+	None,
+	Nft,
+	SftAll,
+	SftOnePerUser,
 }
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, PartialEq)]
 pub enum AuctionStatus {
-    None,
-    Running,
-    SftWaitingForBuyOrOwnerClaim,
+	None,
+	Running,
+	SftWaitingForBuyOrOwnerClaim,
 }
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, Clone)]

--- a/contracts/examples/esdt-nft-marketplace/src/auction.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/auction.rs
@@ -6,6 +6,7 @@ pub struct Auction<BigUint: BigUintApi> {
 	pub auctioned_token: EsdtToken,
 	pub nr_auctioned_tokens: BigUint,
     pub auction_type: AuctionType,
+    pub auction_status: AuctionStatus,
 
 	pub payment_token: EsdtToken,
 	pub min_bid: BigUint,
@@ -22,9 +23,17 @@ pub struct Auction<BigUint: BigUintApi> {
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi)]
 pub enum AuctionType {
+    None,
     Nft,
     SftAll,
     SftOnePerUser
+}
+
+#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi)]
+pub enum AuctionStatus {
+    None,
+    Running,
+    SftWaitingForBuyOrOwnerClaim,
 }
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, Clone)]

--- a/contracts/examples/esdt-nft-marketplace/src/auction.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/auction.rs
@@ -26,7 +26,7 @@ pub enum AuctionType {
 	None,
 	Nft,
 	SftAll,
-	SftOnePerUser,
+	SftOnePerPayment,
 }
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, PartialEq)]
@@ -40,4 +40,10 @@ pub enum AuctionStatus {
 pub struct EsdtToken {
 	pub token_type: TokenIdentifier,
 	pub nonce: u64,
+}
+
+pub struct BidSplitAmounts<BigUint: BigUintApi> {
+	pub creator: BigUint,
+	pub marketplace: BigUint,
+	pub seller: BigUint,
 }

--- a/contracts/examples/esdt-nft-marketplace/src/auction.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/auction.rs
@@ -1,0 +1,34 @@
+elrond_wasm::imports!();
+elrond_wasm::derive_imports!();
+
+#[derive(TopEncode, TopDecode, NestedEncode, TypeAbi)]
+pub struct Auction<BigUint: BigUintApi> {
+	pub auctioned_token: EsdtToken,
+	pub nr_auctioned_tokens: BigUint,
+    pub auction_type: AuctionType,
+
+	pub payment_token: EsdtToken,
+	pub min_bid: BigUint,
+	pub max_bid: BigUint,
+	pub start_time: u64,
+	pub deadline: u64,
+
+	pub original_owner: Address,
+	pub current_bid: BigUint,
+	pub current_winner: Address,
+	pub marketplace_cut_percentage: BigUint,
+	pub creator_royalties_percentage: BigUint,
+}
+
+#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi)]
+pub enum AuctionType {
+    Nft,
+    SftAll,
+    SftOnePerUser
+}
+
+#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, Clone)]
+pub struct EsdtToken {
+	pub token_type: TokenIdentifier,
+	pub nonce: u64,
+}

--- a/contracts/examples/esdt-nft-marketplace/src/lib.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/lib.rs
@@ -1,33 +1,18 @@
 #![no_std]
 
 elrond_wasm::imports!();
-elrond_wasm::derive_imports!();
+
+pub mod auction;
+use auction::*;
+
+mod storage;
+mod views;
 
 const PERCENTAGE_TOTAL: u64 = 10_000; // 100%
 const NFT_AMOUNT: u32 = 1; // Token has to be unique to be considered NFT
 
-#[derive(TopEncode, TopDecode, NestedEncode, TypeAbi)]
-pub struct Auction<BigUint: BigUintApi> {
-	pub payment_token: EsdtToken,
-	pub min_bid: BigUint,
-	pub max_bid: BigUint,
-	pub start_time: u64,
-	pub deadline: u64,
-	pub original_owner: Address,
-	pub current_bid: BigUint,
-	pub current_winner: Address,
-	pub marketplace_cut_percentage: BigUint,
-	pub creator_royalties_percentage: BigUint,
-}
-
-#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, Clone)]
-pub struct EsdtToken {
-	pub token_type: TokenIdentifier,
-	pub nonce: u64,
-}
-
 #[elrond_wasm_derive::contract]
-pub trait EsdtNftMarketplace {
+pub trait EsdtNftMarketplace: storage::StorageModule + views::ViewsModule {
 	#[init]
 	fn init(&self, bid_cut_percentage: u64) -> SCResult<()> {
 		self.try_set_bid_cut_percentage(bid_cut_percentage)
@@ -290,132 +275,6 @@ pub trait EsdtNftMarketplace {
 		Ok(())
 	}
 
-	// views
-
-	#[view(isAlreadyUpForAuction)]
-	fn is_already_up_for_auction(&self, nft_type: &TokenIdentifier, nft_nonce: u64) -> bool {
-		!self.auction_for_token(nft_type, nft_nonce).is_empty()
-	}
-
-	#[view(getPaymentTokenForAuctionedNft)]
-	fn get_payment_token_for_auctioned_nft(
-		&self,
-		nft_type: &TokenIdentifier,
-		nft_nonce: u64,
-	) -> OptionalResult<MultiResult2<TokenIdentifier, u64>> {
-		if self.is_already_up_for_auction(nft_type, nft_nonce) {
-			let esdt_token = self
-				.auction_for_token(nft_type, nft_nonce)
-				.get()
-				.payment_token;
-
-			OptionalResult::Some((esdt_token.token_type, esdt_token.nonce).into())
-		} else {
-			OptionalResult::None
-		}
-	}
-
-	#[view(getMinMaxBid)]
-	fn get_min_max_bid(
-		&self,
-		nft_type: TokenIdentifier,
-		nft_nonce: u64,
-	) -> OptionalResult<MultiResult2<Self::BigUint, Self::BigUint>> {
-		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
-			let auction = self.auction_for_token(&nft_type, nft_nonce).get();
-
-			OptionalResult::Some((auction.min_bid, auction.max_bid).into())
-		} else {
-			OptionalResult::None
-		}
-	}
-
-	#[view(getStartTime)]
-	fn get_start_time(&self, nft_type: TokenIdentifier, nft_nonce: u64) -> OptionalResult<u64> {
-		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
-			OptionalResult::Some(
-				self.auction_for_token(&nft_type, nft_nonce)
-					.get()
-					.start_time,
-			)
-		} else {
-			OptionalResult::None
-		}
-	}
-
-	#[view(getDeadline)]
-	fn get_deadline(&self, nft_type: TokenIdentifier, nft_nonce: u64) -> OptionalResult<u64> {
-		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
-			OptionalResult::Some(self.auction_for_token(&nft_type, nft_nonce).get().deadline)
-		} else {
-			OptionalResult::None
-		}
-	}
-
-	#[view(getOriginalOwner)]
-	fn get_original_owner(
-		&self,
-		nft_type: TokenIdentifier,
-		nft_nonce: u64,
-	) -> OptionalResult<Address> {
-		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
-			OptionalResult::Some(
-				self.auction_for_token(&nft_type, nft_nonce)
-					.get()
-					.original_owner,
-			)
-		} else {
-			OptionalResult::None
-		}
-	}
-
-	#[view(getCurrentWinningBid)]
-	fn get_current_winning_bid(
-		&self,
-		nft_type: TokenIdentifier,
-		nft_nonce: u64,
-	) -> OptionalResult<Self::BigUint> {
-		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
-			OptionalResult::Some(
-				self.auction_for_token(&nft_type, nft_nonce)
-					.get()
-					.current_bid,
-			)
-		} else {
-			OptionalResult::None
-		}
-	}
-
-	#[view(getCurrentWinner)]
-	fn get_current_winner(
-		&self,
-		nft_type: TokenIdentifier,
-		nft_nonce: u64,
-	) -> OptionalResult<Address> {
-		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
-			OptionalResult::Some(
-				self.auction_for_token(&nft_type, nft_nonce)
-					.get()
-					.current_winner,
-			)
-		} else {
-			OptionalResult::None
-		}
-	}
-
-	#[view(getFullAuctionData)]
-	fn get_full_auction_data(
-		&self,
-		nft_type: TokenIdentifier,
-		nft_nonce: u64,
-	) -> OptionalResult<Auction<Self::BigUint>> {
-		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
-			OptionalResult::Some(self.auction_for_token(&nft_type, nft_nonce).get())
-		} else {
-			OptionalResult::None
-		}
-	}
-
 	// private
 
 	fn calculate_cut_amount(
@@ -482,15 +341,4 @@ pub trait EsdtNftMarketplace {
 	}
 
 	// storage
-
-	#[view(getMarketplaceCutPercentage)]
-	#[storage_mapper("bidCutPerecentage")]
-	fn bid_cut_percentage(&self) -> SingleValueMapper<Self::Storage, Self::BigUint>;
-
-	#[storage_mapper("auctionForToken")]
-	fn auction_for_token(
-		&self,
-		nft_type: &TokenIdentifier,
-		nft_nonce: u64,
-	) -> SingleValueMapper<Self::Storage, Auction<Self::BigUint>>;
 }

--- a/contracts/examples/esdt-nft-marketplace/src/lib.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(clippy::too_many_arguments)]
 
 elrond_wasm::imports!();
 

--- a/contracts/examples/esdt-nft-marketplace/src/lib.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/lib.rs
@@ -203,6 +203,10 @@ pub trait EsdtNftMarketplace: storage::StorageModule + views::ViewsModule {
 			current_time > auction.deadline || auction.current_bid == auction.max_bid,
 			"Auction deadline has not passed nor is the current bid equal to max bid"
 		);
+		require!(
+			auction.auction_status == AuctionStatus::Running,
+			"Auction already ended"
+		);
 
 		self.distribute_tokens_after_auction_end(&auction);
 
@@ -229,6 +233,7 @@ pub trait EsdtNftMarketplace: storage::StorageModule + views::ViewsModule {
 		nft_nonce: u64,
 	) -> SCResult<()> {
 		let mut auction = self.try_get_auction(auction_id)?;
+		let caller = self.blockchain().get_caller();
 
 		require!(
 			auction.auctioned_token.token_type == nft_type
@@ -249,6 +254,7 @@ pub trait EsdtNftMarketplace: storage::StorageModule + views::ViewsModule {
 			"Wrong amount paid, must pay equal to current winning bid"
 		);
 
+		auction.current_winner = caller;
 		self.distribute_tokens_after_auction_end(&auction);
 
 		auction.nr_auctioned_tokens -= &NFT_AMOUNT.into();

--- a/contracts/examples/esdt-nft-marketplace/src/storage.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/storage.rs
@@ -1,0 +1,17 @@
+elrond_wasm::imports!();
+
+use crate::auction::*;
+
+#[elrond_wasm_derive::module]
+pub trait StorageModule {
+	#[view(getMarketplaceCutPercentage)]
+	#[storage_mapper("bidCutPerecentage")]
+	fn bid_cut_percentage(&self) -> SingleValueMapper<Self::Storage, Self::BigUint>;
+
+	#[storage_mapper("auctionForToken")]
+	fn auction_for_token(
+		&self,
+		nft_type: &TokenIdentifier,
+		nft_nonce: u64,
+	) -> SingleValueMapper<Self::Storage, Auction<Self::BigUint>>;
+}

--- a/contracts/examples/esdt-nft-marketplace/src/storage.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/storage.rs
@@ -8,10 +8,13 @@ pub trait StorageModule {
 	#[storage_mapper("bidCutPerecentage")]
 	fn bid_cut_percentage(&self) -> SingleValueMapper<Self::Storage, Self::BigUint>;
 
-	#[storage_mapper("auctionForToken")]
-	fn auction_for_token(
+	#[storage_mapper("auctionById")]
+	fn auction_by_id(
 		&self,
-		nft_type: &TokenIdentifier,
-		nft_nonce: u64,
+		auction_id: u64,
 	) -> SingleValueMapper<Self::Storage, Auction<Self::BigUint>>;
+
+	#[view(getLastValidAuctionId)]
+	#[storage_mapper("lastValidAuctionId")]
+	fn last_valid_auction_id(&self) -> SingleValueMapper<Self::Storage, u64>;
 }

--- a/contracts/examples/esdt-nft-marketplace/src/views.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/views.rs
@@ -1,0 +1,130 @@
+elrond_wasm::imports!();
+
+use crate::auction::*;
+
+#[elrond_wasm_derive::module]
+pub trait ViewsModule: crate::storage::StorageModule {
+	#[view(isAlreadyUpForAuction)]
+	fn is_already_up_for_auction(&self, nft_type: &TokenIdentifier, nft_nonce: u64) -> bool {
+		!self.auction_for_token(nft_type, nft_nonce).is_empty()
+	}
+
+	#[view(getPaymentTokenForAuctionedNft)]
+	fn get_payment_token_for_auctioned_nft(
+		&self,
+		nft_type: &TokenIdentifier,
+		nft_nonce: u64,
+	) -> OptionalResult<MultiResult2<TokenIdentifier, u64>> {
+		if self.is_already_up_for_auction(nft_type, nft_nonce) {
+			let esdt_token = self
+				.auction_for_token(nft_type, nft_nonce)
+				.get()
+				.payment_token;
+
+			OptionalResult::Some((esdt_token.token_type, esdt_token.nonce).into())
+		} else {
+			OptionalResult::None
+		}
+	}
+
+	#[view(getMinMaxBid)]
+	fn get_min_max_bid(
+		&self,
+		nft_type: TokenIdentifier,
+		nft_nonce: u64,
+	) -> OptionalResult<MultiResult2<Self::BigUint, Self::BigUint>> {
+		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
+			let auction = self.auction_for_token(&nft_type, nft_nonce).get();
+
+			OptionalResult::Some((auction.min_bid, auction.max_bid).into())
+		} else {
+			OptionalResult::None
+		}
+	}
+
+	#[view(getStartTime)]
+	fn get_start_time(&self, nft_type: TokenIdentifier, nft_nonce: u64) -> OptionalResult<u64> {
+		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
+			OptionalResult::Some(
+				self.auction_for_token(&nft_type, nft_nonce)
+					.get()
+					.start_time,
+			)
+		} else {
+			OptionalResult::None
+		}
+	}
+
+	#[view(getDeadline)]
+	fn get_deadline(&self, nft_type: TokenIdentifier, nft_nonce: u64) -> OptionalResult<u64> {
+		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
+			OptionalResult::Some(self.auction_for_token(&nft_type, nft_nonce).get().deadline)
+		} else {
+			OptionalResult::None
+		}
+	}
+
+	#[view(getOriginalOwner)]
+	fn get_original_owner(
+		&self,
+		nft_type: TokenIdentifier,
+		nft_nonce: u64,
+	) -> OptionalResult<Address> {
+		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
+			OptionalResult::Some(
+				self.auction_for_token(&nft_type, nft_nonce)
+					.get()
+					.original_owner,
+			)
+		} else {
+			OptionalResult::None
+		}
+	}
+
+	#[view(getCurrentWinningBid)]
+	fn get_current_winning_bid(
+		&self,
+		nft_type: TokenIdentifier,
+		nft_nonce: u64,
+	) -> OptionalResult<Self::BigUint> {
+		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
+			OptionalResult::Some(
+				self.auction_for_token(&nft_type, nft_nonce)
+					.get()
+					.current_bid,
+			)
+		} else {
+			OptionalResult::None
+		}
+	}
+
+	#[view(getCurrentWinner)]
+	fn get_current_winner(
+		&self,
+		nft_type: TokenIdentifier,
+		nft_nonce: u64,
+	) -> OptionalResult<Address> {
+		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
+			OptionalResult::Some(
+				self.auction_for_token(&nft_type, nft_nonce)
+					.get()
+					.current_winner,
+			)
+		} else {
+			OptionalResult::None
+		}
+	}
+
+	#[view(getFullAuctionData)]
+	fn get_full_auction_data(
+		&self,
+		nft_type: TokenIdentifier,
+		nft_nonce: u64,
+	) -> OptionalResult<Auction<Self::BigUint>> {
+		if self.is_already_up_for_auction(&nft_type, nft_nonce) {
+			OptionalResult::Some(self.auction_for_token(&nft_type, nft_nonce).get())
+		} else {
+			OptionalResult::None
+		}
+	}
+}


### PR DESCRIPTION
Some refactoring: splitting into modules and moving some code from endpoints into private functions.
SFTs with custom quantity are now supported. They can also be sold one at a time through a single auction.