### PR TITLE
ManagedVec

### DIFF
--- a/contracts/examples/crypto-kitties/kitty-auction/src/auction.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/src/auction.rs
@@ -2,7 +2,7 @@ elrond_wasm::derive_imports!();
 
 use elrond_wasm::{
     api::ManagedTypeApi,
-    types::{Address, BigUint},
+    types::{Address, BigUint, ManagedType},
 };
 
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]

--- a/contracts/feature-tests/basic-features/mandos/managed_vec_push.scen.json
+++ b/contracts/feature-tests/basic-features/mandos/managed_vec_push.scen.json
@@ -1,0 +1,81 @@
+{
+    "steps": [
+        {
+            "step": "setState",
+            "accounts": {
+                "sc:basic-features": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "storage": {},
+                    "code": "file:../output/basic-features.wasm"
+                },
+                "address:an_account": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "storage": {},
+                    "code": ""
+                }
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "1",
+            "tx": {
+                "to": "sc:basic-features",
+                "function": "managed_vec_push",
+                "arguments": [
+                    "biguint:1",
+                    "2"
+                ]
+            },
+            "expect": {
+                "out": [ "biguint:1|biguint:2" ]
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "2",
+            "tx": {
+                "to": "sc:basic-features",
+                "function": "managed_vec_push",
+                "arguments": [
+                    "",
+                    "2"
+                ]
+            },
+            "expect": {
+                "out": [ "biguint:2" ]
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "3",
+            "tx": {
+                "to": "sc:basic-features",
+                "function": "managed_vec_push",
+                "arguments": [
+                    "biguint:1",
+                    ""
+                ]
+            },
+            "expect": {
+                "out": [ "biguint:1|biguint:0" ]
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "4",
+            "tx": {
+                "to": "sc:basic-features",
+                "function": "managed_vec_push",
+                "arguments": [
+                    "",
+                    ""
+                ]
+            },
+            "expect": {
+                "out": [ "biguint:0" ]
+            }
+        }
+    ]
+}

--- a/contracts/feature-tests/basic-features/src/basic_features_main.rs
+++ b/contracts/feature-tests/basic-features/src/basic_features_main.rs
@@ -15,6 +15,7 @@ pub mod elliptic_curve_features;
 pub mod event_features;
 pub mod macros;
 pub mod managed_buffer_features;
+pub mod managed_vec_features;
 pub mod storage_direct_load;
 pub mod storage_direct_store;
 pub mod storage_mapper_linked_list;
@@ -41,6 +42,7 @@ pub trait BasicFeatures:
     + event_features::EventFeatures
     + macros::Macros
     + managed_buffer_features::ManagedBufferFeatures
+    + managed_vec_features::ManagedVecFeatures
     + storage_direct_load::StorageLoadFeatures
     + storage_direct_store::StorageStoreFeatures
     + storage_mapper_linked_list::LinkedListMapperFeatures

--- a/contracts/feature-tests/basic-features/src/managed_vec_features.rs
+++ b/contracts/feature-tests/basic-features/src/managed_vec_features.rs
@@ -1,0 +1,15 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait ManagedVecFeatures {
+    #[endpoint]
+    fn managed_vec_push(
+        &self,
+        mv: ManagedVec<Self::TypeManager, BigUint>,
+        item: BigUint,
+    ) -> ManagedVec<Self::TypeManager, BigUint> {
+        let mut result = mv;
+        result.push(item);
+        result
+    }
+}

--- a/contracts/feature-tests/basic-features/tests/basic_features_mandos_go_test.rs
+++ b/contracts/feature-tests/basic-features/tests/basic_features_mandos_go_test.rs
@@ -29,8 +29,18 @@ fn count_ones_go() {
 }
 
 #[test]
+fn crypto_elliptic_curves_go() {
+    elrond_wasm_debug::mandos_go("mandos/crypto_elliptic_curves.scen.json");
+}
+
+#[test]
 fn crypto_keccak256_go() {
     elrond_wasm_debug::mandos_go("mandos/crypto_keccak256.scen.json");
+}
+
+#[test]
+fn crypto_ripemd160_go() {
+    elrond_wasm_debug::mandos_go("mandos/crypto_ripemd160.scen.json");
 }
 
 #[test]
@@ -164,6 +174,46 @@ fn get_esdt_local_roles_go() {
 }
 
 #[test]
+fn log2_func_go() {
+    elrond_wasm_debug::mandos_go("mandos/log2_func.scen.json");
+}
+
+#[test]
+fn managed_buffer_concat_1_go() {
+    elrond_wasm_debug::mandos_go("mandos/managed_buffer_concat_1.scen.json");
+}
+
+#[test]
+fn managed_buffer_concat_2_go() {
+    elrond_wasm_debug::mandos_go("mandos/managed_buffer_concat_2.scen.json");
+}
+
+#[test]
+fn managed_buffer_eq_go() {
+    elrond_wasm_debug::mandos_go("mandos/managed_buffer_eq.scen.json");
+}
+
+#[test]
+fn managed_buffer_overwrite_go() {
+    elrond_wasm_debug::mandos_go("mandos/managed_buffer_overwrite.scen.json");
+}
+
+#[test]
+fn managed_buffer_slice_1_go() {
+    elrond_wasm_debug::mandos_go("mandos/managed_buffer_slice_1.scen.json");
+}
+
+#[test]
+fn managed_buffer_slice_2_go() {
+    elrond_wasm_debug::mandos_go("mandos/managed_buffer_slice_2.scen.json");
+}
+
+#[test]
+fn managed_vec_push_go() {
+    elrond_wasm_debug::mandos_go("mandos/managed_vec_push.scen.json");
+}
+
+#[test]
 fn only_owner_go() {
     elrond_wasm_debug::mandos_go("mandos/only_owner.scen.json");
 }
@@ -179,6 +229,11 @@ fn panic_go() {
 }
 
 #[test]
+fn pow_func_go() {
+    elrond_wasm_debug::mandos_go("mandos/pow_func.scen.json");
+}
+
+#[test]
 fn return_codes_go() {
     elrond_wasm_debug::mandos_go("mandos/return_codes.scen.json");
 }
@@ -191,6 +246,11 @@ fn sc_properties_go() {
 #[test]
 fn sc_result_go() {
     elrond_wasm_debug::mandos_go("mandos/sc_result.scen.json");
+}
+
+#[test]
+fn sqrt_go() {
+    elrond_wasm_debug::mandos_go("mandos/sqrt.scen.json");
 }
 
 #[test]
@@ -269,6 +329,11 @@ fn storage_mapper_single_value_go() {
 }
 
 #[test]
+fn storage_mapper_token_attributes_go() {
+    elrond_wasm_debug::mandos_go("mandos/storage_mapper_token_attributes.scen.json");
+}
+
+#[test]
 fn storage_mapper_vec_go() {
     elrond_wasm_debug::mandos_go("mandos/storage_mapper_vec.scen.json");
 }
@@ -306,19 +371,4 @@ fn storage_usize_bad_go() {
 #[test]
 fn storage_vec_u8_go() {
     elrond_wasm_debug::mandos_go("mandos/storage_vec_u8.scen.json");
-}
-
-#[test]
-fn sqrt() {
-    elrond_wasm_debug::mandos_go("mandos/sqrt.scen.json");
-}
-
-#[test]
-fn log2() {
-    elrond_wasm_debug::mandos_go("mandos/log2_func.scen.json");
-}
-
-#[test]
-fn pow() {
-    elrond_wasm_debug::mandos_go("mandos/pow_func.scen.json");
 }

--- a/contracts/feature-tests/basic-features/tests/basic_features_mandos_rs_test.rs
+++ b/contracts/feature-tests/basic-features/tests/basic_features_mandos_rs_test.rs
@@ -9,7 +9,6 @@ fn contract_map() -> ContractMap<TxContext> {
     );
     contract_map
 }
-
 #[test]
 fn big_int_to_i64_rs() {
     elrond_wasm_debug::mandos_rs("mandos/big_int_to_i64.scen.json", &contract_map());
@@ -40,20 +39,30 @@ fn count_ones_rs() {
     elrond_wasm_debug::mandos_rs("mandos/count_ones.scen.json", &contract_map());
 }
 
-#[test]
-fn only_owner_rs() {
-    elrond_wasm_debug::mandos_rs("mandos/only_owner.scen.json", &contract_map());
-}
+// #[test]
+// fn crypto_elliptic_curves_rs() {
+//     elrond_wasm_debug::mandos_rs("mandos/crypto_elliptic_curves.scen.json", &contract_map());
+// }
 
 #[test]
 fn crypto_keccak256_rs() {
     elrond_wasm_debug::mandos_rs("mandos/crypto_keccak256.scen.json", &contract_map());
 }
 
+// #[test]
+// fn crypto_ripemd160_rs() {
+//     elrond_wasm_debug::mandos_rs("mandos/crypto_ripemd160.scen.json", &contract_map());
+// }
+
 #[test]
 fn crypto_sha256_rs() {
     elrond_wasm_debug::mandos_rs("mandos/crypto_sha256.scen.json", &contract_map());
 }
+
+// #[test]
+// fn crypto_verify_funcs_rs() {
+//     elrond_wasm_debug::mandos_rs("mandos/crypto_verify_funcs.scen.json", &contract_map());
+// }
 
 #[test]
 fn echo_array_u8_rs() {
@@ -183,8 +192,64 @@ fn get_cumulated_validator_rewards_rs() {
 // }
 
 #[test]
+fn log2_func_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/log2_func.scen.json", &contract_map());
+}
+
+#[test]
+fn managed_buffer_concat_1_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/managed_buffer_concat_1.scen.json", &contract_map());
+}
+
+#[test]
+fn managed_buffer_concat_2_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/managed_buffer_concat_2.scen.json", &contract_map());
+}
+
+#[test]
+fn managed_buffer_eq_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/managed_buffer_eq.scen.json", &contract_map());
+}
+
+#[test]
+fn managed_buffer_overwrite_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/managed_buffer_overwrite.scen.json", &contract_map());
+}
+
+#[test]
+fn managed_buffer_slice_1_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/managed_buffer_slice_1.scen.json", &contract_map());
+}
+
+#[test]
+fn managed_buffer_slice_2_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/managed_buffer_slice_2.scen.json", &contract_map());
+}
+
+#[test]
+fn managed_vec_push_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/managed_vec_push.scen.json", &contract_map());
+}
+
+#[test]
+fn only_owner_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/only_owner.scen.json", &contract_map());
+}
+
+// Will never run in mandos-rs.
+// #[test]
+// fn out_of_gas_rs() {
+//     elrond_wasm_debug::mandos_rs("mandos/out_of_gas.scen.json", &contract_map());
+// }
+
+#[test]
 fn panic_rs() {
     elrond_wasm_debug::mandos_rs("mandos/panic.scen.json", &contract_map());
+}
+
+#[test]
+fn pow_func_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/pow_func.scen.json", &contract_map());
 }
 
 #[test]
@@ -203,6 +268,11 @@ fn sc_properties_rs() {
 #[test]
 fn sc_result_rs() {
     elrond_wasm_debug::mandos_rs("mandos/sc_result.scen.json", &contract_map());
+}
+
+#[test]
+fn sqrt_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/sqrt.scen.json", &contract_map());
 }
 
 #[test]
@@ -269,11 +339,6 @@ fn storage_mapper_map_rs() {
 }
 
 #[test]
-fn storage_mapper_set_rs() {
-    elrond_wasm_debug::mandos_rs("mandos/storage_mapper_set.scen.json", &contract_map());
-}
-
-#[test]
 fn storage_mapper_map_storage_rs() {
     elrond_wasm_debug::mandos_rs(
         "mandos/storage_mapper_map_storage.scen.json",
@@ -282,9 +347,22 @@ fn storage_mapper_map_storage_rs() {
 }
 
 #[test]
+fn storage_mapper_set_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/storage_mapper_set.scen.json", &contract_map());
+}
+
+#[test]
 fn storage_mapper_single_value_rs() {
     elrond_wasm_debug::mandos_rs(
         "mandos/storage_mapper_single_value.scen.json",
+        &contract_map(),
+    );
+}
+
+#[test]
+fn storage_mapper_token_attributes_rs() {
+    elrond_wasm_debug::mandos_rs(
+        "mandos/storage_mapper_token_attributes.scen.json",
         &contract_map(),
     );
 }
@@ -327,19 +405,4 @@ fn storage_usize_bad_rs() {
 #[test]
 fn storage_vec_u8_rs() {
     elrond_wasm_debug::mandos_rs("mandos/storage_vec_u8.scen.json", &contract_map());
-}
-
-#[test]
-fn sqrt() {
-    elrond_wasm_debug::mandos_rs("mandos/sqrt.scen.json", &contract_map());
-}
-
-#[test]
-fn log2() {
-    elrond_wasm_debug::mandos_rs("mandos/log2_func.scen.json", &contract_map());
-}
-
-#[test]
-fn pow() {
-    elrond_wasm_debug::mandos_rs("mandos/pow_func.scen.json", &contract_map());
 }

--- a/elrond-wasm-debug/src/api/managed_types/big_int_util.rs
+++ b/elrond-wasm-debug/src/api/managed_types/big_int_util.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 
+use elrond_wasm::types::ManagedType;
 use num_bigint::Sign;
 use num_traits::Zero;
 

--- a/elrond-wasm-node/src/api/blockchain_api_node.rs
+++ b/elrond-wasm-node/src/api/blockchain_api_node.rs
@@ -1,6 +1,7 @@
 use elrond_wasm::api::BlockchainApi;
 use elrond_wasm::types::{
-    Address, BigUint, Box, BoxedBytes, EsdtTokenData, EsdtTokenType, TokenIdentifier, H256,
+    Address, BigUint, Box, BoxedBytes, EsdtTokenData, EsdtTokenType, ManagedType, TokenIdentifier,
+    H256,
 };
 
 extern "C" {

--- a/elrond-wasm-node/src/api/call_value_api_node.rs
+++ b/elrond-wasm-node/src/api/call_value_api_node.rs
@@ -1,6 +1,6 @@
 use crate::ArwenApiImpl;
 use elrond_wasm::api::CallValueApi;
-use elrond_wasm::types::{BigUint, BoxedBytes, EsdtTokenType, TokenIdentifier};
+use elrond_wasm::types::{BigUint, BoxedBytes, EsdtTokenType, ManagedType, TokenIdentifier};
 
 const MAX_POSSIBLE_TOKEN_IDENTIFIER_LENGTH: usize = 32;
 

--- a/elrond-wasm-node/src/api/send_api_node.rs
+++ b/elrond-wasm-node/src/api/send_api_node.rs
@@ -2,7 +2,9 @@ use crate::api::managed_types::unsafe_buffer_load_be_pad_right;
 use crate::ArwenApiImpl;
 use alloc::vec::Vec;
 use elrond_wasm::api::{BlockchainApi, SendApi, StorageReadApi, StorageWriteApi};
-use elrond_wasm::types::{Address, ArgBuffer, BigUint, BoxedBytes, CodeMetadata, TokenIdentifier};
+use elrond_wasm::types::{
+    Address, ArgBuffer, BigUint, BoxedBytes, CodeMetadata, ManagedType, TokenIdentifier,
+};
 
 // Token ID + nonce + amount, as bytes
 const AVERAGE_MULTI_TRANSFER_ARG_PAIR_LENGTH: usize = 15 + 2 + 8;

--- a/elrond-wasm/src/api/blockchain_api.rs
+++ b/elrond-wasm/src/api/blockchain_api.rs
@@ -1,7 +1,8 @@
 use super::{ErrorApi, ManagedTypeApi, StorageReadApi};
 use crate::storage::{self, StorageKey};
 use crate::types::{
-    Address, BigUint, BoxedBytes, EsdtLocalRole, EsdtTokenData, TokenIdentifier, Vec, H256,
+    Address, BigUint, BoxedBytes, EsdtLocalRole, EsdtTokenData, ManagedType, TokenIdentifier, Vec,
+    H256,
 };
 use alloc::boxed::Box;
 

--- a/elrond-wasm/src/api/helpers/serializer.rs
+++ b/elrond-wasm/src/api/helpers/serializer.rs
@@ -3,7 +3,7 @@ use elrond_codec::{DecodeError, EncodeError, TopDecode, TopEncode};
 use crate::{
     api::{ErrorApi, ManagedTypeApi},
     err_msg,
-    types::{BoxedBytes, ManagedBuffer, ManagedBytesTopDecodeInput},
+    types::{BoxedBytes, ManagedBuffer, ManagedBytesTopDecodeInput, ManagedType},
 };
 
 pub struct ManagedSerializer<M>

--- a/elrond-wasm/src/io/arg_de_input.rs
+++ b/elrond-wasm/src/io/arg_de_input.rs
@@ -1,5 +1,5 @@
 use crate::api::ManagedTypeApi;
-use crate::types::{BigInt, BigUint, ManagedBufferNestedDecodeInput};
+use crate::types::{BigInt, BigUint, ManagedBufferNestedDecodeInput, ManagedType};
 use crate::Box;
 use crate::{api::EndpointArgumentApi, types::ManagedBuffer};
 use elrond_codec::{try_execute_then_cast, DecodeError, TopDecodeInput, TryStaticCast};
@@ -33,7 +33,7 @@ where
     #[inline]
     fn to_managed_buffer(&self) -> ManagedBuffer<AA> {
         let mbuf_handle = self.api.get_argument_managed_buffer_raw(self.arg_index);
-        ManagedBuffer::new_from_raw_handle(self.api.clone(), mbuf_handle)
+        ManagedBuffer::from_raw_handle(self.api.clone(), mbuf_handle)
     }
 
     #[inline]

--- a/elrond-wasm/src/io/finish.rs
+++ b/elrond-wasm/src/io/finish.rs
@@ -3,7 +3,7 @@ use elrond_codec::TryStaticCast;
 use crate::api::{EndpointFinishApi, ErrorApi, ManagedTypeApi};
 use crate::elrond_codec::{EncodeError, TopEncode, TopEncodeOutput};
 use crate::err_msg;
-use crate::types::{BigInt, BigUint, ManagedBuffer};
+use crate::types::{BigInt, BigUint, ManagedBuffer, ManagedType};
 
 struct ApiOutputAdapter<FA>
 where

--- a/elrond-wasm/src/io/signal_error.rs
+++ b/elrond-wasm/src/io/signal_error.rs
@@ -1,7 +1,7 @@
 use super::ArgId;
 use crate::api::{ErrorApi, ManagedTypeApi};
 use crate::err_msg;
-use crate::types::ManagedBuffer;
+use crate::types::{ManagedBuffer, ManagedType};
 use elrond_codec::DecodeError;
 
 pub fn signal_arg_de_error<EA>(api: EA, arg_id: ArgId, decode_err: DecodeError) -> !

--- a/elrond-wasm/src/log_util.rs
+++ b/elrond-wasm/src/log_util.rs
@@ -3,7 +3,7 @@ use elrond_codec::{EncodeError, TopEncode};
 use crate::{
     api::{ErrorApi, ManagedTypeApi},
     err_msg,
-    types::{BoxedBytes, ManagedBuffer},
+    types::{BoxedBytes, ManagedBuffer, ManagedType},
 };
 
 pub fn serialize_log_data<T, EA>(data: T, api: EA) -> BoxedBytes

--- a/elrond-wasm/src/storage/storage_get.rs
+++ b/elrond-wasm/src/storage/storage_get.rs
@@ -1,6 +1,6 @@
 use crate::api::{ErrorApi, ManagedTypeApi, StorageReadApi};
 use crate::err_msg;
-use crate::types::{BigInt, BigUint, ManagedBuffer, ManagedBufferNestedDecodeInput};
+use crate::types::{BigInt, BigUint, ManagedBuffer, ManagedBufferNestedDecodeInput, ManagedType};
 use alloc::boxed::Box;
 use elrond_codec::*;
 
@@ -27,7 +27,7 @@ where
         let mbuf_handle = self
             .api
             .storage_load_managed_buffer_raw(self.key.buffer.get_raw_handle());
-        ManagedBuffer::new_from_raw_handle(self.api.clone(), mbuf_handle)
+        ManagedBuffer::from_raw_handle(self.api.clone(), mbuf_handle)
     }
 
     fn to_big_uint(&self) -> BigUint<A> {

--- a/elrond-wasm/src/storage/storage_key.rs
+++ b/elrond-wasm/src/storage/storage_key.rs
@@ -1,5 +1,5 @@
 use crate::api::{ErrorApi, ManagedTypeApi};
-use crate::types::{BoxedBytes, ManagedBuffer};
+use crate::types::{BoxedBytes, ManagedBuffer, ManagedType};
 use crate::*;
 use elrond_codec::*;
 

--- a/elrond-wasm/src/storage/storage_set.rs
+++ b/elrond-wasm/src/storage/storage_set.rs
@@ -1,5 +1,5 @@
 use crate::api::{ErrorApi, ManagedTypeApi, StorageWriteApi};
-use crate::types::{BigInt, BigUint, ManagedBuffer};
+use crate::types::{BigInt, BigUint, ManagedBuffer, ManagedType};
 use crate::*;
 use elrond_codec::*;
 

--- a/elrond-wasm/src/types/general/esdt_token_data.rs
+++ b/elrond-wasm/src/types/general/esdt_token_data.rs
@@ -1,7 +1,7 @@
 use crate::{
     abi::TypeAbi,
     api::ManagedTypeApi,
-    types::{BigUint, ManagedBytesTopDecodeInput},
+    types::{BigUint, ManagedBytesTopDecodeInput, ManagedType},
 };
 use alloc::string::String;
 use elrond_codec::*;

--- a/elrond-wasm/src/types/managed/big_int.rs
+++ b/elrond-wasm/src/types/managed/big_int.rs
@@ -1,4 +1,4 @@
-use super::ManagedBuffer;
+use super::{ManagedBuffer, ManagedType};
 use crate::api::{Handle, ManagedTypeApi};
 use crate::types::BoxedBytes;
 use alloc::string::String;
@@ -21,13 +21,23 @@ pub enum Sign {
     Plus,
 }
 
-impl<M: ManagedTypeApi> BigInt<M> {
+impl<M: ManagedTypeApi> ManagedType<M> for BigInt<M> {
     #[doc(hidden)]
-    pub fn from_raw_handle(api: M, raw_handle: Handle) -> Self {
+    fn from_raw_handle(api: M, raw_handle: Handle) -> Self {
         BigInt {
             handle: raw_handle,
             api,
         }
+    }
+
+    #[doc(hidden)]
+    fn get_raw_handle(&self) -> Handle {
+        self.handle
+    }
+
+    #[inline]
+    fn type_manager(&self) -> M {
+        self.api.clone()
     }
 }
 

--- a/elrond-wasm/src/types/managed/big_uint.rs
+++ b/elrond-wasm/src/types/managed/big_uint.rs
@@ -1,4 +1,4 @@
-use super::ManagedBuffer;
+use super::{ManagedBuffer, ManagedType};
 use crate::api::{Handle, ManagedTypeApi};
 use crate::types::BoxedBytes;
 use alloc::string::String;
@@ -13,9 +13,9 @@ pub struct BigUint<M: ManagedTypeApi> {
     pub(crate) api: M,
 }
 
-impl<M: ManagedTypeApi> BigUint<M> {
+impl<M: ManagedTypeApi> ManagedType<M> for BigUint<M> {
     #[doc(hidden)]
-    pub fn from_raw_handle(api: M, raw_handle: Handle) -> Self {
+    fn from_raw_handle(api: M, raw_handle: Handle) -> Self {
         BigUint {
             handle: raw_handle,
             api,
@@ -23,12 +23,12 @@ impl<M: ManagedTypeApi> BigUint<M> {
     }
 
     #[doc(hidden)]
-    pub fn get_raw_handle(&self) -> Handle {
+    fn get_raw_handle(&self) -> Handle {
         self.handle
     }
 
     #[inline]
-    pub fn type_manager(&self) -> M {
+    fn type_manager(&self) -> M {
         self.api.clone()
     }
 }

--- a/elrond-wasm/src/types/managed/elliptic_curve.rs
+++ b/elrond-wasm/src/types/managed/elliptic_curve.rs
@@ -6,7 +6,7 @@ use elrond_codec::*;
 
 use crate::types::BoxedBytes;
 
-use super::BigUint;
+use super::{BigUint, ManagedType};
 
 pub type EllipticCurveComponents<M> = (
     BigUint<M>,
@@ -21,6 +21,26 @@ pub type EllipticCurveComponents<M> = (
 pub struct EllipticCurve<M: ManagedTypeApi> {
     pub(super) handle: Handle,
     pub(super) api: M,
+}
+
+impl<M: ManagedTypeApi> ManagedType<M> for EllipticCurve<M> {
+    #[doc(hidden)]
+    fn from_raw_handle(api: M, raw_handle: Handle) -> Self {
+        EllipticCurve {
+            handle: raw_handle,
+            api,
+        }
+    }
+
+    #[doc(hidden)]
+    fn get_raw_handle(&self) -> Handle {
+        self.handle
+    }
+
+    #[inline]
+    fn type_manager(&self) -> M {
+        self.api.clone()
+    }
 }
 
 impl<M: ManagedTypeApi> EllipticCurve<M> {

--- a/elrond-wasm/src/types/managed/managed_buffer.rs
+++ b/elrond-wasm/src/types/managed/managed_buffer.rs
@@ -1,3 +1,4 @@
+use super::ManagedType;
 use crate::api::InvalidSliceError;
 use crate::{
     api::{Handle, ManagedTypeApi},
@@ -16,6 +17,23 @@ pub struct ManagedBuffer<M: ManagedTypeApi> {
     pub(crate) api: M,
 }
 
+impl<M: ManagedTypeApi> ManagedType<M> for ManagedBuffer<M> {
+    #[inline]
+    fn from_raw_handle(api: M, handle: Handle) -> Self {
+        ManagedBuffer { handle, api }
+    }
+
+    #[doc(hidden)]
+    fn get_raw_handle(&self) -> Handle {
+        self.handle
+    }
+
+    #[inline]
+    fn type_manager(&self) -> M {
+        self.api.clone()
+    }
+}
+
 impl<M: ManagedTypeApi> ManagedBuffer<M> {
     #[inline]
     pub fn new_empty(api: M) -> Self {
@@ -31,21 +49,6 @@ impl<M: ManagedTypeApi> ManagedBuffer<M> {
             handle: api.mb_new_from_bytes(bytes),
             api,
         }
-    }
-
-    #[inline]
-    pub(crate) fn new_from_raw_handle(api: M, handle: Handle) -> Self {
-        ManagedBuffer { handle, api }
-    }
-
-    #[inline]
-    pub fn type_manager(&self) -> M {
-        self.api.clone()
-    }
-
-    #[doc(hidden)]
-    pub fn get_raw_handle(&self) -> Handle {
-        self.handle
     }
 
     #[inline]
@@ -83,7 +86,7 @@ impl<M: ManagedTypeApi> ManagedBuffer<M> {
             self.api
                 .mb_copy_slice(self.handle, starting_position, slice_len, result_handle);
         if err_result.is_ok() {
-            Some(ManagedBuffer::new_from_raw_handle(
+            Some(ManagedBuffer::from_raw_handle(
                 self.api.clone(),
                 result_handle,
             ))

--- a/elrond-wasm/src/types/managed/managed_type_trait.rs
+++ b/elrond-wasm/src/types/managed/managed_type_trait.rs
@@ -1,0 +1,12 @@
+use crate::api::{Handle, ManagedTypeApi};
+
+/// Commonalities between all managed types.
+pub trait ManagedType<M: ManagedTypeApi> {
+    #[doc(hidden)]
+    fn from_raw_handle(api: M, raw_handle: Handle) -> Self;
+
+    #[doc(hidden)]
+    fn get_raw_handle(&self) -> Handle;
+
+    fn type_manager(&self) -> M;
+}

--- a/elrond-wasm/src/types/managed/managed_vec.rs
+++ b/elrond-wasm/src/types/managed/managed_vec.rs
@@ -1,0 +1,188 @@
+use super::{ManagedBuffer, ManagedType, ManagedVecItem};
+use crate::{
+    abi::TypeAbi,
+    api::{Handle, ManagedTypeApi},
+    types::ManagedBufferNestedDecodeInput,
+};
+use alloc::string::String;
+use core::marker::PhantomData;
+use elrond_codec::{
+    DecodeError, EncodeError, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput,
+    TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
+};
+
+/// A list of items that lives inside a managed buffer.
+/// Items can be either stored there in full (e.g. `u32`),
+/// or just via handle (e.g. `BigUint<M>`).
+#[derive(Debug)]
+pub struct ManagedVec<M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    pub(crate) buffer: ManagedBuffer<M>,
+    _phantom: PhantomData<T>,
+}
+
+impl<M, T> ManagedType<M> for ManagedVec<M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    #[inline]
+    fn from_raw_handle(api: M, handle: Handle) -> Self {
+        ManagedVec {
+            buffer: ManagedBuffer::from_raw_handle(api, handle),
+            _phantom: PhantomData,
+        }
+    }
+
+    #[doc(hidden)]
+    fn get_raw_handle(&self) -> Handle {
+        self.buffer.get_raw_handle()
+    }
+
+    #[inline]
+    fn type_manager(&self) -> M {
+        self.buffer.type_manager()
+    }
+}
+
+impl<M, T> ManagedVec<M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    #[inline]
+    pub fn new_empty(api: M) -> Self {
+        ManagedVec {
+            buffer: ManagedBuffer::new_empty(api),
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn new_from_raw_buffer(buffer: ManagedBuffer<M>) -> Self {
+        ManagedVec {
+            buffer,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Length of the underlying buffer in bytes.
+    #[inline]
+    pub fn byte_len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Number of items.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.byte_len() / T::PAYLOAD_SIZE
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.byte_len() == 0
+    }
+
+    pub fn push(&mut self, item: T) {
+        item.to_byte_writer(|bytes| {
+            self.buffer.append_bytes(bytes);
+        });
+    }
+
+    pub fn get(&self, index: usize) -> Option<T> {
+        let byte_index = index * T::PAYLOAD_SIZE;
+        let mut load_result = Ok(());
+        let result = T::from_byte_reader(self.type_manager(), |dest_slice| {
+            load_result = self.buffer.load_slice(byte_index, dest_slice);
+        });
+        match load_result {
+            Ok(_) => Some(result),
+            Err(_) => None,
+        }
+    }
+}
+
+impl<M, T> TopEncode for ManagedVec<M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    #[inline]
+    fn top_encode<O: TopEncodeOutput>(&self, output: O) -> Result<(), EncodeError> {
+        if T::NEEDS_RESERIALIZATION {
+            let mut nested_buffer = output.start_nested_encode();
+            for item in self {
+                item.dep_encode(&mut nested_buffer)?;
+            }
+            output.finalize_nested_encode(nested_buffer);
+            Ok(())
+        } else {
+            self.buffer.top_encode(output)
+        }
+    }
+}
+
+impl<M, T> NestedEncode for ManagedVec<M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {
+        if T::NEEDS_RESERIALIZATION {
+            self.len().dep_encode(dest)?;
+            for item in self {
+                item.dep_encode(dest)?;
+            }
+            Ok(())
+        } else {
+            self.buffer.dep_encode(dest)?;
+            Ok(())
+        }
+    }
+}
+
+impl<M, T> TopDecode for ManagedVec<M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
+        let buffer = ManagedBuffer::top_decode(input)?;
+        if T::NEEDS_RESERIALIZATION {
+            let mut result = ManagedVec::new_empty(buffer.type_manager());
+            let mut nested_de_input = ManagedBufferNestedDecodeInput::new(buffer);
+            while nested_de_input.remaining_len() > 0 {
+                result.push(T::dep_decode(&mut nested_de_input)?);
+            }
+            Ok(result)
+        } else {
+            Ok(ManagedVec::new_from_raw_buffer(buffer))
+        }
+    }
+}
+
+impl<M, T> NestedDecode for ManagedVec<M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    fn dep_decode<I: NestedDecodeInput>(_input: &mut I) -> Result<Self, DecodeError> {
+        // TODO: this is more complex and requires more specialization
+        // not immediately needed
+        Err(DecodeError::UNSUPPORTED_OPERATION)
+    }
+}
+
+impl<M, T> TypeAbi for ManagedVec<M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    /// It is semantically equivalent to any list of `T`.
+    fn type_name() -> String {
+        <&[T] as TypeAbi>::type_name()
+    }
+}

--- a/elrond-wasm/src/types/managed/managed_vec_item.rs
+++ b/elrond-wasm/src/types/managed/managed_vec_item.rs
@@ -7,7 +7,11 @@ use crate::{
 
 use super::{BigInt, BigUint, ManagedBuffer, ManagedType};
 
-/// Types that implement this trait can fir inside a `ManagedVec`.
+/// Types that implement this trait can be items inside a `ManagedVec`.
+/// All these types need a payload, i.e a representation that gets stored
+/// in the underlying managed buffer.
+/// Not all data needs to be stored as payload, for instance for most managed types
+/// the payload is just the handle, whereas the mai ndata is kept by the VM.
 pub trait ManagedVecItem<M: ManagedTypeApi>: NestedDecode + NestedEncode + TypeAbi {
     /// Size of the data stored in the underlying `ManagedBuffer`.
     const PAYLOAD_SIZE: usize;

--- a/elrond-wasm/src/types/managed/managed_vec_item.rs
+++ b/elrond-wasm/src/types/managed/managed_vec_item.rs
@@ -1,0 +1,69 @@
+use elrond_codec::{NestedDecode, NestedEncode};
+
+use crate::{
+    abi::TypeAbi,
+    api::{Handle, ManagedTypeApi},
+};
+
+use super::{BigInt, BigUint, ManagedBuffer, ManagedType};
+
+/// Types that implement this trait can fir inside a `ManagedVec`.
+pub trait ManagedVecItem<M: ManagedTypeApi>: NestedDecode + NestedEncode + TypeAbi {
+    /// Size of the data stored in the underlying `ManagedBuffer`.
+    const PAYLOAD_SIZE: usize;
+
+    /// If false, then the encoding of the item is identical to the payload,
+    /// and no further conversion is necessary
+    /// (the underlying buffer can be used as-is during serialization).
+    /// True for all managed types, but false for basic types (like `u32`).
+    const NEEDS_RESERIALIZATION: bool;
+
+    fn from_byte_reader<Reader: FnMut(&mut [u8])>(api: M, reader: Reader) -> Self;
+
+    fn to_byte_writer<R, Writer: FnMut(&[u8]) -> R>(&self, writer: Writer) -> R;
+}
+
+macro_rules! impl_int {
+    ($ty:ident, $payload_size:expr) => {
+        impl<M: ManagedTypeApi> ManagedVecItem<M> for $ty {
+            const PAYLOAD_SIZE: usize = $payload_size;
+            const NEEDS_RESERIALIZATION: bool = false;
+
+            fn from_byte_reader<Reader: FnMut(&mut [u8])>(_api: M, mut reader: Reader) -> Self {
+                let mut arr: [u8; $payload_size] = [0u8; $payload_size];
+                reader(&mut arr[..]);
+                $ty::from_be_bytes(arr)
+            }
+
+            fn to_byte_writer<R, Writer: FnMut(&[u8]) -> R>(&self, mut writer: Writer) -> R {
+                let bytes = self.to_be_bytes();
+                writer(&bytes)
+            }
+        }
+    };
+}
+
+impl_int! {u32, 4}
+impl_int! {i32, 4}
+
+macro_rules! impl_managed_type {
+    ($ty:ident) => {
+        impl<M: ManagedTypeApi> ManagedVecItem<M> for $ty<M> {
+            const PAYLOAD_SIZE: usize = 4;
+            const NEEDS_RESERIALIZATION: bool = true;
+
+            fn from_byte_reader<Reader: FnMut(&mut [u8])>(api: M, reader: Reader) -> Self {
+                let handle = Handle::from_byte_reader(api.clone(), reader);
+                $ty::from_raw_handle(api, handle)
+            }
+
+            fn to_byte_writer<R, Writer: FnMut(&[u8]) -> R>(&self, writer: Writer) -> R {
+                <Handle as ManagedVecItem<M>>::to_byte_writer(&self.get_raw_handle(), writer)
+            }
+        }
+    };
+}
+
+impl_managed_type! {ManagedBuffer}
+impl_managed_type! {BigUint}
+impl_managed_type! {BigInt}

--- a/elrond-wasm/src/types/managed/managed_vec_iter.rs
+++ b/elrond-wasm/src/types/managed/managed_vec_iter.rs
@@ -1,0 +1,63 @@
+use crate::api::ManagedTypeApi;
+
+use super::{ManagedType, ManagedVec, ManagedVecItem};
+
+impl<'a, M, T> IntoIterator for &'a ManagedVec<M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    type Item = T;
+    type IntoIter = ManagedVecIterator<'a, M, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        ManagedVecIterator::new(self)
+    }
+}
+
+pub struct ManagedVecIterator<'a, M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    managed_vec: &'a ManagedVec<M, T>,
+    byte_index: usize,
+    byte_limit: usize,
+}
+
+impl<'a, M, T> ManagedVecIterator<'a, M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    fn new(managed_vec: &'a ManagedVec<M, T>) -> Self {
+        ManagedVecIterator {
+            managed_vec,
+            byte_index: 0,
+            byte_limit: managed_vec.byte_len(),
+        }
+    }
+}
+
+impl<'a, M, T> Iterator for ManagedVecIterator<'a, M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        let next_byte_index = self.byte_index + T::PAYLOAD_SIZE;
+        if next_byte_index > self.byte_limit {
+            return None;
+        }
+        let result = T::from_byte_reader(self.managed_vec.type_manager(), |dest_slice| {
+            let _ = self
+                .managed_vec
+                .buffer
+                .load_slice(self.byte_index, dest_slice);
+        });
+
+        self.byte_index = next_byte_index;
+        Some(result)
+    }
+}

--- a/elrond-wasm/src/types/managed/mod.rs
+++ b/elrond-wasm/src/types/managed/mod.rs
@@ -6,8 +6,16 @@ mod big_uint_cmp;
 mod big_uint_operators;
 mod elliptic_curve;
 mod managed_buffer;
+mod managed_type_trait;
+mod managed_vec;
+mod managed_vec_item;
+mod managed_vec_iter;
 
 pub use big_int::BigInt;
 pub use big_uint::BigUint;
 pub use elliptic_curve::{EllipticCurve, EllipticCurveComponents};
 pub use managed_buffer::ManagedBuffer;
+pub use managed_type_trait::ManagedType;
+pub use managed_vec::ManagedVec;
+pub use managed_vec_item::ManagedVecItem;
+pub use managed_vec_iter::ManagedVecIterator;

--- a/tools/test-gen/src/test_gen.rs
+++ b/tools/test-gen/src/test_gen.rs
@@ -65,8 +65,9 @@ fn {}_go() {{
     }
 }
 
-/// Example run:
+/// Examples how to run:
 /// `cargo run ../../contracts/examples/erc20/mandos`
+/// `cargo run ../../contracts/feature-tests/basic-features/mandos`
 fn main() {
     let args: Vec<String> = env::args().collect();
     let files_path = &args[1];


### PR DESCRIPTION
A structure based on a managed buffer, that can hold meaningful content.
Can be used to create "managed list of managed buffers" or of other managed types.
Highly extensible.

The idea is to use a managed buffer containing handles to other managed buffers to send log topics to Arwen, or to pass arguments. Also to retrieve results from execute_on_dest_context.