### PR TITLE
Add span information to error messages

### DIFF
--- a/elrond-wasm-derive/src/preprocessing/substitution_algorithm.rs
+++ b/elrond-wasm-derive/src/preprocessing/substitution_algorithm.rs
@@ -17,7 +17,12 @@ pub(super) fn perform_substitutions(
             continue;
         }
         if let Some((sub_length, sub)) = substitutions.check_subsequence(tt_iter.clone()) {
-            result.extend(sub.clone().into_iter());
+            let first_token_span = tt_iter.clone().next().unwrap().span();
+            let final_sub = sub.clone().into_iter().map(|mut tt| {
+                tt.set_span(first_token_span);
+                tt
+            });
+            result.extend(final_sub);
             to_skip = sub_length;
             continue;
         }


### PR DESCRIPTION
Add span information to the substitutions made. This means that error messages now show the exact line where the problem occurs. An example error is presented below, with before & after:
**Before:**
```
error[E0107]: this struct takes 2 generic arguments but 3 generic arguments were supplied
  --> contracts/examples/egld-esdt-swap/src/swap.rs:11:1
   |
11 | #[elrond_wasm::contract]
   | ^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | expected 2 generic arguments
   | help: remove this generic argument
   |
note: struct defined here, with 2 generic parameters: `SA`, `T`
  --> /home/claudiu/code/elrond-wasm-rs/elrond-wasm/src/storage/mappers/single_value_mapper.rs:12:12
   |
12 | pub struct SingleValueMapper<SA, T>
   |            ^^^^^^^^^^^^^^^^^ --  -
   = note: this error originates in the attribute macro `elrond_wasm::contract` (in Nightly builds, run with -Z macro-backtrace for more info)
```

**After:**
```
error[E0107]: this struct takes 2 generic arguments but 3 generic arguments were supplied
   --> contracts/examples/egld-esdt-swap/src/swap.rs:215:40
    |
215 |     fn wrapped_egld_token_id(&self) -> SingleValueMapper<BigUint, TokenIdentifier>;
    |                                        ^^^^^^^^^^^^^^^^^          --------------- help: remove this generic argument
    |                                        |
    |                                        expected 2 generic arguments
    |
note: struct defined here, with 2 generic parameters: `SA`, `T`
   --> /home/claudiu/code/elrond-wasm-rs/elrond-wasm/src/storage/mappers/single_value_mapper.rs:12:12
    |
12  | pub struct SingleValueMapper<SA, T>
    |            ^^^^^^^^^^^^^^^^^ --  -
```