### PR TITLE
Size report fix - check that the event is a pull request

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -42,6 +42,7 @@ jobs:
           path: sizes.txt
       - name: Download base report
         uses: dawidd6/action-download-artifact@v2
+        if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
           workflow: actions.yml
@@ -50,26 +51,30 @@ jobs:
           path: base-sizes
       - name: Generate report
         id: sizes-report
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           source .github/workflows/env
           python tools/size-report/size_report.py base-sizes/sizes.txt sizes.txt --allow-missing > report.md
       - name: Render report
         id: template
         uses: chuhlomin/render-template@v1.2
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           template: report.md
           vars: |
             base: ${{github.event.pull_request.base.sha}}
             head: ${{github.event.pull_request.head.sha}}
       - name: Find sizes report comment
-        uses: peter-evans/find-comment@v1
         id: fc
+        uses: peter-evans/find-comment@v1
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Contract file size comparison
       - name: Create or update sizes report comment
         uses: peter-evans/create-or-update-comment@v1
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
The size report generation works fine when inside a pull request - but fails when there's a push to the master branch.
Add a check for certain steps so that they are only run when inside of a pull request.
Example of a build that fails: https://github.com/ElrondNetwork/elrond-wasm-rs/runs/4007112255?check_suite_focus=true