### PR TITLE
GitHub Action - Upload assets on release

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,7 +17,7 @@ jobs:
           default: true
           toolchain: nightly
       - name: Install erdpy and arwentools
-        run : |
+        run: |
           source .github/workflows/env
           pip3 install erdpy
           mkdir $HOME/elrondsdk
@@ -49,10 +49,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
-            components: clippy
-            default: true
+          toolchain: nightly
+          components: clippy
+          default: true
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args:

--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -1,0 +1,30 @@
+name: Upload assets on release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    name: Upload release asset to ${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install erdpy
+        run : |
+          source .github/workflows/env
+          pip3 install erdpy
+      - name: Build project example outputs
+        run: |
+          ./zip-example-wasm.sh
+      - name: Upload binaries to release ${{ github.ref }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          tag: ${{ github.ref }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./examples-wasm.zip
+          asset_name: examples-wasm.zip
+          overwrite: true
+          body: "This is my release text"

--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install erdpy
-        run : |
+        run: |
           source .github/workflows/env
           pip3 install erdpy
       - name: Build project example outputs


### PR DESCRIPTION
Only starts when pressing the "Publish Release" button.
No more flooding git with tags that no-one asked for.
Seems to be working.