### PR TITLE
Changed deploy_contract to return Option<Address>

### DIFF
--- a/contracts/examples/multisig/src/multisig.rs
+++ b/contracts/examples/multisig/src/multisig.rs
@@ -483,13 +483,10 @@ pub trait Multisig {
 				for arg in arguments {
 					arg_buffer.push_argument_bytes(arg.as_slice());
 				}
-				let new_address = self.send().deploy_contract(
-					gas_left,
-					&amount,
-					&code,
-					code_metadata,
-					&arg_buffer,
-				);
+				let new_address = self
+					.send()
+					.deploy_contract(gas_left, &amount, &code, code_metadata, &arg_buffer)
+					.ok_or("Contract deployment failed")?;
 				Ok(PerformActionResult::DeployResult(new_address))
 			},
 			Action::SCCall {

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
@@ -18,16 +18,20 @@ pub trait Parent {
 	fn deposit(&self) {}
 
 	#[endpoint(deployChildContract)]
-	fn deploy_child_contract(&self, code: BoxedBytes) {
-		let child_contract_address = self.send().deploy_contract(
-			self.blockchain().get_gas_left(),
-			&Self::BigUint::zero(),
-			&code,
-			CodeMetadata::DEFAULT,
-			&ArgBuffer::new(),
-		);
+	fn deploy_child_contract(&self, code: BoxedBytes) -> SCResult<()> {
+		let child_contract_address = self
+			.send()
+			.deploy_contract(
+				self.blockchain().get_gas_left(),
+				&Self::BigUint::zero(),
+				&code,
+				CodeMetadata::DEFAULT,
+				&ArgBuffer::new(),
+			)
+			.ok_or("Child contract deployment failed")?;
 
 		self.child_contract_address().set(&child_contract_address);
+		Ok(())
 	}
 
 	#[payable("EGLD")]

--- a/contracts/feature-tests/composability/forwarder/src/contract_deploy.rs
+++ b/contracts/feature-tests/composability/forwarder/src/contract_deploy.rs
@@ -8,10 +8,9 @@ pub trait DeployContractModule {
 		code: BoxedBytes,
 		#[var_args] arguments: VarArgs<BoxedBytes>,
 	) -> SCResult<Address> {
-		let deployed_contract_address = self.deploy(&code, &arguments.into_vec());
-		if deployed_contract_address.is_zero() {
-			return sc_error!("Deploy failed");
-		}
+		let deployed_contract_address = self
+			.deploy(&code, &arguments.into_vec())
+			.ok_or("Deploy failed")?;
 
 		Ok(deployed_contract_address)
 	}
@@ -23,15 +22,13 @@ pub trait DeployContractModule {
 		#[var_args] arguments: VarArgs<BoxedBytes>,
 	) -> SCResult<(Address, Address)> {
 		let args_as_vec = arguments.into_vec();
-		let first_deployed_contract_address = self.deploy(&code, &args_as_vec);
-		if first_deployed_contract_address.is_zero() {
-			return sc_error!("First deploy failed");
-		}
+		let first_deployed_contract_address = self
+			.deploy(&code, &args_as_vec)
+			.ok_or("First deploy failed")?;
 
-		let second_deployed_contract_address = self.deploy(&code, &args_as_vec);
-		if second_deployed_contract_address.is_zero() {
-			return sc_error!("Second deploy failed");
-		}
+		let second_deployed_contract_address = self
+			.deploy(&code, &args_as_vec)
+			.ok_or("Second deploy failed")?;
 
 		Ok((
 			first_deployed_contract_address,
@@ -39,7 +36,7 @@ pub trait DeployContractModule {
 		))
 	}
 
-	fn deploy(&self, code: &BoxedBytes, arguments: &[BoxedBytes]) -> Address {
+	fn deploy(&self, code: &BoxedBytes, arguments: &[BoxedBytes]) -> Option<Address> {
 		self.send().deploy_contract(
 			self.blockchain().get_gas_left(),
 			&Self::BigUint::zero(),

--- a/elrond-wasm-debug/src/api/send_api_mock.rs
+++ b/elrond-wasm-debug/src/api/send_api_mock.rs
@@ -146,7 +146,7 @@ impl SendApi for TxContext {
 		_code: &BoxedBytes,
 		_code_metadata: CodeMetadata,
 		_arg_buffer: &ArgBuffer,
-	) -> Address {
+	) -> Option<Address> {
 		panic!("deploy_contract not yet implemented")
 	}
 

--- a/elrond-wasm-node/src/api/send_api_node.rs
+++ b/elrond-wasm-node/src/api/send_api_node.rs
@@ -257,7 +257,7 @@ impl SendApi for ArwenApiImpl {
 		code: &BoxedBytes,
 		code_metadata: CodeMetadata,
 		arg_buffer: &ArgBuffer,
-	) -> Address {
+	) -> Option<Address> {
 		let mut new_address = Address::zero();
 		unsafe {
 			let amount_bytes32_ptr = amount.unsafe_buffer_load_be_pad_right(32);
@@ -273,7 +273,11 @@ impl SendApi for ArwenApiImpl {
 				arg_buffer.arg_data_ptr(),
 			);
 		}
-		new_address
+		if new_address.is_zero() {
+			None
+		} else {
+			Some(new_address)
+		}
 	}
 
 	fn upgrade_contract(
@@ -426,7 +430,12 @@ impl SendApi for ArwenApiImpl {
 		self.storage_load_boxed_bytes(tx_hash.as_bytes())
 	}
 
-	fn call_local_esdt_built_in_function(&self, gas: u64, function: &[u8], arg_buffer: &ArgBuffer) -> Vec<BoxedBytes> {
+	fn call_local_esdt_built_in_function(
+		&self,
+		gas: u64,
+		function: &[u8],
+		arg_buffer: &ArgBuffer,
+	) -> Vec<BoxedBytes> {
 		// account-level built-in function, so the destination address is the contract itself
 		let own_address = BlockchainApi::get_sc_address(self);
 

--- a/elrond-wasm/src/api/send_api.rs
+++ b/elrond-wasm/src/api/send_api.rs
@@ -149,6 +149,7 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 	/// Deploys a new contract in the same shard.
 	/// Unlike `async_call_raw`, the deployment is synchronous and tx execution continues afterwards.
 	/// Also unlike `async_call_raw`, it uses an argument buffer to pass arguments
+	/// If the deployment fails, Option::None is returned
 	fn deploy_contract(
 		&self,
 		gas: u64,
@@ -156,7 +157,7 @@ pub trait SendApi: ErrorApi + Clone + Sized {
 		code: &BoxedBytes,
 		code_metadata: CodeMetadata,
 		arg_buffer: &ArgBuffer,
-	) -> Address;
+	) -> Option<Address>;
 
 	/// Upgrades a child contract of the currently executing contract.
 	/// The upgrade is synchronous, and the current transaction will fail if the upgrade fails.

--- a/elrond-wasm/src/api/uncallable/send_api_uncallable.rs
+++ b/elrond-wasm/src/api/uncallable/send_api_uncallable.rs
@@ -67,7 +67,7 @@ impl SendApi for super::UncallableApi {
 		_code: &BoxedBytes,
 		_code_metadata: CodeMetadata,
 		_arg_buffer: &ArgBuffer,
-	) -> Address {
+	) -> Option<Address> {
 		unreachable!()
 	}
 


### PR DESCRIPTION
Changed the `deploy_contract` method to return an `Option<Address>` so that the user doesn't have to check if the address is 0 if the deployment fails.
The idiomatic way to check for a failed deployment is now:
```
let new_address = self
  .send()
  .deploy_contract(gas_left, &amount, &code, code_metadata, &arg_buffer)
  .ok_or("Contract deployment failed")?;
```