### PR TITLE
combine some send_api functions + update in contracts

### DIFF
--- a/contracts/examples/crowdfunding-erc20/src/crowdfunding_erc20.rs
+++ b/contracts/examples/crowdfunding-erc20/src/crowdfunding_erc20.rs
@@ -46,7 +46,11 @@ pub trait Crowdfunding {
 	fn status(&self) -> Status {
 		if self.blockchain().get_block_nonce() <= self.get_deadline() {
 			Status::FundingPeriod
-		} else if self.blockchain().get_sc_balance() >= self.get_target() {
+		} else if self
+			.blockchain()
+			.get_sc_balance(&TokenIdentifier::egld(), 0)
+			>= self.get_target()
+		{
 			Status::Successful
 		} else {
 			Status::Failed

--- a/contracts/examples/crowdfunding-esdt/src/crowdfunding_esdt.rs
+++ b/contracts/examples/crowdfunding-esdt/src/crowdfunding_esdt.rs
@@ -93,7 +93,8 @@ pub trait Crowdfunding {
 				let token_name = self.cf_token_name().get();
 				let sc_balance = self.get_current_funds();
 
-				self.send().direct(&caller, &token_name, &sc_balance, &[]);
+				self.send()
+					.direct(&caller, &token_name, 0, &sc_balance, &[]);
 
 				Ok(())
 			},
@@ -105,7 +106,7 @@ pub trait Crowdfunding {
 					let token_name = self.cf_token_name().get();
 
 					self.deposit(&caller).clear();
-					self.send().direct(&caller, &token_name, &deposit, &[]);
+					self.send().direct(&caller, &token_name, 0, &deposit, &[]);
 				}
 
 				Ok(())

--- a/contracts/examples/crowdfunding-esdt/src/crowdfunding_esdt.rs
+++ b/contracts/examples/crowdfunding-esdt/src/crowdfunding_esdt.rs
@@ -70,13 +70,8 @@ pub trait Crowdfunding {
 	#[view(getCurrentFunds)]
 	fn get_current_funds(&self) -> Self::BigUint {
 		let token = self.cf_token_name().get();
-		let sc_address = self.blockchain().get_sc_address();
 
-		if token.is_egld() {
-			self.blockchain().get_sc_balance()
-		} else {
-			self.blockchain().get_esdt_balance(&sc_address, &token, 0)
-		}
+		self.blockchain().get_sc_balance(&token, 0)
 	}
 
 	#[endpoint]

--- a/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
@@ -56,7 +56,9 @@ pub trait KittyOwnership {
 
 		self.send().direct_egld(
 			&self.blockchain().get_caller(),
-			&self.blockchain().get_sc_balance(),
+			&self
+				.blockchain()
+				.get_sc_balance(&TokenIdentifier::egld(), 0),
 			b"claim",
 		);
 

--- a/contracts/examples/egld-esdt-swap/src/swap.rs
+++ b/contracts/examples/egld-esdt-swap/src/swap.rs
@@ -180,7 +180,10 @@ pub trait EgldEsdtSwap {
 		require!(wrapped_egld_payment > 0, "Must pay more than 0 tokens!");
 		// this should never happen, but we'll check anyway
 		require!(
-			wrapped_egld_payment <= self.blockchain().get_sc_balance(),
+			wrapped_egld_payment
+				<= self
+					.blockchain()
+					.get_sc_balance(&TokenIdentifier::egld(), 0),
 			"Contract does not have enough funds"
 		);
 
@@ -199,7 +202,7 @@ pub trait EgldEsdtSwap {
 
 	#[view(getLockedEgldBalance)]
 	fn get_locked_egld_balance(&self) -> Self::BigUint {
-		self.blockchain().get_sc_balance()
+		self.blockchain().get_sc_balance(&TokenIdentifier::egld(), 0)
 	}
 
 	// storage

--- a/contracts/examples/egld-esdt-swap/src/swap.rs
+++ b/contracts/examples/egld-esdt-swap/src/swap.rs
@@ -147,6 +147,7 @@ pub trait EgldEsdtSwap {
 		let _ = self.send().direct(
 			&caller,
 			&self.wrapped_egld_token_id().get(),
+			0,
 			&payment,
 			b"wrapping",
 		);

--- a/contracts/examples/erc1155-marketplace/src/lib.rs
+++ b/contracts/examples/erc1155-marketplace/src/lib.rs
@@ -113,7 +113,7 @@ pub trait Erc1155Marketplace {
 		let claimable_funds_mapper = self.get_claimable_funds_mapper();
 		for (token_identifier, amount) in claimable_funds_mapper.iter() {
 			self.send()
-				.direct(&caller, &token_identifier, &amount, data);
+				.direct(&caller, &token_identifier, 0, &amount, data);
 
 			self.clear_claimable_funds(&token_identifier);
 		}
@@ -199,6 +199,7 @@ pub trait Erc1155Marketplace {
 			self.send().direct(
 				&auction.current_winner,
 				&auction.token_identifier,
+				0,
 				&auction.current_bid,
 				data,
 			);
@@ -245,6 +246,7 @@ pub trait Erc1155Marketplace {
 			self.send().direct(
 				&auction.original_owner,
 				&auction.token_identifier,
+				0,
 				&amount_to_send,
 				data,
 			);

--- a/contracts/examples/esdt-nft-marketplace/src/marketplace_main.rs
+++ b/contracts/examples/esdt-nft-marketplace/src/marketplace_main.rs
@@ -396,19 +396,13 @@ pub trait EsdtNftMarketplace: storage::StorageModule + views::ViewsModule {
 		amount: &Self::BigUint,
 		data: &'static [u8],
 	) {
-		// nonce 0 means fungible ESDT or EGLD
-		if nonce == 0 {
-			self.send()
-				.direct(to, token_id, amount, self.data_or_empty_if_sc(to, data));
-		} else {
-			self.send().direct_nft(
-				to,
-				token_id,
-				nonce,
-				amount,
-				self.data_or_empty_if_sc(to, data),
-			);
-		}
+		self.send().direct(
+			to,
+			token_id,
+			nonce,
+			amount,
+			self.data_or_empty_if_sc(to, data),
+		);
 	}
 
 	fn data_or_empty_if_sc(&self, dest: &Address, data: &'static [u8]) -> &[u8] {

--- a/contracts/examples/lottery-esdt/src/lottery.rs
+++ b/contracts/examples/lottery-esdt/src/lottery.rs
@@ -262,7 +262,8 @@ pub trait Lottery {
 			// The tokens will simply remain locked forever
 			let roles = self.blockchain().get_esdt_local_roles(&info.token_name);
 			if roles.contains(&EsdtLocalRole::Burn) {
-				self.send().esdt_local_burn(&info.token_name, &burn_amount);
+				self.send()
+					.esdt_local_burn(&info.token_name, 0, &burn_amount);
 			}
 
 			info.prize_pool -= burn_amount;
@@ -293,6 +294,7 @@ pub trait Lottery {
 			self.send().direct(
 				&winner_address,
 				&info.token_name,
+				0,
 				&prize,
 				b"You won the lottery! Congratulations!",
 			);
@@ -304,6 +306,7 @@ pub trait Lottery {
 		self.send().direct(
 			&first_place_winner,
 			&info.token_name,
+			0,
 			&info.prize_pool,
 			b"You won the lottery, 1st place! Congratulations!",
 		);

--- a/contracts/examples/ping-pong-egld/src/ping_pong.rs
+++ b/contracts/examples/ping-pong-egld/src/ping_pong.rs
@@ -73,7 +73,10 @@ pub trait PingPong {
 
 		if let Some(max_funds) = self.max_funds().get() {
 			require!(
-				&self.blockchain().get_sc_balance() + &payment <= max_funds,
+				&self
+					.blockchain()
+					.get_sc_balance(&TokenIdentifier::egld(), 0)
+					+ &payment <= max_funds,
 				"smart contract full"
 			);
 		}

--- a/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw.rs
@@ -35,7 +35,7 @@ pub trait ForwarderRaw {
 		#[payment_token] token: TokenIdentifier,
 		#[payment] payment: Self::BigUint,
 	) {
-		let _ = self.send().direct(&to, &token, &payment, &[]);
+		let _ = self.send().direct(&to, &token, 0, &payment, &[]);
 	}
 
 	fn forward_contract_call(

--- a/contracts/feature-tests/composability/forwarder/src/esdt.rs
+++ b/contracts/feature-tests/composability/forwarder/src/esdt.rs
@@ -22,7 +22,7 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
 			OptionalArg::Some(data) => data.as_slice(),
 			OptionalArg::None => &[],
 		};
-		let _ = self.send().direct(to, &token_id, amount, data);
+		self.send().direct(to, &token_id, 0, amount, data);
 	}
 
 	#[endpoint]
@@ -38,8 +38,10 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
 			OptionalArg::Some(data) => data.as_slice(),
 			OptionalArg::None => &[],
 		};
-		let _ = self.send().direct(to, &token_id, amount_first_time, data);
-		let _ = self.send().direct(to, &token_id, amount_second_time, data);
+		self.send()
+			.direct(to, &token_id, 0, amount_first_time, data);
+		self.send()
+			.direct(to, &token_id, 0, amount_second_time, data);
 	}
 
 	#[payable("EGLD")]
@@ -103,11 +105,11 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
 
 	#[endpoint]
 	fn local_mint(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send().esdt_local_mint(&token_identifier, &amount);
+		self.send().esdt_local_mint(&token_identifier, 0, &amount);
 	}
 
 	#[endpoint]
 	fn local_burn(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send().esdt_local_burn(&token_identifier, &amount);
+		self.send().esdt_local_burn(&token_identifier, 0, &amount);
 	}
 }

--- a/contracts/feature-tests/composability/forwarder/src/nft.rs
+++ b/contracts/feature-tests/composability/forwarder/src/nft.rs
@@ -188,7 +188,7 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 		);
 
 		self.send()
-			.direct_nft(&to, &token_identifier, token_nonce, &amount, b"NFT transfer");
+			.direct(&to, &token_identifier, token_nonce, &amount, b"NFT transfer");
 
 		self.send_event(&to, &token_identifier, token_nonce, &amount);
 	}

--- a/contracts/feature-tests/composability/forwarder/src/nft.rs
+++ b/contracts/feature-tests/composability/forwarder/src/nft.rs
@@ -104,12 +104,13 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 		amount: Self::BigUint,
 	) {
 		self.send()
-			.esdt_nft_add_quantity(&token_identifier, nonce, &amount);
+			.esdt_local_mint(&token_identifier, nonce, &amount);
 	}
 
 	#[endpoint]
 	fn nft_burn(&self, token_identifier: TokenIdentifier, nonce: u64, amount: Self::BigUint) {
-		self.send().esdt_nft_burn(&token_identifier, nonce, &amount);
+		self.send()
+			.esdt_local_burn(&token_identifier, nonce, &amount);
 	}
 
 	#[endpoint]
@@ -121,8 +122,7 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
 		amount: Self::BigUint,
 		data: BoxedBytes,
 	) {
-		self.send().transfer_esdt_nft_via_async_call(
-			&self.blockchain().get_sc_address(),
+		self.send().transfer_esdt_via_async_call(
 			&to,
 			&token_identifier,
 			nonce,

--- a/contracts/feature-tests/composability/local-esdt-and-nft/src/lib.rs
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/src/lib.rs
@@ -53,12 +53,12 @@ pub trait LocalEsdtAndEsdtNft {
 
 	#[endpoint(localMint)]
 	fn local_mint(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send().esdt_local_mint(&token_identifier, &amount);
+		self.send().esdt_local_mint(&token_identifier, 0, &amount);
 	}
 
 	#[endpoint(localBurn)]
 	fn local_burn(&self, token_identifier: TokenIdentifier, amount: Self::BigUint) {
-		self.send().esdt_local_burn(&token_identifier, &amount);
+		self.send().esdt_local_burn(&token_identifier, 0, &amount);
 	}
 
 	// Non-Fungible Tokens
@@ -122,12 +122,13 @@ pub trait LocalEsdtAndEsdtNft {
 		amount: Self::BigUint,
 	) {
 		self.send()
-			.esdt_nft_add_quantity(&token_identifier, nonce, &amount);
+			.esdt_local_mint(&token_identifier, nonce, &amount);
 	}
 
 	#[endpoint(nftBurn)]
 	fn nft_burn(&self, token_identifier: TokenIdentifier, nonce: u64, amount: Self::BigUint) {
-		self.send().esdt_nft_burn(&token_identifier, nonce, &amount);
+		self.send()
+			.esdt_local_burn(&token_identifier, nonce, &amount);
 	}
 
 	#[endpoint(transferNftViaAsyncCall)]
@@ -139,8 +140,7 @@ pub trait LocalEsdtAndEsdtNft {
 		amount: Self::BigUint,
 		data: BoxedBytes,
 	) {
-		self.send().transfer_esdt_nft_via_async_call(
-			&self.blockchain().get_sc_address(),
+		self.send().transfer_esdt_via_async_call(
 			&to,
 			&token_identifier,
 			nonce,

--- a/contracts/feature-tests/composability/vault/src/vault.rs
+++ b/contracts/feature-tests/composability/vault/src/vault.rs
@@ -91,13 +91,9 @@ pub trait Vault {
 
 		if token.is_egld() {
 			self.send().direct_egld(&caller, &amount, data);
-		} else if nonce == 0 {
-			self.send()
-				.transfer_esdt_via_async_call(&caller, &token, &amount, data);
 		} else {
-			let from = self.blockchain().get_sc_address();
 			self.send()
-				.transfer_esdt_nft_via_async_call(&from, &caller, &token, nonce, &amount, data);
+				.transfer_esdt_via_async_call(&caller, &token, nonce, &amount, data);
 		}
 	}
 

--- a/contracts/modules/elrond-wasm-module-esdt/src/lib.rs
+++ b/contracts/modules/elrond-wasm-module-esdt/src/lib.rs
@@ -86,7 +86,7 @@ pub trait EsdtModule {
 		let token_id = self.token_id().get();
 
 		self.require_local_roles_set(&token_id)?;
-		self.send().esdt_local_mint(&token_id, amount);
+		self.send().esdt_local_mint(&token_id, 0, amount);
 
 		Ok(())
 	}
@@ -95,7 +95,7 @@ pub trait EsdtModule {
 		let token_id = self.token_id().get();
 
 		self.require_local_roles_set(&token_id)?;
-		self.send().esdt_local_burn(&token_id, amount);
+		self.send().esdt_local_burn(&token_id, 0, amount);
 
 		Ok(())
 	}

--- a/contracts/modules/elrond-wasm-module-governance/src/lib.rs
+++ b/contracts/modules/elrond-wasm-module-governance/src/lib.rs
@@ -42,7 +42,7 @@ pub trait GovernanceModule:
 			self.downvotes(proposal_id).remove(&caller);
 
 			self.send()
-				.direct(&caller, &governance_token_id, &total_tokens, &[]);
+				.direct(&caller, &governance_token_id, 0, &total_tokens, &[]);
 		}
 
 		Ok(())

--- a/elrond-wasm/src/api/blockchain_api.rs
+++ b/elrond-wasm/src/api/blockchain_api.rs
@@ -26,8 +26,14 @@ pub trait BlockchainApi: StorageReadApi + ErrorApi + Clone + Sized + 'static {
 
 	fn get_balance(&self, address: &Address) -> Self::BalanceType;
 
-	fn get_sc_balance(&self) -> Self::BalanceType {
-		self.get_balance(&self.get_sc_address())
+	fn get_sc_balance(&self, token: &TokenIdentifier, nonce: u64) -> Self::BalanceType {
+		let sc_address = self.get_sc_address();
+
+		if token.is_egld() {
+			self.get_balance(&sc_address)
+		} else {
+			self.get_esdt_balance(&sc_address, token, nonce)
+		}
 	}
 
 	fn get_tx_hash(&self) -> H256;

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -67,41 +67,9 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 		arg_buffer: &ArgBuffer,
 	) -> Result<(), &'static [u8]>;
 
-	/// Performs a simple ESDT transfer, but via async call.
-	/// This is the preferred way to send ESDT.
-	fn transfer_esdt_via_async_call(
-		&self,
-		to: &Address,
-		token: &TokenIdentifier,
-		amount: &Self::AmountType,
-		data: &[u8],
-	) -> ! {
-		let mut serializer = HexCallDataSerializer::new(ESDT_TRANSFER_STRING);
-		serializer.push_argument_bytes(token.as_esdt_identifier());
-		serializer.push_argument_bytes(amount.to_bytes_be().as_slice());
-		if !data.is_empty() {
-			serializer.push_argument_bytes(data);
-		}
-		self.async_call_raw(to, &Self::AmountType::zero(), serializer.as_slice())
-	}
-
-	/// Sends either EGLD or an ESDT token to the target address,
-	/// depending on what token identifier was specified.
+	/// Sends either EGLD, ESDT or NFT to the target address,
+	/// depending on the token identifier and nonce
 	fn direct(
-		&self,
-		to: &Address,
-		token: &TokenIdentifier,
-		amount: &Self::AmountType,
-		data: &[u8],
-	) {
-		if token.is_egld() {
-			self.direct_egld(to, amount, data);
-		} else {
-			let _ = self.direct_esdt_execute(to, token, amount, 0, data, &ArgBuffer::new());
-		}
-	}
-
-	fn direct_nft(
 		&self,
 		to: &Address,
 		token: &TokenIdentifier,
@@ -109,7 +77,14 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 		amount: &Self::AmountType,
 		data: &[u8],
 	) {
-		let _ = self.direct_esdt_nft_execute(to, token, nonce, amount, 0, data, &ArgBuffer::new());
+		if token.is_egld() {
+			self.direct_egld(to, amount, data);
+		} else if nonce == 0 {
+			let _ = self.direct_esdt_execute(to, token, amount, 0, data, &ArgBuffer::new());
+		} else {
+			let _ =
+				self.direct_esdt_nft_execute(to, token, nonce, amount, 0, data, &ArgBuffer::new());
+		}
 	}
 
 	/// Sends an asynchronous call to another contract.
@@ -129,6 +104,46 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 			&async_call.egld_payment,
 			async_call.hex_data.as_slice(),
 		)
+	}
+
+	/// Performs a simple ESDT/NFT transfer, but via async call.  
+	/// As with any async call, this immediately terminates the execution of the current call.  
+	/// So only use as the last call in your endpoint.  
+	/// If you want to perform multiple transfers, use `self.send().direct()` instead.  
+	/// Note that EGLD can NOT be transfered with this function.  
+	fn transfer_esdt_via_async_call(
+		&self,
+		to: &Address,
+		token: &TokenIdentifier,
+		nonce: u64,
+		amount: &Self::AmountType,
+		data: &[u8],
+	) -> ! {
+		if nonce == 0 {
+			let mut serializer = HexCallDataSerializer::new(ESDT_TRANSFER_STRING);
+			serializer.push_argument_bytes(token.as_esdt_identifier());
+			serializer.push_argument_bytes(amount.to_bytes_be().as_slice());
+			if !data.is_empty() {
+				serializer.push_argument_bytes(data);
+			}
+
+			self.async_call_raw(to, &Self::AmountType::zero(), serializer.as_slice())
+		} else {
+			let mut serializer = HexCallDataSerializer::new(ESDT_NFT_TRANSFER_STRING);
+			serializer.push_argument_bytes(token.as_esdt_identifier());
+			serializer.push_argument_bytes(&nonce.to_be_bytes()[..]);
+			serializer.push_argument_bytes(amount.to_bytes_be().as_slice());
+			serializer.push_argument_bytes(to.as_bytes());
+			if !data.is_empty() {
+				serializer.push_argument_bytes(data);
+			}
+
+			self.async_call_raw(
+				&self.get_sc_address(),
+				&Self::AmountType::zero(),
+				serializer.as_slice(),
+			);
+		}
 	}
 
 	/// Deploys a new contract in the same shard.
@@ -227,27 +242,54 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 	/// Use the other specific methods instead.
 	fn call_local_esdt_built_in_function(&self, gas: u64, function: &[u8], arg_buffer: &ArgBuffer);
 
-	/// Allows synchronous minting of ESDT tokens. Execution is resumed afterwards.
-	fn esdt_local_mint(&self, token: &TokenIdentifier, amount: &Self::AmountType) {
+	/// Allows synchronous minting of ESDT/SFT (depending on nonce). Execution is resumed afterwards.
+	/// Note that the SC must have the ESDTLocalMint or ESDTNftAddQuantity roles set,
+	/// or this will fail with "action is not allowed"
+	/// For SFTs, you must use `self.send().esdt_nft_create()` before adding additional quantity.
+	/// This function cannot be used for NFTs.
+	fn esdt_local_mint(&self, token: &TokenIdentifier, nonce: u64, amount: &Self::AmountType) {
 		let mut arg_buffer = ArgBuffer::new();
+		let func_name: &[u8];
+
 		arg_buffer.push_argument_bytes(token.as_esdt_identifier());
+
+		if nonce == 0 {
+			func_name = b"ESDTLocalMint";
+		} else {
+			func_name = b"ESDTNFTAddQuantity";
+			arg_buffer.push_argument_bytes(&nonce.to_be_bytes()[..]);
+		}
+
 		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
 
-		self.call_local_esdt_built_in_function(self.get_gas_left(), b"ESDTLocalMint", &arg_buffer);
+		self.call_local_esdt_built_in_function(self.get_gas_left(), func_name, &arg_buffer);
 	}
 
-	/// Allows synchronous burning of ESDT tokens. Execution is resumed afterwards.
-	fn esdt_local_burn(&self, token: &TokenIdentifier, amount: &Self::AmountType) {
+	/// Allows synchronous burning of ESDT/SFT/NFT (depending on nonce). Execution is resumed afterwards.
+	/// Note that the SC must have the ESDTLocalBurn or ESDTNftBurn roles set,
+	/// or this will fail with "action is not allowed"
+	fn esdt_local_burn(&self, token: &TokenIdentifier, nonce: u64, amount: &Self::AmountType) {
 		let mut arg_buffer = ArgBuffer::new();
+		let func_name: &[u8];
+
 		arg_buffer.push_argument_bytes(token.as_esdt_identifier());
+
+		if nonce == 0 {
+			func_name = b"ESDTLocalBurn";
+		} else {
+			func_name = b"ESDTNFTBurn";
+			arg_buffer.push_argument_bytes(&nonce.to_be_bytes()[..]);
+		}
+
 		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
 
-		self.call_local_esdt_built_in_function(self.get_gas_left(), b"ESDTLocalBurn", &arg_buffer);
+		self.call_local_esdt_built_in_function(self.get_gas_left(), func_name, &arg_buffer);
 	}
 
 	/// Creates a new NFT token of a certain type (determined by `token_identifier`).  
 	/// `attributes` can be any serializable custom struct.  
 	/// This is a built-in function, so the smart contract execution is resumed after.
+	/// Must have ESDTNftCreate role set, or this will fail with "action is not allowed".
 	#[allow(clippy::too_many_arguments)]
 	fn esdt_nft_create<T: elrond_codec::TopEncode>(
 		&self,
@@ -280,59 +322,5 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 		}
 
 		self.call_local_esdt_built_in_function(self.get_gas_left(), b"ESDTNFTCreate", &arg_buffer);
-	}
-
-	/// Adds quantity for an Non-Fungible Token. (which makes it a Semi-Fungible Token by definition)  
-	/// This is a built-in function, so the smart contract execution is resumed after.
-	fn esdt_nft_add_quantity(
-		&self,
-		token: &TokenIdentifier,
-		nonce: u64,
-		amount: &Self::AmountType,
-	) {
-		let mut arg_buffer = ArgBuffer::new();
-		arg_buffer.push_argument_bytes(token.as_esdt_identifier());
-		arg_buffer.push_argument_bytes(&nonce.to_be_bytes()[..]);
-		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
-
-		self.call_local_esdt_built_in_function(
-			self.get_gas_left(),
-			b"ESDTNFTAddQuantity",
-			&arg_buffer,
-		);
-	}
-
-	/// The reverse operation of `esdt_nft_add_quantity`, this locally decreases
-	/// This is a built-in function, so the smart contract execution is resumed after.
-	fn esdt_nft_burn(&self, token: &TokenIdentifier, nonce: u64, amount: &Self::AmountType) {
-		let mut arg_buffer = ArgBuffer::new();
-		arg_buffer.push_argument_bytes(token.as_esdt_identifier());
-		arg_buffer.push_argument_bytes(&nonce.to_be_bytes()[..]);
-		arg_buffer.push_argument_bytes(amount.to_bytes_be().as_slice());
-
-		self.call_local_esdt_built_in_function(self.get_gas_left(), b"ESDTNFTBurn", &arg_buffer);
-	}
-
-	/// Performs a simple ESDT NFT transfer, but via async call.
-	/// This is the preferred way to send ESDT.
-	/// Note: call is done to the SC itself, so `from` should be the SCs own address
-	fn transfer_esdt_nft_via_async_call(
-		&self,
-		from: &Address,
-		to: &Address,
-		token: &TokenIdentifier,
-		nonce: u64,
-		amount: &Self::AmountType,
-		data: &[u8],
-	) {
-		let mut serializer = HexCallDataSerializer::new(ESDT_NFT_TRANSFER_STRING);
-		serializer.push_argument_bytes(token.as_esdt_identifier());
-		serializer.push_argument_bytes(&nonce.to_be_bytes()[..]);
-		serializer.push_argument_bytes(amount.to_bytes_be().as_slice());
-		serializer.push_argument_bytes(to.as_bytes());
-		if !data.is_empty() {
-			serializer.push_argument_bytes(data);
-		}
-		self.async_call_raw(from, &Self::AmountType::zero(), serializer.as_slice());
 	}
 }

--- a/elrond-wasm/src/types/interaction/send_esdt.rs
+++ b/elrond-wasm/src/types/interaction/send_esdt.rs
@@ -27,6 +27,7 @@ where
 		self.api.transfer_esdt_via_async_call(
 			&self.to,
 			&TokenIdentifier::from(self.token_name.clone()),
+			0,
 			&self.amount,
 			self.data.as_slice(),
 		);

--- a/elrond-wasm/src/types/interaction/send_token.rs
+++ b/elrond-wasm/src/types/interaction/send_token.rs
@@ -31,6 +31,7 @@ where
 			self.api.transfer_esdt_via_async_call(
 				&self.to,
 				&self.token,
+				0,
 				&self.amount,
 				self.data.as_slice(),
 			);


### PR DESCRIPTION
- `self.send().direct()` now takes a nonce as argument. `direct_nft` removed.
- combined `esdt_local_mint` and `esdt_nft_add_quantity`
- combined `esdt_local_burn` and `esdt_nft_burn`