### PR TITLE
add `unwrap_or_signal_error()` method for `SCResult`

### DIFF
--- a/contracts/feature-tests/basic-features/mandos/sc_result.scen.json
+++ b/contracts/feature-tests/basic-features/mandos/sc_result.scen.json
@@ -298,6 +298,54 @@
                 "gas": "*",
                 "refund": "*"
             }
+        },
+        {
+            "step": "scCall",
+            "txId": "result_echo_3 - option is none",
+            "tx": {
+                "from": "address:an_account",
+                "to": "sc:basic-features",
+                "value": "0",
+                "function": "result_echo_3",
+                "arguments": [
+                    "0"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "4",
+                "message": "str:option argument is none",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "result_echo_3 - ok",
+            "tx": {
+                "from": "address:an_account",
+                "to": "sc:basic-features",
+                "value": "0",
+                "function": "result_echo_3",
+                "arguments": [
+                    "1|nested:str:test string echo 3"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [
+                    "str:test string echo 3"
+                ],
+                "status": "0",
+                "message": "",
+                "logs": [],
+                "gas": "*",
+                "refund": "*"
+            }
         }
     ]
 }

--- a/contracts/feature-tests/basic-features/src/macro_features.rs
+++ b/contracts/feature-tests/basic-features/src/macro_features.rs
@@ -70,4 +70,11 @@ pub trait Macros {
         let unwrapped = arg.ok_or("option argument is none")?;
         Ok(unwrapped)
     }
+
+    #[endpoint]
+    fn result_echo_3(&self, arg: Option<String>) -> String {
+        let result: SCResult<String> = arg.ok_or("option argument is none").into();
+        let unwrapped = result.unwrap_or_signal_error();
+        unwrapped
+    }
 }

--- a/contracts/feature-tests/basic-features/src/macro_features.rs
+++ b/contracts/feature-tests/basic-features/src/macro_features.rs
@@ -74,7 +74,6 @@ pub trait Macros {
     #[endpoint]
     fn result_echo_3(&self, arg: Option<String>) -> String {
         let result: SCResult<String> = arg.ok_or("option argument is none").into();
-        let unwrapped = result.unwrap_or_signal_error();
-        unwrapped
+        result.unwrap_or_signal_error()
     }
 }

--- a/elrond-wasm-derive/src/preprocessing/substitution_list.rs
+++ b/elrond-wasm-derive/src/preprocessing/substitution_list.rs
@@ -88,6 +88,10 @@ fn add_special_methods(substitutions: &mut SubstitutionsMap) {
         quote!(ManagedVec::from),
         quote!(self.types().managed_vec_from),
     );
+    substitutions.add_substitution(
+        quote!(.unwrap_or_signal_error()),
+        quote!(.unwrap_or_signal_error(self.raw_vm_api())),
+    );
 }
 
 fn add_storage_mapper_single_generic_arg(

--- a/elrond-wasm/src/types/io/sc_error.rs
+++ b/elrond-wasm/src/types/io/sc_error.rs
@@ -3,5 +3,5 @@ use crate::api::EndpointFinishApi;
 /// Any type that implements this trait can be used to signal errors
 /// when returning from a SC endpoint.
 pub trait SCError {
-    fn finish_err<FA: EndpointFinishApi>(&self, api: FA);
+    fn finish_err<FA: EndpointFinishApi>(&self, api: FA) -> !;
 }

--- a/elrond-wasm/src/types/io/sc_error_managed.rs
+++ b/elrond-wasm/src/types/io/sc_error_managed.rs
@@ -20,7 +20,7 @@ impl<M> SCError for ManagedSCError<M>
 where
     M: ManagedTypeApi + ErrorApi,
 {
-    fn finish_err<FA: EndpointFinishApi>(&self, api: FA) {
+    fn finish_err<FA: EndpointFinishApi>(&self, api: FA) -> ! {
         api.signal_error_from_buffer(self.buffer.get_raw_handle())
     }
 }

--- a/elrond-wasm/src/types/io/sc_error_static.rs
+++ b/elrond-wasm/src/types/io/sc_error_static.rs
@@ -12,7 +12,7 @@ use super::SCError;
 pub struct StaticSCError(&'static [u8]);
 
 impl SCError for StaticSCError {
-    fn finish_err<FA: EndpointFinishApi>(&self, api: FA) {
+    fn finish_err<FA: EndpointFinishApi>(&self, api: FA) -> ! {
         api.signal_error(self.0)
     }
 }

--- a/elrond-wasm/src/types/io/sc_result.rs
+++ b/elrond-wasm/src/types/io/sc_result.rs
@@ -45,6 +45,18 @@ impl<T, E> SCResult<T, E> {
         }
     }
 
+    #[inline]
+    /// Returns the contained Some value or signals the error and exits.
+    pub fn unwrap_or_signal_error<FA: EndpointFinishApi>(self, api: FA) -> T
+    where
+        E: SCError,
+    {
+        match self {
+            SCResult::Ok(t) => t,
+            SCResult::Err(e) => e.finish_err(api),
+        }
+    }
+
     /// Used to convert from a regular Rust result.
     /// Any error type is accepted as long as it can be converted to a SCError
     /// (`Vec<u8>`, `&[u8]`, `BoxedBytes`, `String`, `&str` are covered).

--- a/elrond-wasm/src/types/io/sc_result.rs
+++ b/elrond-wasm/src/types/io/sc_result.rs
@@ -46,7 +46,7 @@ impl<T, E> SCResult<T, E> {
     }
 
     #[inline]
-    /// Returns the contained Some value or signals the error and exits.
+    /// Returns the contained Ok value or signals the error and exits.
     pub fn unwrap_or_signal_error<FA: EndpointFinishApi>(self, api: FA) -> T
     where
         E: SCError,


### PR DESCRIPTION
Add `unwrap_or_signal_error()` in order to signal errors and exit immediately, without returning a `SCResult`.
Makes use of the macro substitution to avoid specifying the api.
Usage:
`let unwrapped = result.unwrap_or_signal_error();`