### PR TITLE
GitHub action for contract sizes

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -58,13 +58,16 @@ jobs:
         uses: chuhlomin/render-template@v1.2
         with:
           template: report.md
+          vars: |
+            base: ${{github.event.pull_request.base.sha}}
+            head: ${{github.event.pull_request.head.sha}}
       - name: Find sizes report comment
         uses: peter-evans/find-comment@v1
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Build output
+          body-includes: Contract file size comparison
       - name: Create or update sizes report comment
         uses: peter-evans/create-or-update-comment@v1
         with:

--- a/tools/size-report/size_report.py
+++ b/tools/size-report/size_report.py
@@ -69,7 +69,7 @@ def generate_size_report(before: Sizes, after: Sizes) -> str:
             "baz": 5, \
         }
     >>> print(generate_size_report(before, after))
-    Contract file size comparison (bytes):
+    Contract file size comparison (bytes) - from {{ .base }} to {{ .head }}
     Contract | Previous | Current | Difference | Percentage
     --:|--:|--:|--:|--:|
     bar | 50 | 30 | -20 | -40.00% &#x1F7E2;
@@ -80,7 +80,7 @@ def generate_size_report(before: Sizes, after: Sizes) -> str:
     """
     with io.StringIO() as output:
         names = sorted(set(before).union(after))
-        print("Contract file size comparison (bytes):")
+        print("Contract file size comparison (bytes) - from {{ .base }} to {{ .head }}")
         print("Contract | Previous | Current | Difference | Percentage", file=output)
         print("--:|--:|--:|--:|--:|", file=output, end='')
         for name in names:


### PR DESCRIPTION
- add `sizes.txt` as an artifact in github actions which contains the output of the `./sizes.sh` script
- add `size_report.py` which creates a table comparing the file sizes
- automatically comment the difference in sizes between `master` and the branch the PR in the github action `sizes_report`