### PR TITLE
Extend Token Attr Mapper

### DIFF
--- a/contracts/feature-tests/basic-features/mandos/storage_mapper_token_attributes.scen.json
+++ b/contracts/feature-tests/basic-features/mandos/storage_mapper_token_attributes.scen.json
@@ -61,7 +61,7 @@
             "expect": {
                 "out": [],
                 "status": "4",
-                "message": "str:A value was already set for this token ID and token nonce",
+                "message": "str:A value was already set",
                 "gas": "*"
             }
         },
@@ -107,7 +107,7 @@
             "expect": {
                 "out": [],
                 "status": "4",
-                "message": "str:A value was already set for this token ID and token nonce",
+                "message": "str:A value was already set",
                 "gas": "*"
             }
         },
@@ -126,6 +126,8 @@
                     "storage": {
                         "str:TokenAttributes.attr|u8:1|u64:1": "biguint:10|u64:20|u32:2|u32:1|u32:2",
                         "str:TokenAttributes.attr|u8:2|u64:1": "biguint:20|u64:20|u32:2|u32:1|u32:2",
+                        "str:TokenAttributes.nonce|u8:1|biguint:10|u64:20|u32:2|u32:1|u32:2": "1",
+                        "str:TokenAttributes.nonce|u8:2|biguint:20|u64:20|u32:2|u32:1|u32:2": "1",
                         "str:TokenAttributes.counter": "2",
                         "str:TokenAttributes.mapping|nested:str:BOB-abcdef": "2",
                         "str:TokenAttributes.mapping|nested:str:ALICE-abcdef": "1"
@@ -141,7 +143,7 @@
                 "from": "address:owner",
                 "to": "sc:contract",
                 "value": "0",
-                "function": "token_attributes_get",
+                "function": "token_attributes_get_attributes",
                 "arguments": [
                     "str:ALICE-abcdef",
                     "u64:1"
@@ -165,7 +167,7 @@
                 "from": "address:owner",
                 "to": "sc:contract",
                 "value": "0",
-                "function": "token_attributes_get",
+                "function": "token_attributes_get_attributes",
                 "arguments": [
                     "str:ALICE-abcdef",
                     "u64:10"
@@ -176,7 +178,7 @@
             "expect": {
                 "out": [],
                 "status": "4",
-                "message": "str:A value was not previously set fot this token ID and token nonce",
+                "message": "str:A value was not previously set",
                 "gas": "*"
             }
         },
@@ -187,7 +189,7 @@
                 "from": "address:owner",
                 "to": "sc:contract",
                 "value": "0",
-                "function": "token_attributes_get",
+                "function": "token_attributes_get_attributes",
                 "arguments": [
                     "str:BOB-abcdef",
                     "u64:1"
@@ -211,7 +213,7 @@
                 "from": "address:owner",
                 "to": "sc:contract",
                 "value": "0",
-                "function": "token_attributes_get",
+                "function": "token_attributes_get_attributes",
                 "arguments": [
                     "str:BOB2-abcdef",
                     "u64:1"
@@ -222,18 +224,110 @@
             "expect": {
                 "out": [],
                 "status": "4",
-                "message": "str:Unknown token id. No attributes were set for this token ID",
+                "message": "str:Unknown token id",
                 "gas": "*"
             }
         },
         {
             "step": "scCall",
-            "txId": "is_empty-token-attributes-1",
+            "txId": "get-token-nonce-1",
             "tx": {
                 "from": "address:owner",
                 "to": "sc:contract",
                 "value": "0",
-                "function": "token_attributes_is_empty",
+                "function": "token_attributes_get_nonce",
+                "arguments": [
+                    "str:ALICE-abcdef",
+                    "biguint:10|u64:20|u32:2|u32:1|u32:2"
+                ],
+                "gasLimit": "100,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [
+                    "1"
+                ],
+                "status": "0",
+                "message": "*",
+                "gas": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "get-token-nonce-2",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:contract",
+                "value": "0",
+                "function": "token_attributes_get_nonce",
+                "arguments": [
+                    "str:ALICE-abcdef",
+                    "biguint:10|u64:20|u32:2|u32:1|u32:10"
+                ],
+                "gasLimit": "100,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "4",
+                "message": "str:A value was not previously set",
+                "gas": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "get-token-nonce-3",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:contract",
+                "value": "0",
+                "function": "token_attributes_get_nonce",
+                "arguments": [
+                    "str:BOB-abcdef",
+                    "biguint:20|u64:20|u32:2|u32:1|u32:2"
+                ],
+                "gasLimit": "100,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [
+                    "1"
+                ],
+                "status": "0",
+                "message": "*",
+                "gas": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "get-token-nonce-4",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:contract",
+                "value": "0",
+                "function": "token_attributes_get_nonce",
+                "arguments": [
+                    "str:BOB2-abcdef",
+                    "biguint:10|u64:20|u32:2|u32:1|u32:2"
+                ],
+                "gasLimit": "100,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "4",
+                "message": "str:Unknown token id",
+                "gas": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "has_attributes-token-attributes-1",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:contract",
+                "value": "0",
+                "function": "token_attributes_has_attributes",
                 "arguments": [
                     "str:ALICE-abcdef",
                     "u64:1"
@@ -252,12 +346,12 @@
         },
         {
             "step": "scCall",
-            "txId": "is_empty-token-attributes-2",
+            "txId": "has_attributes-token-attributes-2",
             "tx": {
                 "from": "address:owner",
                 "to": "sc:contract",
                 "value": "0",
-                "function": "token_attributes_is_empty",
+                "function": "token_attributes_has_attributes",
                 "arguments": [
                     "str:ALICE-abcdef",
                     "u64:10"
@@ -276,12 +370,12 @@
         },
         {
             "step": "scCall",
-            "txId": "is_empty-token-attributes-3",
+            "txId": "has_attributes-token-attributes-3",
             "tx": {
                 "from": "address:owner",
                 "to": "sc:contract",
                 "value": "0",
-                "function": "token_attributes_is_empty",
+                "function": "token_attributes_has_attributes",
                 "arguments": [
                     "str:BOB-abcdef",
                     "u64:1"
@@ -300,12 +394,12 @@
         },
         {
             "step": "scCall",
-            "txId": "is_empty-token-attributes-4",
+            "txId": "has_attributes-token-attributes-4",
             "tx": {
                 "from": "address:owner",
                 "to": "sc:contract",
                 "value": "0",
-                "function": "token_attributes_is_empty",
+                "function": "token_attributes_has_attributes",
                 "arguments": [
                     "str:BOB2-abcdef",
                     "u64:1"
@@ -342,7 +436,8 @@
                 "out": [],
                 "status": "0",
                 "message": "*",
-                "gas": "*"
+                "gas": "*",
+                "refund": "*"
             }
         },
         {
@@ -364,7 +459,7 @@
             "expect": {
                 "out": [],
                 "status": "4",
-                "message": "str:A value was not previously set fot this token ID and token nonce",
+                "message": "str:A value was not previously set",
                 "gas": "*"
             }
         },
@@ -388,7 +483,8 @@
                 "out": [],
                 "status": "0",
                 "message": "*",
-                "gas": "*"
+                "gas": "*",
+                "refund": "*"
             }
         },
         {
@@ -410,7 +506,7 @@
             "expect": {
                 "out": [],
                 "status": "4",
-                "message": "str:Unknown token id. No attributes were set for this token ID",
+                "message": "str:Unknown token id",
                 "gas": "*"
             }
         },
@@ -418,7 +514,7 @@
             "step": "checkState",
             "accounts": {
                 "address:owner": {
-                    "nonce": "16",
+                    "nonce": "20",
                     "balance": "1000",
                     "storage": {},
                     "code": ""
@@ -429,6 +525,8 @@
                     "storage": {
                         "str:TokenAttributes.attr|u8:1|u64:1": "biguint:30|u64:20|u32:2|u32:1|u32:2",
                         "str:TokenAttributes.attr|u8:2|u64:1": "biguint:40|u64:20|u32:2|u32:1|u32:2",
+                        "str:TokenAttributes.nonce|u8:1|biguint:30|u64:20|u32:2|u32:1|u32:2": "1",
+                        "str:TokenAttributes.nonce|u8:2|biguint:40|u64:20|u32:2|u32:1|u32:2": "1",
                         "str:TokenAttributes.counter": "2",
                         "str:TokenAttributes.mapping|nested:str:BOB-abcdef": "2",
                         "str:TokenAttributes.mapping|nested:str:ALICE-abcdef": "1"
@@ -531,7 +629,7 @@
             "step": "checkState",
             "accounts": {
                 "address:owner": {
-                    "nonce": "20",
+                    "nonce": "24",
                     "balance": "1000",
                     "storage": {},
                     "code": ""

--- a/contracts/feature-tests/basic-features/src/storage_mapper_token_attributes.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_token_attributes.rs
@@ -1,7 +1,7 @@
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
-#[derive(TopEncode, TopDecode, TypeAbi)]
+#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi)]
 pub struct TokenAttributesStruct<M: ManagedTypeApi> {
     field_biguint: BigUint<M>,
     field_u64: u64,
@@ -36,21 +36,47 @@ pub trait TokenAttributesMapperFeatures {
     }
 
     #[endpoint]
-    fn token_attributes_get(
+    fn token_attributes_get_attributes(
         &self,
         token_id: &TokenIdentifier,
         token_nonce: u64,
     ) -> TokenAttributesStruct<Self::TypeManager> {
-        self.token_attributes().get(token_id, token_nonce)
+        self.token_attributes()
+            .get_attributes::<TokenAttributesStruct<Self::TypeManager>, Self::TypeManager>(
+                token_id,
+                token_nonce,
+            )
+    }
+
+    #[endpoint]
+    fn token_attributes_get_nonce(
+        &self,
+        token_id: &TokenIdentifier,
+        attributes: TokenAttributesStruct<Self::TypeManager>,
+    ) -> u64 {
+        self.token_attributes()
+            .get_nonce::<TokenAttributesStruct<Self::TypeManager>, Self::TypeManager>(
+                token_id,
+                &attributes,
+            )
     }
 
     #[endpoint]
     fn token_attributes_clear(&self, token_id: &TokenIdentifier, token_nonce: u64) {
-        self.token_attributes().clear(token_id, token_nonce)
+        self.token_attributes()
+            .clear::<TokenAttributesStruct<Self::TypeManager>, Self::TypeManager>(
+                token_id,
+                token_nonce,
+            )
     }
 
     #[endpoint]
-    fn token_attributes_is_empty(&self, token_id: &TokenIdentifier, token_nonce: u64) -> bool {
-        self.token_attributes().is_empty(token_id, token_nonce)
+    fn token_attributes_has_attributes(
+        &self,
+        token_id: &TokenIdentifier,
+        token_nonce: u64,
+    ) -> bool {
+        self.token_attributes()
+            .has_attributes(token_id, token_nonce)
     }
 }

--- a/elrond-wasm/src/storage/mappers/token_attributes_mapper.rs
+++ b/elrond-wasm/src/storage/mappers/token_attributes_mapper.rs
@@ -1,4 +1,4 @@
-use elrond_codec::{TopDecode, TopEncode};
+use elrond_codec::{NestedDecode, NestedEncode, TopDecode, TopEncode};
 
 use super::StorageMapper;
 use crate::api::{ErrorApi, ManagedTypeApi, StorageReadApi, StorageWriteApi};
@@ -8,15 +8,13 @@ use crate::types::TokenIdentifier;
 const MAPPING_SUFFIX: &[u8] = b".mapping";
 const COUNTER_SUFFIX: &[u8] = b".counter";
 const ATTR_SUFFIX: &[u8] = b".attr";
+const NONCE_SUFFIX: &[u8] = b".nonce";
 
-const VALUE_ALREADY_SET_ERROR_MESSAGE: &[u8] =
-    b"A value was already set for this token ID and token nonce";
+const VALUE_ALREADY_SET_ERROR_MESSAGE: &[u8] = b"A value was already set";
 
-const UNKNOWN_TOKEN_ID_ERROR_MESSAGE: &[u8] =
-    b"Unknown token id. No attributes were set for this token ID";
+const UNKNOWN_TOKEN_ID_ERROR_MESSAGE: &[u8] = b"Unknown token id";
 
-const VALUE_NOT_PREVIOUSLY_SET_ERROR_MESSAGE: &[u8] =
-    b"A value was not previously set fot this token ID and token nonce";
+const VALUE_NOT_PREVIOUSLY_SET_ERROR_MESSAGE: &[u8] = b"A value was not previously set";
 
 const COUNTER_OVERFLOW_ERROR_MESSAGE: &[u8] =
     b"Counter overflow. This module can hold evidence for maximum u8::MAX different token IDs";
@@ -42,7 +40,7 @@ impl<SA> TokenAttributesMapper<SA>
 where
     SA: StorageReadApi + StorageWriteApi + ManagedTypeApi + ErrorApi + Clone + 'static,
 {
-    pub fn set<T: TopEncode + TopDecode, M: ManagedTypeApi>(
+    pub fn set<T: TopEncode + TopDecode + NestedEncode + NestedDecode, M: ManagedTypeApi>(
         &self,
         token_id: &TokenIdentifier<M>,
         token_nonce: u64,
@@ -70,10 +68,11 @@ where
         }
 
         self.set_token_attributes_value(mapping, token_nonce, attributes);
+        self.set_attributes_to_nonce_mapping(mapping, attributes, token_nonce);
     }
 
     ///Use carefully. Update should be used mainly when backed up by the protocol.
-    pub fn update<T: TopEncode + TopDecode, M: ManagedTypeApi>(
+    pub fn update<T: TopEncode + TopDecode + NestedEncode + NestedDecode, M: ManagedTypeApi>(
         &self,
         token_id: &TokenIdentifier<M>,
         token_nonce: u64,
@@ -91,10 +90,18 @@ where
                 .signal_error(VALUE_NOT_PREVIOUSLY_SET_ERROR_MESSAGE);
         }
 
+        let old_attr = self.get_token_attributes_value::<T>(mapping, token_nonce);
+        self.clear_attributes_to_nonce_mapping(mapping, &old_attr);
+
         self.set_token_attributes_value(mapping, token_nonce, attributes);
+        self.set_attributes_to_nonce_mapping(mapping, attributes, token_nonce);
     }
 
-    pub fn clear<M: ManagedTypeApi>(&self, token_id: &TokenIdentifier<M>, token_nonce: u64) {
+    pub fn clear<T: TopEncode + TopDecode + NestedEncode + NestedDecode, M: ManagedTypeApi>(
+        &self,
+        token_id: &TokenIdentifier<M>,
+        token_nonce: u64,
+    ) {
         let has_mapping = self.has_mapping_value(token_id);
         if !has_mapping {
             return;
@@ -106,10 +113,12 @@ where
             return;
         }
 
+        let attr: T = self.get_token_attributes_value(mapping, token_nonce);
         self.clear_token_attributes_value(mapping, token_nonce);
+        self.clear_attributes_to_nonce_mapping(mapping, &attr);
     }
 
-    pub fn is_empty<M: ManagedTypeApi>(
+    pub fn has_attributes<M: ManagedTypeApi>(
         &self,
         token_id: &TokenIdentifier<M>,
         token_nonce: u64,
@@ -123,7 +132,24 @@ where
         self.is_empty_token_attributes_value(mapping, token_nonce)
     }
 
-    pub fn get<T: TopEncode + TopDecode, M: ManagedTypeApi>(
+    pub fn has_nonce<T: TopEncode + TopDecode + NestedEncode + NestedDecode, M: ManagedTypeApi>(
+        &self,
+        token_id: &TokenIdentifier<M>,
+        attr: &T,
+    ) -> bool {
+        let has_mapping = self.has_mapping_value(token_id);
+        if !has_mapping {
+            return true;
+        }
+
+        let mapping = self.get_mapping_value(token_id);
+        self.is_empty_attributes_to_nonce_mapping(mapping, attr)
+    }
+
+    pub fn get_attributes<
+        T: TopEncode + TopDecode + NestedEncode + NestedDecode,
+        M: ManagedTypeApi,
+    >(
         &self,
         token_id: &TokenIdentifier<M>,
         token_nonce: u64,
@@ -143,12 +169,40 @@ where
         self.get_token_attributes_value(mapping, token_nonce)
     }
 
+    pub fn get_nonce<T: TopEncode + TopDecode + NestedEncode + NestedDecode, M: ManagedTypeApi>(
+        &self,
+        token_id: &TokenIdentifier<M>,
+        attr: &T,
+    ) -> u64 {
+        let has_mapping = self.has_mapping_value(token_id);
+        if !has_mapping {
+            self.api.signal_error(UNKNOWN_TOKEN_ID_ERROR_MESSAGE);
+        }
+
+        let mapping = self.get_mapping_value(token_id);
+        let has_value = self.has_attr_to_nonce_mapping::<T>(mapping, attr);
+        if !has_value {
+            self.api
+                .signal_error(VALUE_NOT_PREVIOUSLY_SET_ERROR_MESSAGE);
+        }
+
+        self.get_attributes_to_nonce_mapping(mapping, attr)
+    }
+
     fn has_mapping_value<M: ManagedTypeApi>(&self, token_id: &TokenIdentifier<M>) -> bool {
         !self.is_empty_mapping_value(token_id)
     }
 
     fn has_token_attributes_value(&self, mapping: u8, token_nonce: u64) -> bool {
         !self.is_empty_token_attributes_value(mapping, token_nonce)
+    }
+
+    fn has_attr_to_nonce_mapping<T: TopEncode + TopDecode + NestedEncode + NestedDecode>(
+        &self,
+        mapping: u8,
+        attr: &T,
+    ) -> bool {
+        !self.is_empty_attributes_to_nonce_mapping(mapping, attr)
     }
 
     fn build_key_token_id_counter(&self) -> StorageKey<SA> {
@@ -172,6 +226,18 @@ where
         key.append_bytes(ATTR_SUFFIX);
         key.append_item(&mapping);
         key.append_item(&token_nonce);
+        key
+    }
+
+    fn build_key_attr_to_nonce_mapping<T: TopEncode + TopDecode + NestedEncode + NestedDecode>(
+        &self,
+        mapping: u8,
+        attr: &T,
+    ) -> StorageKey<SA> {
+        let mut key = self.base_key.clone();
+        key.append_bytes(NONCE_SUFFIX);
+        key.append_item(&mapping);
+        key.append_item(attr);
         key
     }
 
@@ -199,7 +265,55 @@ where
         storage_get_len(self.api.clone(), &self.build_key_token_id_mapping(token_id)) == 0
     }
 
-    fn get_token_attributes_value<T: TopEncode + TopDecode>(
+    fn get_attributes_to_nonce_mapping<T: TopEncode + TopDecode + NestedEncode + NestedDecode>(
+        &self,
+        mapping: u8,
+        attr: &T,
+    ) -> u64 {
+        storage_get(
+            self.api.clone(),
+            &self.build_key_attr_to_nonce_mapping(mapping, attr),
+        )
+    }
+
+    fn set_attributes_to_nonce_mapping<T: TopEncode + TopDecode + NestedEncode + NestedDecode>(
+        &self,
+        mapping: u8,
+        attr: &T,
+        token_nonce: u64,
+    ) {
+        storage_set(
+            self.api.clone(),
+            &self.build_key_attr_to_nonce_mapping(mapping, attr),
+            &token_nonce,
+        );
+    }
+
+    fn is_empty_attributes_to_nonce_mapping<
+        T: TopEncode + TopDecode + NestedEncode + NestedDecode,
+    >(
+        &self,
+        mapping: u8,
+        attr: &T,
+    ) -> bool {
+        storage_get_len(
+            self.api.clone(),
+            &self.build_key_attr_to_nonce_mapping(mapping, attr),
+        ) == 0
+    }
+
+    fn clear_attributes_to_nonce_mapping<T: TopEncode + TopDecode + NestedEncode + NestedDecode>(
+        &self,
+        mapping: u8,
+        attr: &T,
+    ) {
+        storage_clear(
+            self.api.clone(),
+            &self.build_key_attr_to_nonce_mapping(mapping, attr),
+        );
+    }
+
+    fn get_token_attributes_value<T: TopEncode + TopDecode + NestedEncode + NestedDecode>(
         &self,
         mapping: u8,
         token_nonce: u64,
@@ -210,7 +324,7 @@ where
         )
     }
 
-    fn set_token_attributes_value<T: TopEncode + TopDecode>(
+    fn set_token_attributes_value<T: TopEncode + TopDecode + NestedEncode + NestedDecode>(
         &self,
         mapping: u8,
         token_nonce: u64,


### PR DESCRIPTION
This PR extends the functionality of token attributes mapper by adding the functions needed to query the nonce of an already created token by its attributes. It should be used as a cache as following: instead of creating the same token (meaning a token with the same attributes as a  previously created one), one can just query for existing nonce by attributes and use AddQuantity instead of Create, thus decreasing the number of nonces a token may have.