### PR TITLE
meta regenerate wasm srcs

### DIFF
--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -2,13 +2,11 @@
 
 # builds all wasm targets
 
-ROOT=$(pwd)
-
+set -e
 SMART_CONTRACT_JSONS=$(find . -name "elrond.json")
 for smart_contract_json in $SMART_CONTRACT_JSONS
 do
-    cd $ROOT
     smart_contract_folder=$(dirname $smart_contract_json)
-    cd $smart_contract_folder/meta
-    cargo run build
+    echo ""
+    (set -x; erdpy --verbose contract build $smart_contract_folder)
 done

--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -2,11 +2,13 @@
 
 # builds all wasm targets
 
-set -e
+ROOT=$(pwd)
+
 SMART_CONTRACT_JSONS=$(find . -name "elrond.json")
 for smart_contract_json in $SMART_CONTRACT_JSONS
 do
+    cd $ROOT
     smart_contract_folder=$(dirname $smart_contract_json)
-    echo ""
-    (set -x; erdpy --verbose contract build $smart_contract_folder)
+    cd $smart_contract_folder/meta
+    cargo run build
 done

--- a/contracts/benchmarks/mappers/linked-list-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/linked-list-repeat/wasm/src/lib.rs
@@ -13,6 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    linked_list_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn add() {
     linked_list_repeat::endpoints::add(elrond_wasm_node::arwen_api());
 }
@@ -23,16 +28,11 @@ pub fn count() {
 }
 
 #[no_mangle]
-pub fn remove() {
-    linked_list_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn getBenchmark() {
     linked_list_repeat::endpoints::getBenchmark(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    linked_list_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn remove() {
+    linked_list_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
 }

--- a/contracts/benchmarks/mappers/map-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/map-repeat/wasm/src/lib.rs
@@ -13,6 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    map_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn add() {
     map_repeat::endpoints::add(elrond_wasm_node::arwen_api());
 }
@@ -25,9 +30,4 @@ pub fn count() {
 #[no_mangle]
 pub fn remove() {
     map_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    map_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/benchmarks/mappers/queue-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/queue-repeat/wasm/src/lib.rs
@@ -13,6 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    queue_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn add() {
     queue_repeat::endpoints::add(elrond_wasm_node::arwen_api());
 }
@@ -23,16 +28,11 @@ pub fn count() {
 }
 
 #[no_mangle]
-pub fn remove() {
-    queue_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn getBenchmark() {
     queue_repeat::endpoints::getBenchmark(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    queue_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn remove() {
+    queue_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
 }

--- a/contracts/benchmarks/mappers/set-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/set-repeat/wasm/src/lib.rs
@@ -13,6 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    set_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn add() {
     set_repeat::endpoints::add(elrond_wasm_node::arwen_api());
 }
@@ -23,16 +28,11 @@ pub fn count() {
 }
 
 #[no_mangle]
-pub fn remove() {
-    set_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn getBenchmark() {
     set_repeat::endpoints::getBenchmark(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    set_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn remove() {
+    set_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
 }

--- a/contracts/benchmarks/mappers/single-value-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/single-value-repeat/wasm/src/lib.rs
@@ -13,6 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    single_value_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn add() {
     single_value_repeat::endpoints::add(elrond_wasm_node::arwen_api());
 }
@@ -25,9 +30,4 @@ pub fn count() {
 #[no_mangle]
 pub fn remove() {
     single_value_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    single_value_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/benchmarks/mappers/vec-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/vec-repeat/wasm/src/lib.rs
@@ -13,6 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    vec_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn add() {
     vec_repeat::endpoints::add(elrond_wasm_node::arwen_api());
 }
@@ -23,16 +28,11 @@ pub fn count() {
 }
 
 #[no_mangle]
-pub fn remove() {
-    vec_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn getBenchmark() {
     vec_repeat::endpoints::getBenchmark(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    vec_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn remove() {
+    vec_repeat::endpoints::remove(elrond_wasm_node::arwen_api());
 }

--- a/contracts/benchmarks/send-tx-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/send-tx-repeat/wasm/src/lib.rs
@@ -13,11 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn repeat() {
-    send_tx_repeat::endpoints::repeat(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    send_tx_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    send_tx_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn repeat() {
+    send_tx_repeat::endpoints::repeat(elrond_wasm_node::arwen_api());
 }

--- a/contracts/benchmarks/str-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/str-repeat/wasm/src/lib.rs
@@ -13,13 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn repeat() {
-    str_repeat::endpoints::repeat(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getByteArrayLength() {
-    str_repeat::endpoints::getByteArrayLength(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    str_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -28,6 +23,11 @@ pub fn getByteArray() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    str_repeat::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn getByteArrayLength() {
+    str_repeat::endpoints::getByteArrayLength(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn repeat() {
+    str_repeat::endpoints::repeat(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/adder/wasm/src/lib.rs
+++ b/contracts/examples/adder/wasm/src/lib.rs
@@ -13,8 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn getSum() {
-    adder::endpoints::getSum(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    adder::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -23,6 +23,6 @@ pub fn add() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    adder::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn getSum() {
+    adder::endpoints::getSum(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/bonding-curve-contract/wasm/src/lib.rs
+++ b/contracts/examples/bonding-curve-contract/wasm/src/lib.rs
@@ -13,13 +13,28 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn sellToken() {
-    bonding_curve_contract::endpoints::sellToken(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    bonding_curve_contract::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
 pub fn buyToken() {
     bonding_curve_contract::endpoints::buyToken(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn claim() {
+    bonding_curve_contract::endpoints::claim(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn deposit() {
+    bonding_curve_contract::endpoints::deposit(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getTokenAvailability() {
+    bonding_curve_contract::endpoints::getTokenAvailability(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -33,8 +48,13 @@ pub fn get_sell_price() {
 }
 
 #[no_mangle]
-pub fn getTokenAvailability() {
-    bonding_curve_contract::endpoints::getTokenAvailability(elrond_wasm_node::arwen_api());
+pub fn sellToken() {
+    bonding_curve_contract::endpoints::sellToken(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn setBondingCurve() {
+    bonding_curve_contract::endpoints::setBondingCurve(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -45,24 +65,4 @@ pub fn setLocalRoles() {
 #[no_mangle]
 pub fn unsetLocalRoles() {
     bonding_curve_contract::endpoints::unsetLocalRoles(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn setBondingCurve() {
-    bonding_curve_contract::endpoints::setBondingCurve(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn deposit() {
-    bonding_curve_contract::endpoints::deposit(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn claim() {
-    bonding_curve_contract::endpoints::claim(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    bonding_curve_contract::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/crowdfunding-erc20/wasm/src/lib.rs
+++ b/contracts/examples/crowdfunding-erc20/wasm/src/lib.rs
@@ -13,13 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn fund() {
-    crowdfunding_erc20::endpoints::fund(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn status() {
-    crowdfunding_erc20::endpoints::status(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    crowdfunding_erc20::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -28,8 +23,8 @@ pub fn claim() {
 }
 
 #[no_mangle]
-pub fn get_target() {
-    crowdfunding_erc20::endpoints::get_target(elrond_wasm_node::arwen_api());
+pub fn fund() {
+    crowdfunding_erc20::endpoints::fund(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -48,11 +43,16 @@ pub fn get_erc20_contract_address() {
 }
 
 #[no_mangle]
+pub fn get_target() {
+    crowdfunding_erc20::endpoints::get_target(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn get_total_balance() {
     crowdfunding_erc20::endpoints::get_total_balance(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    crowdfunding_erc20::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn status() {
+    crowdfunding_erc20::endpoints::status(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/crowdfunding-esdt/wasm/src/lib.rs
+++ b/contracts/examples/crowdfunding-esdt/wasm/src/lib.rs
@@ -13,18 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn fund() {
-    crowdfunding_esdt::endpoints::fund(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn status() {
-    crowdfunding_esdt::endpoints::status(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getCurrentFunds() {
-    crowdfunding_esdt::endpoints::getCurrentFunds(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    crowdfunding_esdt::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -33,8 +23,18 @@ pub fn claim() {
 }
 
 #[no_mangle]
-pub fn getTarget() {
-    crowdfunding_esdt::endpoints::getTarget(elrond_wasm_node::arwen_api());
+pub fn fund() {
+    crowdfunding_esdt::endpoints::fund(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getCrowdfundingTokenIdentifier() {
+    crowdfunding_esdt::endpoints::getCrowdfundingTokenIdentifier(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getCurrentFunds() {
+    crowdfunding_esdt::endpoints::getCurrentFunds(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -48,11 +48,11 @@ pub fn getDeposit() {
 }
 
 #[no_mangle]
-pub fn getCrowdfundingTokenIdentifier() {
-    crowdfunding_esdt::endpoints::getCrowdfundingTokenIdentifier(elrond_wasm_node::arwen_api());
+pub fn getTarget() {
+    crowdfunding_esdt::endpoints::getTarget(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    crowdfunding_esdt::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn status() {
+    crowdfunding_esdt::endpoints::status(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/crypto-bubbles/wasm/src/lib.rs
+++ b/contracts/examples/crypto-bubbles/wasm/src/lib.rs
@@ -13,28 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn topUp() {
-    crypto_bubbles::endpoints::topUp(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn withdraw() {
-    crypto_bubbles::endpoints::withdraw(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn joinGame() {
-    crypto_bubbles::endpoints::joinGame(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn rewardWinner() {
-    crypto_bubbles::endpoints::rewardWinner(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn rewardAndSendToWallet() {
-    crypto_bubbles::endpoints::rewardAndSendToWallet(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    crypto_bubbles::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -43,6 +23,26 @@ pub fn balanceOf() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    crypto_bubbles::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn joinGame() {
+    crypto_bubbles::endpoints::joinGame(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rewardAndSendToWallet() {
+    crypto_bubbles::endpoints::rewardAndSendToWallet(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rewardWinner() {
+    crypto_bubbles::endpoints::rewardWinner(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn topUp() {
+    crypto_bubbles::endpoints::topUp(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn withdraw() {
+    crypto_bubbles::endpoints::withdraw(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/crypto-kitties/kitty-auction/wasm/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/wasm/src/lib.rs
@@ -13,28 +13,18 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn setKittyOwnershipContractAddress() {
-    kitty_auction::endpoints::setKittyOwnershipContractAddress(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    kitty_auction::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bid() {
+    kitty_auction::endpoints::bid(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
 pub fn createAndAuctionGenZeroKitty() {
     kitty_auction::endpoints::createAndAuctionGenZeroKitty(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn isUpForAuction() {
-    kitty_auction::endpoints::isUpForAuction(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getAuctionStatus() {
-    kitty_auction::endpoints::getAuctionStatus(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getCurrentWinningBid() {
-    kitty_auction::endpoints::getCurrentWinningBid(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -48,16 +38,26 @@ pub fn createSiringAuction() {
 }
 
 #[no_mangle]
-pub fn bid() {
-    kitty_auction::endpoints::bid(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn endAuction() {
     kitty_auction::endpoints::endAuction(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    kitty_auction::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn getAuctionStatus() {
+    kitty_auction::endpoints::getAuctionStatus(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getCurrentWinningBid() {
+    kitty_auction::endpoints::getCurrentWinningBid(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn isUpForAuction() {
+    kitty_auction::endpoints::isUpForAuction(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn setKittyOwnershipContractAddress() {
+    kitty_auction::endpoints::setKittyOwnershipContractAddress(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/src/lib.rs
@@ -13,11 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn generateKittyGenes() {
-    kitty_genetic_alg::endpoints::generateKittyGenes(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    kitty_genetic_alg::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    kitty_genetic_alg::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn generateKittyGenes() {
+    kitty_genetic_alg::endpoints::generateKittyGenes(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/crypto-kitties/kitty-ownership/wasm/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/wasm/src/lib.rs
@@ -13,53 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn setGeneScienceContractAddress() {
-    kitty_ownership::endpoints::setGeneScienceContractAddress(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn setKittyAuctionContractAddress() {
-    kitty_ownership::endpoints::setKittyAuctionContractAddress(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn claim() {
-    kitty_ownership::endpoints::claim(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn totalSupply() {
-    kitty_ownership::endpoints::totalSupply(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn balanceOf() {
-    kitty_ownership::endpoints::balanceOf(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn ownerOf() {
-    kitty_ownership::endpoints::ownerOf(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn approve() {
-    kitty_ownership::endpoints::approve(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn transfer() {
-    kitty_ownership::endpoints::transfer(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn transfer_from() {
-    kitty_ownership::endpoints::transfer_from(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn tokensOfOwner() {
-    kitty_ownership::endpoints::tokensOfOwner(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    kitty_ownership::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -68,8 +23,43 @@ pub fn allowAuctioning() {
 }
 
 #[no_mangle]
+pub fn approve() {
+    kitty_ownership::endpoints::approve(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn approveSiring() {
+    kitty_ownership::endpoints::approveSiring(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn approveSiringAndReturnKitty() {
     kitty_ownership::endpoints::approveSiringAndReturnKitty(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn balanceOf() {
+    kitty_ownership::endpoints::balanceOf(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn birthFee() {
+    kitty_ownership::endpoints::birthFee(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn breedWith() {
+    kitty_ownership::endpoints::breedWith(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn canBreedWith() {
+    kitty_ownership::endpoints::canBreedWith(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn claim() {
+    kitty_ownership::endpoints::claim(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -83,8 +73,8 @@ pub fn getKittyById() {
 }
 
 #[no_mangle]
-pub fn isReadyToBreed() {
-    kitty_ownership::endpoints::isReadyToBreed(elrond_wasm_node::arwen_api());
+pub fn giveBirth() {
+    kitty_ownership::endpoints::giveBirth(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -93,31 +83,41 @@ pub fn isPregnant() {
 }
 
 #[no_mangle]
-pub fn canBreedWith() {
-    kitty_ownership::endpoints::canBreedWith(elrond_wasm_node::arwen_api());
+pub fn isReadyToBreed() {
+    kitty_ownership::endpoints::isReadyToBreed(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn approveSiring() {
-    kitty_ownership::endpoints::approveSiring(elrond_wasm_node::arwen_api());
+pub fn ownerOf() {
+    kitty_ownership::endpoints::ownerOf(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn breedWith() {
-    kitty_ownership::endpoints::breedWith(elrond_wasm_node::arwen_api());
+pub fn setGeneScienceContractAddress() {
+    kitty_ownership::endpoints::setGeneScienceContractAddress(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn giveBirth() {
-    kitty_ownership::endpoints::giveBirth(elrond_wasm_node::arwen_api());
+pub fn setKittyAuctionContractAddress() {
+    kitty_ownership::endpoints::setKittyAuctionContractAddress(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn birthFee() {
-    kitty_ownership::endpoints::birthFee(elrond_wasm_node::arwen_api());
+pub fn tokensOfOwner() {
+    kitty_ownership::endpoints::tokensOfOwner(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    kitty_ownership::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn totalSupply() {
+    kitty_ownership::endpoints::totalSupply(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transfer() {
+    kitty_ownership::endpoints::transfer(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transfer_from() {
+    kitty_ownership::endpoints::transfer_from(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/egld-esdt-swap/wasm/src/lib.rs
+++ b/contracts/examples/egld-esdt-swap/wasm/src/lib.rs
@@ -13,6 +13,26 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    egld_esdt_swap::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getLockedEgldBalance() {
+    egld_esdt_swap::endpoints::getLockedEgldBalance(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getUnusedWrappedEgld() {
+    egld_esdt_swap::endpoints::getUnusedWrappedEgld(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getWrappedEgldTokenIdentifier() {
+    egld_esdt_swap::endpoints::getWrappedEgldTokenIdentifier(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn issueWrappedEgld() {
     egld_esdt_swap::endpoints::issueWrappedEgld(elrond_wasm_node::arwen_api());
 }
@@ -23,31 +43,11 @@ pub fn mintWrappedEgld() {
 }
 
 #[no_mangle]
-pub fn wrapEgld() {
-    egld_esdt_swap::endpoints::wrapEgld(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn unwrapEgld() {
     egld_esdt_swap::endpoints::unwrapEgld(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn getLockedEgldBalance() {
-    egld_esdt_swap::endpoints::getLockedEgldBalance(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getWrappedEgldTokenIdentifier() {
-    egld_esdt_swap::endpoints::getWrappedEgldTokenIdentifier(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getUnusedWrappedEgld() {
-    egld_esdt_swap::endpoints::getUnusedWrappedEgld(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    egld_esdt_swap::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn wrapEgld() {
+    egld_esdt_swap::endpoints::wrapEgld(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/erc1155-marketplace/wasm/src/lib.rs
+++ b/contracts/examples/erc1155-marketplace/wasm/src/lib.rs
@@ -13,8 +13,48 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn onERC1155Received() {
-    erc1155_marketplace::endpoints::onERC1155Received(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    erc1155_marketplace::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bid() {
+    erc1155_marketplace::endpoints::bid(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn claim() {
+    erc1155_marketplace::endpoints::claim(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn endAuction() {
+    erc1155_marketplace::endpoints::endAuction(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getAuctionStatus() {
+    erc1155_marketplace::endpoints::getAuctionStatus(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getCurrentWinner() {
+    erc1155_marketplace::endpoints::getCurrentWinner(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getCurrentWinningBid() {
+    erc1155_marketplace::endpoints::getCurrentWinningBid(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getPercentageCut() {
+    erc1155_marketplace::endpoints::getPercentageCut(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn isUpForAuction() {
+    erc1155_marketplace::endpoints::isUpForAuction(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -23,8 +63,8 @@ pub fn onERC1155BatchReceived() {
 }
 
 #[no_mangle]
-pub fn claim() {
-    erc1155_marketplace::endpoints::claim(elrond_wasm_node::arwen_api());
+pub fn onERC1155Received() {
+    erc1155_marketplace::endpoints::onERC1155Received(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -35,44 +75,4 @@ pub fn setCutPercentage() {
 #[no_mangle]
 pub fn setTokenOwnershipContractAddress() {
     erc1155_marketplace::endpoints::setTokenOwnershipContractAddress(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bid() {
-    erc1155_marketplace::endpoints::bid(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn endAuction() {
-    erc1155_marketplace::endpoints::endAuction(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn isUpForAuction() {
-    erc1155_marketplace::endpoints::isUpForAuction(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getAuctionStatus() {
-    erc1155_marketplace::endpoints::getAuctionStatus(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getCurrentWinningBid() {
-    erc1155_marketplace::endpoints::getCurrentWinningBid(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getCurrentWinner() {
-    erc1155_marketplace::endpoints::getCurrentWinner(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getPercentageCut() {
-    erc1155_marketplace::endpoints::getPercentageCut(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    erc1155_marketplace::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/erc1155-user-mock/wasm/src/lib.rs
+++ b/contracts/examples/erc1155-user-mock/wasm/src/lib.rs
@@ -13,8 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn onERC1155Received() {
-    erc1155_user_mock::endpoints::onERC1155Received(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    erc1155_user_mock::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -23,6 +23,6 @@ pub fn onERC1155BatchReceived() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    erc1155_user_mock::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn onERC1155Received() {
+    erc1155_user_mock::endpoints::onERC1155Received(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/erc1155/wasm/src/lib.rs
+++ b/contracts/examples/erc1155/wasm/src/lib.rs
@@ -13,33 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn safeTransferFrom() {
-    erc1155::endpoints::safeTransferFrom(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn safeBatchTransferFrom() {
-    erc1155::endpoints::safeBatchTransferFrom(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn setApprovalForAll() {
-    erc1155::endpoints::setApprovalForAll(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn createToken() {
-    erc1155::endpoints::createToken(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn mint() {
-    erc1155::endpoints::mint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn burn() {
-    erc1155::endpoints::burn(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    erc1155::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -50,6 +25,16 @@ pub fn balanceOf() {
 #[no_mangle]
 pub fn balanceOfBatch() {
     erc1155::endpoints::balanceOfBatch(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn burn() {
+    erc1155::endpoints::burn(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn createToken() {
+    erc1155::endpoints::createToken(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -68,16 +53,31 @@ pub fn getTokenTypeUri() {
 }
 
 #[no_mangle]
-pub fn isFungible() {
-    erc1155::endpoints::isFungible(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn isApprovedForAll() {
     erc1155::endpoints::isApprovedForAll(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    erc1155::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn isFungible() {
+    erc1155::endpoints::isFungible(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mint() {
+    erc1155::endpoints::mint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn safeBatchTransferFrom() {
+    erc1155::endpoints::safeBatchTransferFrom(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn safeTransferFrom() {
+    erc1155::endpoints::safeTransferFrom(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn setApprovalForAll() {
+    erc1155::endpoints::setApprovalForAll(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/erc20/wasm/src/lib.rs
+++ b/contracts/examples/erc20/wasm/src/lib.rs
@@ -13,8 +13,18 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn totalSupply() {
-    erc20::endpoints::totalSupply(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    erc20::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn allowance() {
+    erc20::endpoints::allowance(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn approve() {
+    erc20::endpoints::approve(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -23,8 +33,8 @@ pub fn balanceOf() {
 }
 
 #[no_mangle]
-pub fn allowance() {
-    erc20::endpoints::allowance(elrond_wasm_node::arwen_api());
+pub fn totalSupply() {
+    erc20::endpoints::totalSupply(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -35,14 +45,4 @@ pub fn transfer() {
 #[no_mangle]
 pub fn transferFrom() {
     erc20::endpoints::transferFrom(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn approve() {
-    erc20::endpoints::approve(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    erc20::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/erc721/wasm/src/lib.rs
+++ b/contracts/examples/erc721/wasm/src/lib.rs
@@ -13,38 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn mint() {
-    erc721::endpoints::mint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn approve() {
-    erc721::endpoints::approve(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn revoke() {
-    erc721::endpoints::revoke(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn transfer() {
-    erc721::endpoints::transfer(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn totalMinted() {
-    erc721::endpoints::totalMinted(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn tokenOwner() {
-    erc721::endpoints::tokenOwner(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn tokenCount() {
-    erc721::endpoints::tokenCount(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    erc721::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -53,6 +23,36 @@ pub fn approval() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    erc721::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn approve() {
+    erc721::endpoints::approve(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mint() {
+    erc721::endpoints::mint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn revoke() {
+    erc721::endpoints::revoke(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn tokenCount() {
+    erc721::endpoints::tokenCount(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn tokenOwner() {
+    erc721::endpoints::tokenOwner(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn totalMinted() {
+    erc721::endpoints::totalMinted(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transfer() {
+    erc721::endpoints::transfer(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/factorial/wasm/src/lib.rs
+++ b/contracts/examples/factorial/wasm/src/lib.rs
@@ -13,11 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn factorial() {
-    factorial::endpoints::factorial(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    factorial::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    factorial::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn factorial() {
+    factorial::endpoints::factorial(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/lottery-erc20/wasm/src/lib.rs
+++ b/contracts/examples/lottery-erc20/wasm/src/lib.rs
@@ -13,13 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn start() {
-    lottery_erc20::endpoints::start(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn createLotteryPool() {
-    lottery_erc20::endpoints::createLotteryPool(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    lottery_erc20::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -28,18 +23,13 @@ pub fn buy_ticket() {
 }
 
 #[no_mangle]
+pub fn createLotteryPool() {
+    lottery_erc20::endpoints::createLotteryPool(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn determine_winner() {
     lottery_erc20::endpoints::determine_winner(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn status() {
-    lottery_erc20::endpoints::status(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn lotteryInfo() {
-    lottery_erc20::endpoints::lotteryInfo(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -48,6 +38,16 @@ pub fn erc20ContractManagedAddress() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    lottery_erc20::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn lotteryInfo() {
+    lottery_erc20::endpoints::lotteryInfo(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn start() {
+    lottery_erc20::endpoints::start(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn status() {
+    lottery_erc20::endpoints::status(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/lottery-esdt/wasm/src/lib.rs
+++ b/contracts/examples/lottery-esdt/wasm/src/lib.rs
@@ -13,13 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn start() {
-    lottery_esdt::endpoints::start(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn createLotteryPool() {
-    lottery_esdt::endpoints::createLotteryPool(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    lottery_esdt::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -28,13 +23,13 @@ pub fn buy_ticket() {
 }
 
 #[no_mangle]
-pub fn determine_winner() {
-    lottery_esdt::endpoints::determine_winner(elrond_wasm_node::arwen_api());
+pub fn createLotteryPool() {
+    lottery_esdt::endpoints::createLotteryPool(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn status() {
-    lottery_esdt::endpoints::status(elrond_wasm_node::arwen_api());
+pub fn determine_winner() {
+    lottery_esdt::endpoints::determine_winner(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -43,6 +38,11 @@ pub fn getLotteryInfo() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    lottery_esdt::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn start() {
+    lottery_esdt::endpoints::start(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn status() {
+    lottery_esdt::endpoints::status(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/nft-minter/wasm/src/lib.rs
+++ b/contracts/examples/nft-minter/wasm/src/lib.rs
@@ -13,8 +13,23 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    nft_minter::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn buyNft() {
+    nft_minter::endpoints::buyNft(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn createNft() {
     nft_minter::endpoints::createNft(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getNftPrice() {
+    nft_minter::endpoints::getNftPrice(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -25,19 +40,4 @@ pub fn issueToken() {
 #[no_mangle]
 pub fn setLocalRoles() {
     nft_minter::endpoints::setLocalRoles(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn buyNft() {
-    nft_minter::endpoints::buyNft(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getNftPrice() {
-    nft_minter::endpoints::getNftPrice(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    nft_minter::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/nft-storage-prepay/wasm/src/lib.rs
+++ b/contracts/examples/nft-storage-prepay/wasm/src/lib.rs
@@ -13,13 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn setCostPerByte() {
-    nft_storage_prepay::endpoints::setCostPerByte(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn reserveFunds() {
-    nft_storage_prepay::endpoints::reserveFunds(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    nft_storage_prepay::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -33,18 +28,8 @@ pub fn depositPaymentForStorage() {
 }
 
 #[no_mangle]
-pub fn withdraw() {
-    nft_storage_prepay::endpoints::withdraw(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn getCostForSize() {
     nft_storage_prepay::endpoints::getCostForSize(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getDepositAmount() {
-    nft_storage_prepay::endpoints::getDepositAmount(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -53,6 +38,21 @@ pub fn getCostPerByte() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    nft_storage_prepay::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn getDepositAmount() {
+    nft_storage_prepay::endpoints::getDepositAmount(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn reserveFunds() {
+    nft_storage_prepay::endpoints::reserveFunds(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn setCostPerByte() {
+    nft_storage_prepay::endpoints::setCostPerByte(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn withdraw() {
+    nft_storage_prepay::endpoints::withdraw(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/order-book/factory/wasm/src/lib.rs
+++ b/contracts/examples/order-book/factory/wasm/src/lib.rs
@@ -13,6 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    order_book_factory::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn createPair() {
     order_book_factory::endpoints::createPair(elrond_wasm_node::arwen_api());
 }
@@ -20,9 +25,4 @@ pub fn createPair() {
 #[no_mangle]
 pub fn getPair() {
     order_book_factory::endpoints::getPair(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    order_book_factory::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/order-book/pair/wasm/src/lib.rs
+++ b/contracts/examples/order-book/pair/wasm/src/lib.rs
@@ -13,6 +13,21 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    order_book_pair::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn cancelAllOrders() {
+    order_book_pair::endpoints::cancelAllOrders(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn cancelOrders() {
+    order_book_pair::endpoints::cancelOrders(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn createBuyOrder() {
     order_book_pair::endpoints::createBuyOrder(elrond_wasm_node::arwen_api());
 }
@@ -23,23 +38,38 @@ pub fn createSellOrder() {
 }
 
 #[no_mangle]
-pub fn matchOrders() {
-    order_book_pair::endpoints::matchOrders(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn cancelOrders() {
-    order_book_pair::endpoints::cancelOrders(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn cancelAllOrders() {
-    order_book_pair::endpoints::cancelAllOrders(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn freeOrders() {
     order_book_pair::endpoints::freeOrders(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getAddressOrderIds() {
+    order_book_pair::endpoints::getAddressOrderIds(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getFirstTokenId() {
+    order_book_pair::endpoints::getFirstTokenId(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getOrderById() {
+    order_book_pair::endpoints::getOrderById(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getOrderIdCounter() {
+    order_book_pair::endpoints::getOrderIdCounter(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getSecondTokenId() {
+    order_book_pair::endpoints::getSecondTokenId(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn matchOrders() {
+    order_book_pair::endpoints::matchOrders(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -50,34 +80,4 @@ pub fn startGlobalOperation() {
 #[no_mangle]
 pub fn stopGlobalOperation() {
     order_book_pair::endpoints::stopGlobalOperation(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getAddressOrderIds() {
-    order_book_pair::endpoints::getAddressOrderIds(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getOrderIdCounter() {
-    order_book_pair::endpoints::getOrderIdCounter(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getOrderById() {
-    order_book_pair::endpoints::getOrderById(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getFirstTokenId() {
-    order_book_pair::endpoints::getFirstTokenId(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getSecondTokenId() {
-    order_book_pair::endpoints::getSecondTokenId(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    order_book_pair::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/examples/ping-pong-egld/wasm/src/lib.rs
+++ b/contracts/examples/ping-pong-egld/wasm/src/lib.rs
@@ -13,6 +13,41 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    ping_pong_egld::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getActivationTimestamp() {
+    ping_pong_egld::endpoints::getActivationTimestamp(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getDeadline() {
+    ping_pong_egld::endpoints::getDeadline(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getMaxFunds() {
+    ping_pong_egld::endpoints::getMaxFunds(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getPingAmount() {
+    ping_pong_egld::endpoints::getPingAmount(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getUserAddresses() {
+    ping_pong_egld::endpoints::getUserAddresses(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getUserStatus() {
+    ping_pong_egld::endpoints::getUserStatus(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn ping() {
     ping_pong_egld::endpoints::ping(elrond_wasm_node::arwen_api());
 }
@@ -28,41 +63,6 @@ pub fn pongAll() {
 }
 
 #[no_mangle]
-pub fn getUserAddresses() {
-    ping_pong_egld::endpoints::getUserAddresses(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getPingAmount() {
-    ping_pong_egld::endpoints::getPingAmount(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getDeadline() {
-    ping_pong_egld::endpoints::getDeadline(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getActivationTimestamp() {
-    ping_pong_egld::endpoints::getActivationTimestamp(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getMaxFunds() {
-    ping_pong_egld::endpoints::getMaxFunds(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getUserStatus() {
-    ping_pong_egld::endpoints::getUserStatus(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn pongAllLastUser() {
     ping_pong_egld::endpoints::pongAllLastUser(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    ping_pong_egld::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/abi-tester/wasm/src/lib.rs
+++ b/contracts/feature-tests/abi-tester/wasm/src/lib.rs
@@ -13,6 +13,16 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    abi_tester::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn address_vs_h256() {
+    abi_tester::endpoints::address_vs_h256(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn echo_abi_test_type() {
     abi_tester::endpoints::echo_abi_test_type(elrond_wasm_node::arwen_api());
 }
@@ -23,6 +33,26 @@ pub fn echo_enum() {
 }
 
 #[no_mangle]
+pub fn esdt_local_role() {
+    abi_tester::endpoints::esdt_local_role(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn esdt_token_data() {
+    abi_tester::endpoints::esdt_token_data(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn esdt_token_payment() {
+    abi_tester::endpoints::esdt_token_payment(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn managed_address_vs_byte_array() {
+    abi_tester::endpoints::managed_address_vs_byte_array(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn multi_result_3() {
     abi_tester::endpoints::multi_result_3(elrond_wasm_node::arwen_api());
 }
@@ -30,11 +60,6 @@ pub fn multi_result_3() {
 #[no_mangle]
 pub fn multi_result_4() {
     abi_tester::endpoints::multi_result_4(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn var_args() {
-    abi_tester::endpoints::var_args(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -53,33 +78,8 @@ pub fn optional_result() {
 }
 
 #[no_mangle]
-pub fn address_vs_h256() {
-    abi_tester::endpoints::address_vs_h256(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn managed_address_vs_byte_array() {
-    abi_tester::endpoints::managed_address_vs_byte_array(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn esdt_local_role() {
-    abi_tester::endpoints::esdt_local_role(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn esdt_token_payment() {
-    abi_tester::endpoints::esdt_token_payment(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn esdt_token_data() {
-    abi_tester::endpoints::esdt_token_data(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sample_storage_mapper() {
-    abi_tester::endpoints::sample_storage_mapper(elrond_wasm_node::arwen_api());
+pub fn payable_any_token() {
+    abi_tester::endpoints::payable_any_token(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -93,11 +93,11 @@ pub fn payable_some_token() {
 }
 
 #[no_mangle]
-pub fn payable_any_token() {
-    abi_tester::endpoints::payable_any_token(elrond_wasm_node::arwen_api());
+pub fn sample_storage_mapper() {
+    abi_tester::endpoints::sample_storage_mapper(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    abi_tester::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn var_args() {
+    abi_tester::endpoints::var_args(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/basic-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/basic-features/wasm/src/lib.rs
@@ -13,203 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn panicWithMessage() {
-    basic_features::endpoints::panicWithMessage(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn count_ones() {
-    basic_features::endpoints::count_ones(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sqrt_big_uint() {
-    basic_features::endpoints::sqrt_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sqrt_big_uint_ref() {
-    basic_features::endpoints::sqrt_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn log2_big_uint() {
-    basic_features::endpoints::log2_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn log2_big_uint_ref() {
-    basic_features::endpoints::log2_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn pow_big_int() {
-    basic_features::endpoints::pow_big_int(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn pow_big_int_ref() {
-    basic_features::endpoints::pow_big_int_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn pow_big_uint() {
-    basic_features::endpoints::pow_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn pow_big_uint_ref() {
-    basic_features::endpoints::pow_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_uint_to_u64() {
-    basic_features::endpoints::big_uint_to_u64(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_uint_zero() {
-    basic_features::endpoints::big_uint_zero(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_uint_from_u64_1() {
-    basic_features::endpoints::big_uint_from_u64_1(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_uint_from_u64_2() {
-    basic_features::endpoints::big_uint_from_u64_2(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_int_zero() {
-    basic_features::endpoints::big_int_zero(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_int_from_i64_1() {
-    basic_features::endpoints::big_int_from_i64_1(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_int_from_i64_2() {
-    basic_features::endpoints::big_int_from_i64_2(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_int_to_i64() {
-    basic_features::endpoints::big_int_to_i64(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_int_to_parts() {
-    basic_features::endpoints::big_int_to_parts(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn big_int_from_biguint() {
-    basic_features::endpoints::big_int_from_biguint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn add_big_int() {
-    basic_features::endpoints::add_big_int(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn add_big_int_ref() {
-    basic_features::endpoints::add_big_int_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn add_big_uint() {
-    basic_features::endpoints::add_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn add_big_uint_ref() {
-    basic_features::endpoints::add_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sub_big_int() {
-    basic_features::endpoints::sub_big_int(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sub_big_int_ref() {
-    basic_features::endpoints::sub_big_int_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sub_big_uint() {
-    basic_features::endpoints::sub_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sub_big_uint_ref() {
-    basic_features::endpoints::sub_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn mul_big_int() {
-    basic_features::endpoints::mul_big_int(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn mul_big_int_ref() {
-    basic_features::endpoints::mul_big_int_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn mul_big_uint() {
-    basic_features::endpoints::mul_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn mul_big_uint_ref() {
-    basic_features::endpoints::mul_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn div_big_int() {
-    basic_features::endpoints::div_big_int(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn div_big_int_ref() {
-    basic_features::endpoints::div_big_int_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn div_big_uint() {
-    basic_features::endpoints::div_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn div_big_uint_ref() {
-    basic_features::endpoints::div_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn rem_big_int() {
-    basic_features::endpoints::rem_big_int(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn rem_big_int_ref() {
-    basic_features::endpoints::rem_big_int_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn rem_big_uint() {
-    basic_features::endpoints::rem_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn rem_big_uint_ref() {
-    basic_features::endpoints::rem_big_uint_ref(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    basic_features::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -233,43 +38,298 @@ pub fn add_assign_big_uint_ref() {
 }
 
 #[no_mangle]
-pub fn sub_assign_big_int() {
-    basic_features::endpoints::sub_assign_big_int(elrond_wasm_node::arwen_api());
+pub fn add_big_int() {
+    basic_features::endpoints::add_big_int(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn sub_assign_big_int_ref() {
-    basic_features::endpoints::sub_assign_big_int_ref(elrond_wasm_node::arwen_api());
+pub fn add_big_int_ref() {
+    basic_features::endpoints::add_big_int_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn sub_assign_big_uint() {
-    basic_features::endpoints::sub_assign_big_uint(elrond_wasm_node::arwen_api());
+pub fn add_big_uint() {
+    basic_features::endpoints::add_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn sub_assign_big_uint_ref() {
-    basic_features::endpoints::sub_assign_big_uint_ref(elrond_wasm_node::arwen_api());
+pub fn add_big_uint_ref() {
+    basic_features::endpoints::add_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mul_assign_big_int() {
-    basic_features::endpoints::mul_assign_big_int(elrond_wasm_node::arwen_api());
+pub fn big_int_from_biguint() {
+    basic_features::endpoints::big_int_from_biguint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mul_assign_big_int_ref() {
-    basic_features::endpoints::mul_assign_big_int_ref(elrond_wasm_node::arwen_api());
+pub fn big_int_from_i64_1() {
+    basic_features::endpoints::big_int_from_i64_1(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mul_assign_big_uint() {
-    basic_features::endpoints::mul_assign_big_uint(elrond_wasm_node::arwen_api());
+pub fn big_int_from_i64_2() {
+    basic_features::endpoints::big_int_from_i64_2(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mul_assign_big_uint_ref() {
-    basic_features::endpoints::mul_assign_big_uint_ref(elrond_wasm_node::arwen_api());
+pub fn big_int_to_i64() {
+    basic_features::endpoints::big_int_to_i64(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn big_int_to_parts() {
+    basic_features::endpoints::big_int_to_parts(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn big_int_zero() {
+    basic_features::endpoints::big_int_zero(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn big_uint_from_u64_1() {
+    basic_features::endpoints::big_uint_from_u64_1(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn big_uint_from_u64_2() {
+    basic_features::endpoints::big_uint_from_u64_2(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn big_uint_to_u64() {
+    basic_features::endpoints::big_uint_to_u64(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn big_uint_zero() {
+    basic_features::endpoints::big_uint_zero(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_and_assign_big_uint() {
+    basic_features::endpoints::bit_and_assign_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_and_assign_big_uint_ref() {
+    basic_features::endpoints::bit_and_assign_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_and_big_uint() {
+    basic_features::endpoints::bit_and_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_and_big_uint_ref() {
+    basic_features::endpoints::bit_and_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_or_assign_big_uint() {
+    basic_features::endpoints::bit_or_assign_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_or_assign_big_uint_ref() {
+    basic_features::endpoints::bit_or_assign_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_or_big_uint() {
+    basic_features::endpoints::bit_or_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_or_big_uint_ref() {
+    basic_features::endpoints::bit_or_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_xor_assign_big_uint() {
+    basic_features::endpoints::bit_xor_assign_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_xor_assign_big_uint_ref() {
+    basic_features::endpoints::bit_xor_assign_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_xor_big_uint() {
+    basic_features::endpoints::bit_xor_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn bit_xor_big_uint_ref() {
+    basic_features::endpoints::bit_xor_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn boxed_bytes_concat_2() {
+    basic_features::endpoints::boxed_bytes_concat_2(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn boxed_bytes_split() {
+    basic_features::endpoints::boxed_bytes_split(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn boxed_bytes_zeros() {
+    basic_features::endpoints::boxed_bytes_zeros(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn clear_single_value_mapper() {
+    basic_features::endpoints::clear_single_value_mapper(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn clear_storage_value() {
+    basic_features::endpoints::clear_storage_value(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn codec_err_contract_call() {
+    basic_features::endpoints::codec_err_contract_call(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn codec_err_contract_init() {
+    basic_features::endpoints::codec_err_contract_init(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn codec_err_event_data() {
+    basic_features::endpoints::codec_err_event_data(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn codec_err_event_topic() {
+    basic_features::endpoints::codec_err_event_topic(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn codec_err_finish() {
+    basic_features::endpoints::codec_err_finish(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn codec_err_storage_get() {
+    basic_features::endpoints::codec_err_storage_get(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn codec_err_storage_key() {
+    basic_features::endpoints::codec_err_storage_key(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn codec_err_storage_set() {
+    basic_features::endpoints::codec_err_storage_set(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compare_h256() {
+    basic_features::endpoints::compare_h256(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn computeKeccak256() {
+    basic_features::endpoints::computeKeccak256(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn computeRipemd160() {
+    basic_features::endpoints::computeRipemd160(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn computeSha256() {
+    basic_features::endpoints::computeSha256(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_create_ec() {
+    basic_features::endpoints::compute_create_ec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_ec_add() {
+    basic_features::endpoints::compute_ec_add(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_ec_double() {
+    basic_features::endpoints::compute_ec_double(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_generate_key_ec() {
+    basic_features::endpoints::compute_generate_key_ec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_get_ec_length() {
+    basic_features::endpoints::compute_get_ec_length(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_get_priv_key_byte_length() {
+    basic_features::endpoints::compute_get_priv_key_byte_length(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_get_values() {
+    basic_features::endpoints::compute_get_values(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_is_on_curve_ec() {
+    basic_features::endpoints::compute_is_on_curve_ec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_marshal_compressed_ec() {
+    basic_features::endpoints::compute_marshal_compressed_ec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_marshal_ec() {
+    basic_features::endpoints::compute_marshal_ec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_scalar_base_mult() {
+    basic_features::endpoints::compute_scalar_base_mult(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_scalar_mult() {
+    basic_features::endpoints::compute_scalar_mult(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_secp256k1_der_signature() {
+    basic_features::endpoints::compute_secp256k1_der_signature(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_unmarshal_compressed_ec() {
+    basic_features::endpoints::compute_unmarshal_compressed_ec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn compute_unmarshal_ec() {
+    basic_features::endpoints::compute_unmarshal_ec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn count_ones() {
+    basic_features::endpoints::count_ones(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -293,433 +353,63 @@ pub fn div_assign_big_uint_ref() {
 }
 
 #[no_mangle]
-pub fn rem_assign_big_int() {
-    basic_features::endpoints::rem_assign_big_int(elrond_wasm_node::arwen_api());
+pub fn div_big_int() {
+    basic_features::endpoints::div_big_int(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn rem_assign_big_int_ref() {
-    basic_features::endpoints::rem_assign_big_int_ref(elrond_wasm_node::arwen_api());
+pub fn div_big_int_ref() {
+    basic_features::endpoints::div_big_int_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn rem_assign_big_uint() {
-    basic_features::endpoints::rem_assign_big_uint(elrond_wasm_node::arwen_api());
+pub fn div_big_uint() {
+    basic_features::endpoints::div_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn rem_assign_big_uint_ref() {
-    basic_features::endpoints::rem_assign_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_and_big_uint() {
-    basic_features::endpoints::bit_and_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_and_big_uint_ref() {
-    basic_features::endpoints::bit_and_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_or_big_uint() {
-    basic_features::endpoints::bit_or_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_or_big_uint_ref() {
-    basic_features::endpoints::bit_or_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_xor_big_uint() {
-    basic_features::endpoints::bit_xor_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_xor_big_uint_ref() {
-    basic_features::endpoints::bit_xor_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_and_assign_big_uint() {
-    basic_features::endpoints::bit_and_assign_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_and_assign_big_uint_ref() {
-    basic_features::endpoints::bit_and_assign_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_or_assign_big_uint() {
-    basic_features::endpoints::bit_or_assign_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_or_assign_big_uint_ref() {
-    basic_features::endpoints::bit_or_assign_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_xor_assign_big_uint() {
-    basic_features::endpoints::bit_xor_assign_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn bit_xor_assign_big_uint_ref() {
-    basic_features::endpoints::bit_xor_assign_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn shr_big_uint() {
-    basic_features::endpoints::shr_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn shr_big_uint_ref() {
-    basic_features::endpoints::shr_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn shl_big_uint() {
-    basic_features::endpoints::shl_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn shl_big_uint_ref() {
-    basic_features::endpoints::shl_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn shr_assign_big_uint() {
-    basic_features::endpoints::shr_assign_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn shr_assign_big_uint_ref() {
-    basic_features::endpoints::shr_assign_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn shl_assign_big_uint() {
-    basic_features::endpoints::shl_assign_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn shl_assign_big_uint_ref() {
-    basic_features::endpoints::shl_assign_big_uint_ref(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_get_values() {
-    basic_features::endpoints::compute_get_values(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_create_ec() {
-    basic_features::endpoints::compute_create_ec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_get_ec_length() {
-    basic_features::endpoints::compute_get_ec_length(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_get_priv_key_byte_length() {
-    basic_features::endpoints::compute_get_priv_key_byte_length(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_ec_add() {
-    basic_features::endpoints::compute_ec_add(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_ec_double() {
-    basic_features::endpoints::compute_ec_double(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_is_on_curve_ec() {
-    basic_features::endpoints::compute_is_on_curve_ec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_scalar_mult() {
-    basic_features::endpoints::compute_scalar_mult(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_scalar_base_mult() {
-    basic_features::endpoints::compute_scalar_base_mult(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_marshal_ec() {
-    basic_features::endpoints::compute_marshal_ec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_marshal_compressed_ec() {
-    basic_features::endpoints::compute_marshal_compressed_ec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_unmarshal_ec() {
-    basic_features::endpoints::compute_unmarshal_ec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_unmarshal_compressed_ec() {
-    basic_features::endpoints::compute_unmarshal_compressed_ec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_generate_key_ec() {
-    basic_features::endpoints::compute_generate_key_ec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_block_timestamp() {
-    basic_features::endpoints::get_block_timestamp(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_block_nonce() {
-    basic_features::endpoints::get_block_nonce(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_block_round() {
-    basic_features::endpoints::get_block_round(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_block_epoch() {
-    basic_features::endpoints::get_block_epoch(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_block_random_seed() {
-    basic_features::endpoints::get_block_random_seed(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_prev_block_timestamp() {
-    basic_features::endpoints::get_prev_block_timestamp(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_prev_block_nonce() {
-    basic_features::endpoints::get_prev_block_nonce(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_prev_block_round() {
-    basic_features::endpoints::get_prev_block_round(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_prev_block_epoch() {
-    basic_features::endpoints::get_prev_block_epoch(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_prev_block_random_seed() {
-    basic_features::endpoints::get_prev_block_random_seed(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_caller() {
-    basic_features::endpoints::get_caller(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_owner_address() {
-    basic_features::endpoints::get_owner_address(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_shard_of_address() {
-    basic_features::endpoints::get_shard_of_address(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn is_smart_contract() {
-    basic_features::endpoints::is_smart_contract(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_state_root_hash_legacy() {
-    basic_features::endpoints::get_state_root_hash_legacy(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_tx_hash_legacy() {
-    basic_features::endpoints::get_tx_hash_legacy(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_gas_left() {
-    basic_features::endpoints::get_gas_left(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_cumulated_validator_rewards() {
-    basic_features::endpoints::get_cumulated_validator_rewards(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_esdt_local_roles() {
-    basic_features::endpoints::get_esdt_local_roles(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn codec_err_finish() {
-    basic_features::endpoints::codec_err_finish(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn codec_err_storage_key() {
-    basic_features::endpoints::codec_err_storage_key(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn codec_err_storage_get() {
-    basic_features::endpoints::codec_err_storage_get(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn codec_err_storage_set() {
-    basic_features::endpoints::codec_err_storage_set(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn codec_err_event_topic() {
-    basic_features::endpoints::codec_err_event_topic(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn codec_err_event_data() {
-    basic_features::endpoints::codec_err_event_data(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn codec_err_contract_init() {
-    basic_features::endpoints::codec_err_contract_init(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn codec_err_contract_call() {
-    basic_features::endpoints::codec_err_contract_call(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn computeSha256() {
-    basic_features::endpoints::computeSha256(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn computeKeccak256() {
-    basic_features::endpoints::computeKeccak256(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn computeRipemd160() {
-    basic_features::endpoints::computeRipemd160(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn verify_bls_signature() {
-    basic_features::endpoints::verify_bls_signature(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn verify_ed25519_signature() {
-    basic_features::endpoints::verify_ed25519_signature(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn verify_secp256k1_signature() {
-    basic_features::endpoints::verify_secp256k1_signature(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn verify_custom_secp256k1_signature() {
-    basic_features::endpoints::verify_custom_secp256k1_signature(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn compute_secp256k1_der_signature() {
-    basic_features::endpoints::compute_secp256k1_der_signature(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_u64() {
-    basic_features::endpoints::echo_u64(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_i64() {
-    basic_features::endpoints::echo_i64(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_i32() {
-    basic_features::endpoints::echo_i32(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_u32() {
-    basic_features::endpoints::echo_u32(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_isize() {
-    basic_features::endpoints::echo_isize(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_usize() {
-    basic_features::endpoints::echo_usize(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_i8() {
-    basic_features::endpoints::echo_i8(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_u8() {
-    basic_features::endpoints::echo_u8(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_bool() {
-    basic_features::endpoints::echo_bool(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_opt_bool() {
-    basic_features::endpoints::echo_opt_bool(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_h256() {
-    basic_features::endpoints::echo_h256(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_nothing() {
-    basic_features::endpoints::echo_nothing(elrond_wasm_node::arwen_api());
+pub fn div_big_uint_ref() {
+    basic_features::endpoints::div_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
 pub fn echo_array_u8() {
     basic_features::endpoints::echo_array_u8(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_async_result_empty() {
+    basic_features::endpoints::echo_async_result_empty(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_big_int() {
+    basic_features::endpoints::echo_big_int(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_big_int_option() {
+    basic_features::endpoints::echo_big_int_option(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_big_int_tuple() {
+    basic_features::endpoints::echo_big_int_tuple(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_big_int_vec() {
+    basic_features::endpoints::echo_big_int_vec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_big_uint() {
+    basic_features::endpoints::echo_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_bool() {
+    basic_features::endpoints::echo_bool(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -733,73 +423,8 @@ pub fn echo_boxed_bytes() {
 }
 
 #[no_mangle]
-pub fn echo_slice_u8() {
-    basic_features::endpoints::echo_slice_u8(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_vec_u8() {
-    basic_features::endpoints::echo_vec_u8(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_string() {
-    basic_features::endpoints::echo_string(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_str() {
-    basic_features::endpoints::echo_str(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_str_box() {
-    basic_features::endpoints::echo_str_box(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_varags_u32() {
-    basic_features::endpoints::echo_varags_u32(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn take_varags_u32() {
-    basic_features::endpoints::take_varags_u32(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_varags_big_uint() {
-    basic_features::endpoints::echo_varags_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_varags_tuples() {
-    basic_features::endpoints::echo_varags_tuples(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_async_result_empty() {
-    basic_features::endpoints::echo_async_result_empty(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_large_boxed_byte_array() {
-    basic_features::endpoints::echo_large_boxed_byte_array(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_ser_example_1() {
-    basic_features::endpoints::echo_ser_example_1(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn echo_boxed_ser_example_1() {
     basic_features::endpoints::echo_boxed_ser_example_1(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_ser_example_2() {
-    basic_features::endpoints::echo_ser_example_2(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -808,33 +433,33 @@ pub fn echo_boxed_ser_example_2() {
 }
 
 #[no_mangle]
-pub fn echo_simple_enum() {
-    basic_features::endpoints::echo_simple_enum(elrond_wasm_node::arwen_api());
+pub fn echo_h256() {
+    basic_features::endpoints::echo_h256(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn finish_simple_enum_variant_1() {
-    basic_features::endpoints::finish_simple_enum_variant_1(elrond_wasm_node::arwen_api());
+pub fn echo_i32() {
+    basic_features::endpoints::echo_i32(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn echo_non_zero_usize() {
-    basic_features::endpoints::echo_non_zero_usize(elrond_wasm_node::arwen_api());
+pub fn echo_i64() {
+    basic_features::endpoints::echo_i64(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn echo_big_uint() {
-    basic_features::endpoints::echo_big_uint(elrond_wasm_node::arwen_api());
+pub fn echo_i8() {
+    basic_features::endpoints::echo_i8(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn echo_big_int() {
-    basic_features::endpoints::echo_big_int(elrond_wasm_node::arwen_api());
+pub fn echo_isize() {
+    basic_features::endpoints::echo_isize(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn echo_managed_buffer() {
-    basic_features::endpoints::echo_managed_buffer(elrond_wasm_node::arwen_api());
+pub fn echo_large_boxed_byte_array() {
+    basic_features::endpoints::echo_large_boxed_byte_array(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -843,28 +468,13 @@ pub fn echo_managed_address() {
 }
 
 #[no_mangle]
-pub fn echo_vec_of_managed_buffer() {
-    basic_features::endpoints::echo_vec_of_managed_buffer(elrond_wasm_node::arwen_api());
+pub fn echo_managed_async_result_empty() {
+    basic_features::endpoints::echo_managed_async_result_empty(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn echo_big_int_vec() {
-    basic_features::endpoints::echo_big_int_vec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_big_int_tuple() {
-    basic_features::endpoints::echo_big_int_tuple(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_big_int_option() {
-    basic_features::endpoints::echo_big_int_option(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_tuple_into_multiresult() {
-    basic_features::endpoints::echo_tuple_into_multiresult(elrond_wasm_node::arwen_api());
+pub fn echo_managed_buffer() {
+    basic_features::endpoints::echo_managed_buffer(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -878,8 +488,368 @@ pub fn echo_managed_vec_of_token_identifier() {
 }
 
 #[no_mangle]
-pub fn echo_managed_async_result_empty() {
-    basic_features::endpoints::echo_managed_async_result_empty(elrond_wasm_node::arwen_api());
+pub fn echo_non_zero_usize() {
+    basic_features::endpoints::echo_non_zero_usize(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_nothing() {
+    basic_features::endpoints::echo_nothing(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_opt_bool() {
+    basic_features::endpoints::echo_opt_bool(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_ser_example_1() {
+    basic_features::endpoints::echo_ser_example_1(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_ser_example_2() {
+    basic_features::endpoints::echo_ser_example_2(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_simple_enum() {
+    basic_features::endpoints::echo_simple_enum(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_slice_u8() {
+    basic_features::endpoints::echo_slice_u8(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_str() {
+    basic_features::endpoints::echo_str(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_str_box() {
+    basic_features::endpoints::echo_str_box(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_string() {
+    basic_features::endpoints::echo_string(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_tuple_into_multiresult() {
+    basic_features::endpoints::echo_tuple_into_multiresult(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_u32() {
+    basic_features::endpoints::echo_u32(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_u64() {
+    basic_features::endpoints::echo_u64(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_u8() {
+    basic_features::endpoints::echo_u8(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_usize() {
+    basic_features::endpoints::echo_usize(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_varags_big_uint() {
+    basic_features::endpoints::echo_varags_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_varags_tuples() {
+    basic_features::endpoints::echo_varags_tuples(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_varags_u32() {
+    basic_features::endpoints::echo_varags_u32(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_vec_of_managed_buffer() {
+    basic_features::endpoints::echo_vec_of_managed_buffer(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_vec_u8() {
+    basic_features::endpoints::echo_vec_u8(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn finish_simple_enum_variant_1() {
+    basic_features::endpoints::finish_simple_enum_variant_1(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getListMapper() {
+    basic_features::endpoints::getListMapper(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_block_epoch() {
+    basic_features::endpoints::get_block_epoch(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_block_nonce() {
+    basic_features::endpoints::get_block_nonce(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_block_random_seed() {
+    basic_features::endpoints::get_block_random_seed(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_block_round() {
+    basic_features::endpoints::get_block_round(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_block_timestamp() {
+    basic_features::endpoints::get_block_timestamp(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_caller() {
+    basic_features::endpoints::get_caller(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_cumulated_validator_rewards() {
+    basic_features::endpoints::get_cumulated_validator_rewards(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_esdt_local_roles() {
+    basic_features::endpoints::get_esdt_local_roles(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_gas_left() {
+    basic_features::endpoints::get_gas_left(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_nr_to_clear() {
+    basic_features::endpoints::get_nr_to_clear(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_owner_address() {
+    basic_features::endpoints::get_owner_address(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_prev_block_epoch() {
+    basic_features::endpoints::get_prev_block_epoch(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_prev_block_nonce() {
+    basic_features::endpoints::get_prev_block_nonce(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_prev_block_random_seed() {
+    basic_features::endpoints::get_prev_block_random_seed(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_prev_block_round() {
+    basic_features::endpoints::get_prev_block_round(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_prev_block_timestamp() {
+    basic_features::endpoints::get_prev_block_timestamp(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_shard_of_address() {
+    basic_features::endpoints::get_shard_of_address(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_state_root_hash_legacy() {
+    basic_features::endpoints::get_state_root_hash_legacy(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_tx_hash_legacy() {
+    basic_features::endpoints::get_tx_hash_legacy(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn h256_is_zero() {
+    basic_features::endpoints::h256_is_zero(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn is_empty_opt_addr() {
+    basic_features::endpoints::is_empty_opt_addr(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn is_empty_single_value_mapper() {
+    basic_features::endpoints::is_empty_single_value_mapper(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn is_smart_contract() {
+    basic_features::endpoints::is_smart_contract(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperBack() {
+    basic_features::endpoints::listMapperBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperFront() {
+    basic_features::endpoints::listMapperFront(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperIterateByHand() {
+    basic_features::endpoints::listMapperIterateByHand(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperIterateByIter() {
+    basic_features::endpoints::listMapperIterateByIter(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperPopBack() {
+    basic_features::endpoints::listMapperPopBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperPopFront() {
+    basic_features::endpoints::listMapperPopFront(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperPushAfter() {
+    basic_features::endpoints::listMapperPushAfter(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperPushBack() {
+    basic_features::endpoints::listMapperPushBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperPushBefore() {
+    basic_features::endpoints::listMapperPushBefore(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperPushFront() {
+    basic_features::endpoints::listMapperPushFront(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperRemoveNode() {
+    basic_features::endpoints::listMapperRemoveNode(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn listMapperRemoveNodeById() {
+    basic_features::endpoints::listMapperRemoveNodeById(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_addr() {
+    basic_features::endpoints::load_addr(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_big_int() {
+    basic_features::endpoints::load_big_int(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_big_uint() {
+    basic_features::endpoints::load_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_bool() {
+    basic_features::endpoints::load_bool(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_i64() {
+    basic_features::endpoints::load_i64(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_map1() {
+    basic_features::endpoints::load_map1(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_map2() {
+    basic_features::endpoints::load_map2(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_map3() {
+    basic_features::endpoints::load_map3(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_opt_addr() {
+    basic_features::endpoints::load_opt_addr(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_ser_1() {
+    basic_features::endpoints::load_ser_1(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_ser_2() {
+    basic_features::endpoints::load_ser_2(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_u64() {
+    basic_features::endpoints::load_u64(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_usize() {
+    basic_features::endpoints::load_usize(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn load_vec_u8() {
+    basic_features::endpoints::load_vec_u8(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn log2_big_uint() {
+    basic_features::endpoints::log2_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn log2_big_uint_ref() {
+    basic_features::endpoints::log2_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -903,8 +873,263 @@ pub fn logLegacyEventB() {
 }
 
 #[no_mangle]
-pub fn only_owner_legacy() {
-    basic_features::endpoints::only_owner_legacy(elrond_wasm_node::arwen_api());
+pub fn managed_address_eq() {
+    basic_features::endpoints::managed_address_eq(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn managed_address_from() {
+    basic_features::endpoints::managed_address_from(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn managed_address_zero() {
+    basic_features::endpoints::managed_address_zero(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn managed_vec_address_push() {
+    basic_features::endpoints::managed_vec_address_push(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn managed_vec_biguint_eq() {
+    basic_features::endpoints::managed_vec_biguint_eq(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn managed_vec_biguint_push() {
+    basic_features::endpoints::managed_vec_biguint_push(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn managed_vec_new() {
+    basic_features::endpoints::managed_vec_new(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_contains_key() {
+    basic_features::endpoints::map_mapper_contains_key(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_entry_and_modify() {
+    basic_features::endpoints::map_mapper_entry_and_modify(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_entry_or_default_update_increment() {
+    basic_features::endpoints::map_mapper_entry_or_default_update_increment(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_entry_or_insert_default() {
+    basic_features::endpoints::map_mapper_entry_or_insert_default(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_entry_or_insert_with_key() {
+    basic_features::endpoints::map_mapper_entry_or_insert_with_key(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_get() {
+    basic_features::endpoints::map_mapper_get(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_insert() {
+    basic_features::endpoints::map_mapper_insert(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_keys() {
+    basic_features::endpoints::map_mapper_keys(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_remove() {
+    basic_features::endpoints::map_mapper_remove(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_mapper_values() {
+    basic_features::endpoints::map_mapper_values(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_my_single_value_mapper() {
+    basic_features::endpoints::map_my_single_value_mapper(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_clear() {
+    basic_features::endpoints::map_storage_mapper_clear(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_contains_key() {
+    basic_features::endpoints::map_storage_mapper_contains_key(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_entry_and_modify_increment_or_default() {
+    basic_features::endpoints::map_storage_mapper_entry_and_modify_increment_or_default(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_entry_or_default_update() {
+    basic_features::endpoints::map_storage_mapper_entry_or_default_update(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_entry_or_default_update_increment() {
+    basic_features::endpoints::map_storage_mapper_entry_or_default_update_increment(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_get() {
+    basic_features::endpoints::map_storage_mapper_get(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_get_value() {
+    basic_features::endpoints::map_storage_mapper_get_value(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_insert_default() {
+    basic_features::endpoints::map_storage_mapper_insert_default(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_insert_value() {
+    basic_features::endpoints::map_storage_mapper_insert_value(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_remove() {
+    basic_features::endpoints::map_storage_mapper_remove(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn map_storage_mapper_view() {
+    basic_features::endpoints::map_storage_mapper_view(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mbuffer_concat_1() {
+    basic_features::endpoints::mbuffer_concat_1(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mbuffer_concat_2() {
+    basic_features::endpoints::mbuffer_concat_2(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mbuffer_eq() {
+    basic_features::endpoints::mbuffer_eq(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mbuffer_from_boxed_bytes() {
+    basic_features::endpoints::mbuffer_from_boxed_bytes(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mbuffer_from_slice() {
+    basic_features::endpoints::mbuffer_from_slice(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mbuffer_new() {
+    basic_features::endpoints::mbuffer_new(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mbuffer_overwrite() {
+    basic_features::endpoints::mbuffer_overwrite(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mbuffer_slice_1() {
+    basic_features::endpoints::mbuffer_slice_1(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mbuffer_slice_2() {
+    basic_features::endpoints::mbuffer_slice_2(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mul_assign_big_int() {
+    basic_features::endpoints::mul_assign_big_int(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mul_assign_big_int_ref() {
+    basic_features::endpoints::mul_assign_big_int_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mul_assign_big_uint() {
+    basic_features::endpoints::mul_assign_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mul_assign_big_uint_ref() {
+    basic_features::endpoints::mul_assign_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mul_big_int() {
+    basic_features::endpoints::mul_big_int(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mul_big_int_ref() {
+    basic_features::endpoints::mul_big_int_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mul_big_uint() {
+    basic_features::endpoints::mul_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn mul_big_uint_ref() {
+    basic_features::endpoints::mul_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn my_single_value_mapper_increment_1() {
+    basic_features::endpoints::my_single_value_mapper_increment_1(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn my_single_value_mapper_increment_2() {
+    basic_features::endpoints::my_single_value_mapper_increment_2(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn my_single_value_mapper_set_if_empty() {
+    basic_features::endpoints::my_single_value_mapper_set_if_empty(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn my_single_value_mapper_subtract_with_require() {
+    basic_features::endpoints::my_single_value_mapper_subtract_with_require(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn non_zero_usize_iter() {
+    basic_features::endpoints::non_zero_usize_iter(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn non_zero_usize_macro() {
+    basic_features::endpoints::non_zero_usize_macro(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -913,43 +1138,103 @@ pub fn only_owner_endpoint() {
 }
 
 #[no_mangle]
+pub fn only_owner_legacy() {
+    basic_features::endpoints::only_owner_legacy(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn panicWithMessage() {
+    basic_features::endpoints::panicWithMessage(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn pow_big_int() {
+    basic_features::endpoints::pow_big_int(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn pow_big_int_ref() {
+    basic_features::endpoints::pow_big_int_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn pow_big_uint() {
+    basic_features::endpoints::pow_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn pow_big_uint_ref() {
+    basic_features::endpoints::pow_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn queue_mapper() {
+    basic_features::endpoints::queue_mapper(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn queue_mapper_front() {
+    basic_features::endpoints::queue_mapper_front(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn queue_mapper_pop_front() {
+    basic_features::endpoints::queue_mapper_pop_front(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn queue_mapper_push_back() {
+    basic_features::endpoints::queue_mapper_push_back(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn raw_byte_length_single_value_mapper() {
+    basic_features::endpoints::raw_byte_length_single_value_mapper(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rem_assign_big_int() {
+    basic_features::endpoints::rem_assign_big_int(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rem_assign_big_int_ref() {
+    basic_features::endpoints::rem_assign_big_int_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rem_assign_big_uint() {
+    basic_features::endpoints::rem_assign_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rem_assign_big_uint_ref() {
+    basic_features::endpoints::rem_assign_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rem_big_int() {
+    basic_features::endpoints::rem_big_int(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rem_big_int_ref() {
+    basic_features::endpoints::rem_big_int_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rem_big_uint() {
+    basic_features::endpoints::rem_big_uint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn rem_big_uint_ref() {
+    basic_features::endpoints::rem_big_uint_ref(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn require_equals() {
     basic_features::endpoints::require_equals(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn return_sc_error() {
-    basic_features::endpoints::return_sc_error(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn result_ok() {
-    basic_features::endpoints::result_ok(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn result_err_from_bytes_1() {
-    basic_features::endpoints::result_err_from_bytes_1(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn result_err_from_bytes_2() {
-    basic_features::endpoints::result_err_from_bytes_2(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn result_err_from_bytes_3() {
-    basic_features::endpoints::result_err_from_bytes_3(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn result_err_from_string() {
-    basic_features::endpoints::result_err_from_string(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn result_err_from_str() {
-    basic_features::endpoints::result_err_from_str(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -968,208 +1253,108 @@ pub fn result_echo_3() {
 }
 
 #[no_mangle]
-pub fn mbuffer_new() {
-    basic_features::endpoints::mbuffer_new(elrond_wasm_node::arwen_api());
+pub fn result_err_from_bytes_1() {
+    basic_features::endpoints::result_err_from_bytes_1(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mbuffer_from_slice() {
-    basic_features::endpoints::mbuffer_from_slice(elrond_wasm_node::arwen_api());
+pub fn result_err_from_bytes_2() {
+    basic_features::endpoints::result_err_from_bytes_2(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mbuffer_from_boxed_bytes() {
-    basic_features::endpoints::mbuffer_from_boxed_bytes(elrond_wasm_node::arwen_api());
+pub fn result_err_from_bytes_3() {
+    basic_features::endpoints::result_err_from_bytes_3(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mbuffer_overwrite() {
-    basic_features::endpoints::mbuffer_overwrite(elrond_wasm_node::arwen_api());
+pub fn result_err_from_str() {
+    basic_features::endpoints::result_err_from_str(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mbuffer_concat_1() {
-    basic_features::endpoints::mbuffer_concat_1(elrond_wasm_node::arwen_api());
+pub fn result_err_from_string() {
+    basic_features::endpoints::result_err_from_string(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mbuffer_concat_2() {
-    basic_features::endpoints::mbuffer_concat_2(elrond_wasm_node::arwen_api());
+pub fn result_ok() {
+    basic_features::endpoints::result_ok(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mbuffer_slice_1() {
-    basic_features::endpoints::mbuffer_slice_1(elrond_wasm_node::arwen_api());
+pub fn return_sc_error() {
+    basic_features::endpoints::return_sc_error(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mbuffer_slice_2() {
-    basic_features::endpoints::mbuffer_slice_2(elrond_wasm_node::arwen_api());
+pub fn set_mapper() {
+    basic_features::endpoints::set_mapper(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn mbuffer_eq() {
-    basic_features::endpoints::mbuffer_eq(elrond_wasm_node::arwen_api());
+pub fn set_mapper_contains() {
+    basic_features::endpoints::set_mapper_contains(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn managed_address_zero() {
-    basic_features::endpoints::managed_address_zero(elrond_wasm_node::arwen_api());
+pub fn set_mapper_insert() {
+    basic_features::endpoints::set_mapper_insert(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn managed_address_from() {
-    basic_features::endpoints::managed_address_from(elrond_wasm_node::arwen_api());
+pub fn set_mapper_remove() {
+    basic_features::endpoints::set_mapper_remove(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn managed_address_eq() {
-    basic_features::endpoints::managed_address_eq(elrond_wasm_node::arwen_api());
+pub fn shl_assign_big_uint() {
+    basic_features::endpoints::shl_assign_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn managed_vec_new() {
-    basic_features::endpoints::managed_vec_new(elrond_wasm_node::arwen_api());
+pub fn shl_assign_big_uint_ref() {
+    basic_features::endpoints::shl_assign_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn managed_vec_biguint_push() {
-    basic_features::endpoints::managed_vec_biguint_push(elrond_wasm_node::arwen_api());
+pub fn shl_big_uint() {
+    basic_features::endpoints::shl_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn managed_vec_biguint_eq() {
-    basic_features::endpoints::managed_vec_biguint_eq(elrond_wasm_node::arwen_api());
+pub fn shl_big_uint_ref() {
+    basic_features::endpoints::shl_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn managed_vec_address_push() {
-    basic_features::endpoints::managed_vec_address_push(elrond_wasm_node::arwen_api());
+pub fn shr_assign_big_uint() {
+    basic_features::endpoints::shr_assign_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn load_big_uint() {
-    basic_features::endpoints::load_big_uint(elrond_wasm_node::arwen_api());
+pub fn shr_assign_big_uint_ref() {
+    basic_features::endpoints::shr_assign_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn load_big_int() {
-    basic_features::endpoints::load_big_int(elrond_wasm_node::arwen_api());
+pub fn shr_big_uint() {
+    basic_features::endpoints::shr_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn load_u64() {
-    basic_features::endpoints::load_u64(elrond_wasm_node::arwen_api());
+pub fn shr_big_uint_ref() {
+    basic_features::endpoints::shr_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn load_usize() {
-    basic_features::endpoints::load_usize(elrond_wasm_node::arwen_api());
+pub fn sqrt_big_uint() {
+    basic_features::endpoints::sqrt_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn load_i64() {
-    basic_features::endpoints::load_i64(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn load_bool() {
-    basic_features::endpoints::load_bool(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn load_vec_u8() {
-    basic_features::endpoints::load_vec_u8(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn load_addr() {
-    basic_features::endpoints::load_addr(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn load_opt_addr() {
-    basic_features::endpoints::load_opt_addr(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn is_empty_opt_addr() {
-    basic_features::endpoints::is_empty_opt_addr(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_nr_to_clear() {
-    basic_features::endpoints::get_nr_to_clear(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn clear_storage_value() {
-    basic_features::endpoints::clear_storage_value(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn load_ser_1() {
-    basic_features::endpoints::load_ser_1(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn load_ser_2() {
-    basic_features::endpoints::load_ser_2(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn load_map1() {
-    basic_features::endpoints::load_map1(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn load_map2() {
-    basic_features::endpoints::load_map2(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn load_map3() {
-    basic_features::endpoints::load_map3(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn store_big_uint() {
-    basic_features::endpoints::store_big_uint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn store_big_int() {
-    basic_features::endpoints::store_big_int(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn store_usize() {
-    basic_features::endpoints::store_usize(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn store_i32() {
-    basic_features::endpoints::store_i32(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn store_u64() {
-    basic_features::endpoints::store_u64(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn store_i64() {
-    basic_features::endpoints::store_i64(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn store_bool() {
-    basic_features::endpoints::store_bool(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn store_vec_u8() {
-    basic_features::endpoints::store_vec_u8(elrond_wasm_node::arwen_api());
+pub fn sqrt_big_uint_ref() {
+    basic_features::endpoints::sqrt_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -1178,18 +1363,28 @@ pub fn store_addr() {
 }
 
 #[no_mangle]
-pub fn store_opt_addr() {
-    basic_features::endpoints::store_opt_addr(elrond_wasm_node::arwen_api());
+pub fn store_big_int() {
+    basic_features::endpoints::store_big_int(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn store_ser_1() {
-    basic_features::endpoints::store_ser_1(elrond_wasm_node::arwen_api());
+pub fn store_big_uint() {
+    basic_features::endpoints::store_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn store_ser_2() {
-    basic_features::endpoints::store_ser_2(elrond_wasm_node::arwen_api());
+pub fn store_bool() {
+    basic_features::endpoints::store_bool(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn store_i32() {
+    basic_features::endpoints::store_i32(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn store_i64() {
+    basic_features::endpoints::store_i64(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -1208,8 +1403,8 @@ pub fn store_map3() {
 }
 
 #[no_mangle]
-pub fn store_reserved_i64() {
-    basic_features::endpoints::store_reserved_i64(elrond_wasm_node::arwen_api());
+pub fn store_opt_addr() {
+    basic_features::endpoints::store_opt_addr(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -1218,288 +1413,88 @@ pub fn store_reserved_big_uint() {
 }
 
 #[no_mangle]
+pub fn store_reserved_i64() {
+    basic_features::endpoints::store_reserved_i64(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn store_reserved_vec_u8() {
     basic_features::endpoints::store_reserved_vec_u8(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn getListMapper() {
-    basic_features::endpoints::getListMapper(elrond_wasm_node::arwen_api());
+pub fn store_ser_1() {
+    basic_features::endpoints::store_ser_1(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperPushBack() {
-    basic_features::endpoints::listMapperPushBack(elrond_wasm_node::arwen_api());
+pub fn store_ser_2() {
+    basic_features::endpoints::store_ser_2(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperPushFront() {
-    basic_features::endpoints::listMapperPushFront(elrond_wasm_node::arwen_api());
+pub fn store_u64() {
+    basic_features::endpoints::store_u64(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperPopFront() {
-    basic_features::endpoints::listMapperPopFront(elrond_wasm_node::arwen_api());
+pub fn store_usize() {
+    basic_features::endpoints::store_usize(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperPopBack() {
-    basic_features::endpoints::listMapperPopBack(elrond_wasm_node::arwen_api());
+pub fn store_vec_u8() {
+    basic_features::endpoints::store_vec_u8(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperFront() {
-    basic_features::endpoints::listMapperFront(elrond_wasm_node::arwen_api());
+pub fn sub_assign_big_int() {
+    basic_features::endpoints::sub_assign_big_int(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperBack() {
-    basic_features::endpoints::listMapperBack(elrond_wasm_node::arwen_api());
+pub fn sub_assign_big_int_ref() {
+    basic_features::endpoints::sub_assign_big_int_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperPushAfter() {
-    basic_features::endpoints::listMapperPushAfter(elrond_wasm_node::arwen_api());
+pub fn sub_assign_big_uint() {
+    basic_features::endpoints::sub_assign_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperPushBefore() {
-    basic_features::endpoints::listMapperPushBefore(elrond_wasm_node::arwen_api());
+pub fn sub_assign_big_uint_ref() {
+    basic_features::endpoints::sub_assign_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperRemoveNode() {
-    basic_features::endpoints::listMapperRemoveNode(elrond_wasm_node::arwen_api());
+pub fn sub_big_int() {
+    basic_features::endpoints::sub_big_int(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperRemoveNodeById() {
-    basic_features::endpoints::listMapperRemoveNodeById(elrond_wasm_node::arwen_api());
+pub fn sub_big_int_ref() {
+    basic_features::endpoints::sub_big_int_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperIterateByHand() {
-    basic_features::endpoints::listMapperIterateByHand(elrond_wasm_node::arwen_api());
+pub fn sub_big_uint() {
+    basic_features::endpoints::sub_big_uint(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn listMapperIterateByIter() {
-    basic_features::endpoints::listMapperIterateByIter(elrond_wasm_node::arwen_api());
+pub fn sub_big_uint_ref() {
+    basic_features::endpoints::sub_big_uint_ref(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn queue_mapper() {
-    basic_features::endpoints::queue_mapper(elrond_wasm_node::arwen_api());
+pub fn take_varags_u32() {
+    basic_features::endpoints::take_varags_u32(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn queue_mapper_push_back() {
-    basic_features::endpoints::queue_mapper_push_back(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn queue_mapper_pop_front() {
-    basic_features::endpoints::queue_mapper_pop_front(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn queue_mapper_front() {
-    basic_features::endpoints::queue_mapper_front(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_keys() {
-    basic_features::endpoints::map_mapper_keys(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_values() {
-    basic_features::endpoints::map_mapper_values(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_insert() {
-    basic_features::endpoints::map_mapper_insert(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_contains_key() {
-    basic_features::endpoints::map_mapper_contains_key(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_get() {
-    basic_features::endpoints::map_mapper_get(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_remove() {
-    basic_features::endpoints::map_mapper_remove(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_entry_or_default_update_increment() {
-    basic_features::endpoints::map_mapper_entry_or_default_update_increment(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_entry_or_insert_default() {
-    basic_features::endpoints::map_mapper_entry_or_insert_default(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_entry_and_modify() {
-    basic_features::endpoints::map_mapper_entry_and_modify(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_mapper_entry_or_insert_with_key() {
-    basic_features::endpoints::map_mapper_entry_or_insert_with_key(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_view() {
-    basic_features::endpoints::map_storage_mapper_view(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_insert_default() {
-    basic_features::endpoints::map_storage_mapper_insert_default(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_contains_key() {
-    basic_features::endpoints::map_storage_mapper_contains_key(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_get() {
-    basic_features::endpoints::map_storage_mapper_get(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_insert_value() {
-    basic_features::endpoints::map_storage_mapper_insert_value(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_get_value() {
-    basic_features::endpoints::map_storage_mapper_get_value(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_remove() {
-    basic_features::endpoints::map_storage_mapper_remove(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_clear() {
-    basic_features::endpoints::map_storage_mapper_clear(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_entry_or_default_update_increment() {
-    basic_features::endpoints::map_storage_mapper_entry_or_default_update_increment(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_entry_and_modify_increment_or_default() {
-    basic_features::endpoints::map_storage_mapper_entry_and_modify_increment_or_default(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_storage_mapper_entry_or_default_update() {
-    basic_features::endpoints::map_storage_mapper_entry_or_default_update(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn set_mapper() {
-    basic_features::endpoints::set_mapper(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn set_mapper_insert() {
-    basic_features::endpoints::set_mapper_insert(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn set_mapper_contains() {
-    basic_features::endpoints::set_mapper_contains(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn set_mapper_remove() {
-    basic_features::endpoints::set_mapper_remove(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn map_my_single_value_mapper() {
-    basic_features::endpoints::map_my_single_value_mapper(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn my_single_value_mapper_increment_1() {
-    basic_features::endpoints::my_single_value_mapper_increment_1(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn my_single_value_mapper_increment_2() {
-    basic_features::endpoints::my_single_value_mapper_increment_2(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn my_single_value_mapper_subtract_with_require() {
-    basic_features::endpoints::my_single_value_mapper_subtract_with_require(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn my_single_value_mapper_set_if_empty() {
-    basic_features::endpoints::my_single_value_mapper_set_if_empty(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn clear_single_value_mapper() {
-    basic_features::endpoints::clear_single_value_mapper(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn is_empty_single_value_mapper() {
-    basic_features::endpoints::is_empty_single_value_mapper(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn raw_byte_length_single_value_mapper() {
-    basic_features::endpoints::raw_byte_length_single_value_mapper(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn vec_mapper() {
-    basic_features::endpoints::vec_mapper(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn vec_mapper_push() {
-    basic_features::endpoints::vec_mapper_push(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn vec_mapper_get() {
-    basic_features::endpoints::vec_mapper_get(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn vec_mapper_len() {
-    basic_features::endpoints::vec_mapper_len(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn token_attributes_set() {
-    basic_features::endpoints::token_attributes_set(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn token_attributes_update() {
-    basic_features::endpoints::token_attributes_update(elrond_wasm_node::arwen_api());
+pub fn token_attributes_clear() {
+    basic_features::endpoints::token_attributes_clear(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -1513,13 +1508,18 @@ pub fn token_attributes_get_nonce() {
 }
 
 #[no_mangle]
-pub fn token_attributes_clear() {
-    basic_features::endpoints::token_attributes_clear(elrond_wasm_node::arwen_api());
+pub fn token_attributes_has_attributes() {
+    basic_features::endpoints::token_attributes_has_attributes(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn token_attributes_has_attributes() {
-    basic_features::endpoints::token_attributes_has_attributes(elrond_wasm_node::arwen_api());
+pub fn token_attributes_set() {
+    basic_features::endpoints::token_attributes_set(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn token_attributes_update() {
+    basic_features::endpoints::token_attributes_update(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -1538,46 +1538,46 @@ pub fn token_identifier_is_valid_2() {
 }
 
 #[no_mangle]
-pub fn compare_h256() {
-    basic_features::endpoints::compare_h256(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn h256_is_zero() {
-    basic_features::endpoints::h256_is_zero(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn boxed_bytes_zeros() {
-    basic_features::endpoints::boxed_bytes_zeros(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn boxed_bytes_concat_2() {
-    basic_features::endpoints::boxed_bytes_concat_2(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn boxed_bytes_split() {
-    basic_features::endpoints::boxed_bytes_split(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn vec_concat_const() {
     basic_features::endpoints::vec_concat_const(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn non_zero_usize_iter() {
-    basic_features::endpoints::non_zero_usize_iter(elrond_wasm_node::arwen_api());
+pub fn vec_mapper() {
+    basic_features::endpoints::vec_mapper(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn non_zero_usize_macro() {
-    basic_features::endpoints::non_zero_usize_macro(elrond_wasm_node::arwen_api());
+pub fn vec_mapper_get() {
+    basic_features::endpoints::vec_mapper_get(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    basic_features::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn vec_mapper_len() {
+    basic_features::endpoints::vec_mapper_len(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn vec_mapper_push() {
+    basic_features::endpoints::vec_mapper_push(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn verify_bls_signature() {
+    basic_features::endpoints::verify_bls_signature(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn verify_custom_secp256k1_signature() {
+    basic_features::endpoints::verify_custom_secp256k1_signature(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn verify_ed25519_signature() {
+    basic_features::endpoints::verify_ed25519_signature(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn verify_secp256k1_signature() {
+    basic_features::endpoints::verify_secp256k1_signature(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/src/lib.rs
@@ -13,8 +13,28 @@ pub fn init() {
 }
 
 #[no_mangle]
+pub fn callBack() {
+    first_contract::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getSecondContractAddress() {
+    first_contract::endpoints::getSecondContractAddress(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getesdtTokenName() {
+    first_contract::endpoints::getesdtTokenName(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn transferToSecondContractFull() {
     first_contract::endpoints::transferToSecondContractFull(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transferToSecondContractFullWithTransferAndExecute() {
+    first_contract::endpoints::transferToSecondContractFullWithTransferAndExecute(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -30,24 +50,4 @@ pub fn transferToSecondContractRejected() {
 #[no_mangle]
 pub fn transferToSecondContractRejectedWithTransferAndExecute() {
     first_contract::endpoints::transferToSecondContractRejectedWithTransferAndExecute(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn transferToSecondContractFullWithTransferAndExecute() {
-    first_contract::endpoints::transferToSecondContractFullWithTransferAndExecute(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getesdtTokenName() {
-    first_contract::endpoints::getesdtTokenName(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getSecondContractAddress() {
-    first_contract::endpoints::getSecondContractAddress(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    first_contract::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/src/lib.rs
@@ -13,13 +13,13 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn acceptEsdtPayment() {
-    second_contract::endpoints::acceptEsdtPayment(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    second_contract::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn rejectEsdtPayment() {
-    second_contract::endpoints::rejectEsdtPayment(elrond_wasm_node::arwen_api());
+pub fn acceptEsdtPayment() {
+    second_contract::endpoints::acceptEsdtPayment(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -28,6 +28,6 @@ pub fn getesdtTokenName() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    second_contract::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn rejectEsdtPayment() {
+    second_contract::endpoints::rejectEsdtPayment(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/src/lib.rs
@@ -13,8 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn issueWrappedEgld() {
-    child::endpoints::issueWrappedEgld(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    child::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -23,6 +23,6 @@ pub fn getWrappedEgldTokenIdentifier() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    child::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn issueWrappedEgld() {
+    child::endpoints::issueWrappedEgld(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/src/lib.rs
@@ -13,13 +13,18 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn deposit() {
-    parent::endpoints::deposit(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    parent::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
 pub fn deployChildContract() {
     parent::endpoints::deployChildContract(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn deposit() {
+    parent::endpoints::deposit(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -30,9 +35,4 @@ pub fn executeOnDestIssueToken() {
 #[no_mangle]
 pub fn getChildContractAddress() {
     parent::endpoints::getChildContractAddress(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    parent::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/forwarder-raw/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm-no-managed-ei/src/lib.rs
@@ -13,48 +13,33 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn forward_payment() {
-    forwarder_raw::endpoints::forward_payment(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    forwarder_raw::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_direct_esdt_via_transf_exec() {
-    forwarder_raw::endpoints::forward_direct_esdt_via_transf_exec(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_dest_context() {
+    forwarder_raw::endpoints::call_execute_on_dest_context(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_async_call() {
-    forwarder_raw::endpoints::forward_async_call(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_dest_context_by_caller() {
+    forwarder_raw::endpoints::call_execute_on_dest_context_by_caller(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_async_call_half_payment() {
-    forwarder_raw::endpoints::forward_async_call_half_payment(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_dest_context_readonly() {
+    forwarder_raw::endpoints::call_execute_on_dest_context_readonly(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_transf_exec_egld() {
-    forwarder_raw::endpoints::forward_transf_exec_egld(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_dest_context_twice() {
+    forwarder_raw::endpoints::call_execute_on_dest_context_twice(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_transf_exec_esdt() {
-    forwarder_raw::endpoints::forward_transf_exec_esdt(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_transf_exec() {
-    forwarder_raw::endpoints::forward_transf_exec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_async_retrieve_multi_transfer_funds() {
-    forwarder_raw::endpoints::forward_async_retrieve_multi_transfer_funds(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forwarder_async_send_and_retrieve_multi_transfer_funds() {
-    forwarder_raw::endpoints::forwarder_async_send_and_retrieve_multi_transfer_funds(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_same_context() {
+    forwarder_raw::endpoints::call_execute_on_same_context(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -68,31 +53,6 @@ pub fn clear_callback_info() {
 }
 
 #[no_mangle]
-pub fn call_execute_on_dest_context() {
-    forwarder_raw::endpoints::call_execute_on_dest_context(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn call_execute_on_dest_context_twice() {
-    forwarder_raw::endpoints::call_execute_on_dest_context_twice(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn call_execute_on_dest_context_by_caller() {
-    forwarder_raw::endpoints::call_execute_on_dest_context_by_caller(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn call_execute_on_same_context() {
-    forwarder_raw::endpoints::call_execute_on_same_context(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn call_execute_on_dest_context_readonly() {
-    forwarder_raw::endpoints::call_execute_on_dest_context_readonly(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn deploy_contract() {
     forwarder_raw::endpoints::deploy_contract(elrond_wasm_node::arwen_api());
 }
@@ -103,6 +63,51 @@ pub fn deploy_from_source() {
 }
 
 #[no_mangle]
+pub fn forward_async_call() {
+    forwarder_raw::endpoints::forward_async_call(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_async_call_half_payment() {
+    forwarder_raw::endpoints::forward_async_call_half_payment(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_async_retrieve_multi_transfer_funds() {
+    forwarder_raw::endpoints::forward_async_retrieve_multi_transfer_funds(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_direct_esdt_via_transf_exec() {
+    forwarder_raw::endpoints::forward_direct_esdt_via_transf_exec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_payment() {
+    forwarder_raw::endpoints::forward_payment(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_transf_exec() {
+    forwarder_raw::endpoints::forward_transf_exec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_transf_exec_egld() {
+    forwarder_raw::endpoints::forward_transf_exec_egld(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_transf_exec_esdt() {
+    forwarder_raw::endpoints::forward_transf_exec_esdt(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forwarder_async_send_and_retrieve_multi_transfer_funds() {
+    forwarder_raw::endpoints::forwarder_async_send_and_retrieve_multi_transfer_funds(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn upgrade() {
     forwarder_raw::endpoints::upgrade(elrond_wasm_node::arwen_api());
 }
@@ -110,9 +115,4 @@ pub fn upgrade() {
 #[no_mangle]
 pub fn upgrade_from_source() {
     forwarder_raw::endpoints::upgrade_from_source(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    forwarder_raw::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/forwarder-raw/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm/src/lib.rs
@@ -13,48 +13,33 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn forward_payment() {
-    forwarder_raw::endpoints::forward_payment(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    forwarder_raw::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_direct_esdt_via_transf_exec() {
-    forwarder_raw::endpoints::forward_direct_esdt_via_transf_exec(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_dest_context() {
+    forwarder_raw::endpoints::call_execute_on_dest_context(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_async_call() {
-    forwarder_raw::endpoints::forward_async_call(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_dest_context_by_caller() {
+    forwarder_raw::endpoints::call_execute_on_dest_context_by_caller(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_async_call_half_payment() {
-    forwarder_raw::endpoints::forward_async_call_half_payment(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_dest_context_readonly() {
+    forwarder_raw::endpoints::call_execute_on_dest_context_readonly(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_transf_exec_egld() {
-    forwarder_raw::endpoints::forward_transf_exec_egld(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_dest_context_twice() {
+    forwarder_raw::endpoints::call_execute_on_dest_context_twice(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn forward_transf_exec_esdt() {
-    forwarder_raw::endpoints::forward_transf_exec_esdt(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_transf_exec() {
-    forwarder_raw::endpoints::forward_transf_exec(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_async_retrieve_multi_transfer_funds() {
-    forwarder_raw::endpoints::forward_async_retrieve_multi_transfer_funds(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forwarder_async_send_and_retrieve_multi_transfer_funds() {
-    forwarder_raw::endpoints::forwarder_async_send_and_retrieve_multi_transfer_funds(elrond_wasm_node::arwen_api());
+pub fn call_execute_on_same_context() {
+    forwarder_raw::endpoints::call_execute_on_same_context(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -68,31 +53,6 @@ pub fn clear_callback_info() {
 }
 
 #[no_mangle]
-pub fn call_execute_on_dest_context() {
-    forwarder_raw::endpoints::call_execute_on_dest_context(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn call_execute_on_dest_context_twice() {
-    forwarder_raw::endpoints::call_execute_on_dest_context_twice(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn call_execute_on_dest_context_by_caller() {
-    forwarder_raw::endpoints::call_execute_on_dest_context_by_caller(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn call_execute_on_same_context() {
-    forwarder_raw::endpoints::call_execute_on_same_context(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn call_execute_on_dest_context_readonly() {
-    forwarder_raw::endpoints::call_execute_on_dest_context_readonly(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn deploy_contract() {
     forwarder_raw::endpoints::deploy_contract(elrond_wasm_node::arwen_api());
 }
@@ -103,6 +63,51 @@ pub fn deploy_from_source() {
 }
 
 #[no_mangle]
+pub fn forward_async_call() {
+    forwarder_raw::endpoints::forward_async_call(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_async_call_half_payment() {
+    forwarder_raw::endpoints::forward_async_call_half_payment(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_async_retrieve_multi_transfer_funds() {
+    forwarder_raw::endpoints::forward_async_retrieve_multi_transfer_funds(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_direct_esdt_via_transf_exec() {
+    forwarder_raw::endpoints::forward_direct_esdt_via_transf_exec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_payment() {
+    forwarder_raw::endpoints::forward_payment(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_transf_exec() {
+    forwarder_raw::endpoints::forward_transf_exec(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_transf_exec_egld() {
+    forwarder_raw::endpoints::forward_transf_exec_egld(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forward_transf_exec_esdt() {
+    forwarder_raw::endpoints::forward_transf_exec_esdt(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn forwarder_async_send_and_retrieve_multi_transfer_funds() {
+    forwarder_raw::endpoints::forwarder_async_send_and_retrieve_multi_transfer_funds(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn upgrade() {
     forwarder_raw::endpoints::upgrade(elrond_wasm_node::arwen_api());
 }
@@ -110,9 +115,4 @@ pub fn upgrade() {
 #[no_mangle]
 pub fn upgrade_from_source() {
     forwarder_raw::endpoints::upgrade_from_source(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    forwarder_raw::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/forwarder/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder/wasm-no-managed-ei/src/lib.rs
@@ -13,8 +13,53 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn send_egld() {
-    forwarder::endpoints::send_egld(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    forwarder::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn buy_nft() {
+    forwarder::endpoints::buy_nft(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn callback_data() {
+    forwarder::endpoints::callback_data(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn callback_data_at_index() {
+    forwarder::endpoints::callback_data_at_index(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn changeOwnerAddress() {
+    forwarder::endpoints::changeOwnerAddress(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn clear_callback_data() {
+    forwarder::endpoints::clear_callback_data(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn create_and_send() {
+    forwarder::endpoints::create_and_send(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn deploy_contract() {
+    forwarder::endpoints::deploy_contract(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn deploy_two_contracts() {
+    forwarder::endpoints::deploy_two_contracts(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn deploy_vault_from_source() {
+    forwarder::endpoints::deploy_vault_from_source(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -30,31 +75,6 @@ pub fn echo_arguments_sync_range() {
 #[no_mangle]
 pub fn echo_arguments_sync_twice() {
     forwarder::endpoints::echo_arguments_sync_twice(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_accept_funds() {
-    forwarder::endpoints::forward_sync_accept_funds(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_accept_funds_with_fees() {
-    forwarder::endpoints::forward_sync_accept_funds_with_fees(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_accept_funds_then_read() {
-    forwarder::endpoints::forward_sync_accept_funds_then_read(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_retrieve_funds() {
-    forwarder::endpoints::forward_sync_retrieve_funds(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_accept_funds_multi_transfer() {
-    forwarder::endpoints::forward_sync_accept_funds_multi_transfer(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -78,28 +98,28 @@ pub fn forward_async_retrieve_funds() {
 }
 
 #[no_mangle]
-pub fn send_funds_twice() {
-    forwarder::endpoints::send_funds_twice(elrond_wasm_node::arwen_api());
+pub fn forward_sync_accept_funds() {
+    forwarder::endpoints::forward_sync_accept_funds(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn multi_transfer_via_async() {
-    forwarder::endpoints::multi_transfer_via_async(elrond_wasm_node::arwen_api());
+pub fn forward_sync_accept_funds_multi_transfer() {
+    forwarder::endpoints::forward_sync_accept_funds_multi_transfer(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callback_data() {
-    forwarder::endpoints::callback_data(elrond_wasm_node::arwen_api());
+pub fn forward_sync_accept_funds_then_read() {
+    forwarder::endpoints::forward_sync_accept_funds_then_read(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callback_data_at_index() {
-    forwarder::endpoints::callback_data_at_index(elrond_wasm_node::arwen_api());
+pub fn forward_sync_accept_funds_with_fees() {
+    forwarder::endpoints::forward_sync_accept_funds_with_fees(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn clear_callback_data() {
-    forwarder::endpoints::clear_callback_data(elrond_wasm_node::arwen_api());
+pub fn forward_sync_retrieve_funds() {
+    forwarder::endpoints::forward_sync_retrieve_funds(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -108,13 +128,8 @@ pub fn forward_transf_exec_accept_funds() {
 }
 
 #[no_mangle]
-pub fn forward_transf_execu_accept_funds_with_fees() {
-    forwarder::endpoints::forward_transf_execu_accept_funds_with_fees(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_transf_exec_accept_funds_twice() {
-    forwarder::endpoints::forward_transf_exec_accept_funds_twice(elrond_wasm_node::arwen_api());
+pub fn forward_transf_exec_accept_funds_multi_transfer() {
+    forwarder::endpoints::forward_transf_exec_accept_funds_multi_transfer(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -123,43 +138,13 @@ pub fn forward_transf_exec_accept_funds_return_values() {
 }
 
 #[no_mangle]
-pub fn forward_transf_exec_accept_funds_multi_transfer() {
-    forwarder::endpoints::forward_transf_exec_accept_funds_multi_transfer(elrond_wasm_node::arwen_api());
+pub fn forward_transf_exec_accept_funds_twice() {
+    forwarder::endpoints::forward_transf_exec_accept_funds_twice(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn changeOwnerAddress() {
-    forwarder::endpoints::changeOwnerAddress(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn deploy_contract() {
-    forwarder::endpoints::deploy_contract(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn deploy_two_contracts() {
-    forwarder::endpoints::deploy_two_contracts(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn deploy_vault_from_source() {
-    forwarder::endpoints::deploy_vault_from_source(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn upgradeVault() {
-    forwarder::endpoints::upgradeVault(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn upgrade_vault_from_source() {
-    forwarder::endpoints::upgrade_vault_from_source(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getFungibleEsdtBalance() {
-    forwarder::endpoints::getFungibleEsdtBalance(elrond_wasm_node::arwen_api());
+pub fn forward_transf_execu_accept_funds_with_fees() {
+    forwarder::endpoints::forward_transf_execu_accept_funds_with_fees(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -168,43 +153,8 @@ pub fn getCurrentNftNonce() {
 }
 
 #[no_mangle]
-pub fn send_esdt() {
-    forwarder::endpoints::send_esdt(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn send_esdt_with_fees() {
-    forwarder::endpoints::send_esdt_with_fees(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn send_esdt_twice() {
-    forwarder::endpoints::send_esdt_twice(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn send_esdt_direct_multi_transfer() {
-    forwarder::endpoints::send_esdt_direct_multi_transfer(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn issue_fungible_token() {
-    forwarder::endpoints::issue_fungible_token(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn local_mint() {
-    forwarder::endpoints::local_mint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn local_burn() {
-    forwarder::endpoints::local_burn(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sft_issue() {
-    forwarder::endpoints::sft_issue(elrond_wasm_node::arwen_api());
+pub fn getFungibleEsdtBalance() {
+    forwarder::endpoints::getFungibleEsdtBalance(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -213,23 +163,33 @@ pub fn get_nft_balance() {
 }
 
 #[no_mangle]
-pub fn buy_nft() {
-    forwarder::endpoints::buy_nft(elrond_wasm_node::arwen_api());
+pub fn issue_fungible_token() {
+    forwarder::endpoints::issue_fungible_token(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn nft_issue() {
-    forwarder::endpoints::nft_issue(elrond_wasm_node::arwen_api());
+pub fn lastErrorMessage() {
+    forwarder::endpoints::lastErrorMessage(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn nft_create() {
-    forwarder::endpoints::nft_create(elrond_wasm_node::arwen_api());
+pub fn lastIssuedToken() {
+    forwarder::endpoints::lastIssuedToken(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn nft_decode_complex_attributes() {
-    forwarder::endpoints::nft_decode_complex_attributes(elrond_wasm_node::arwen_api());
+pub fn local_burn() {
+    forwarder::endpoints::local_burn(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn local_mint() {
+    forwarder::endpoints::local_mint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn multi_transfer_via_async() {
+    forwarder::endpoints::multi_transfer_via_async(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -243,18 +203,48 @@ pub fn nft_burn() {
 }
 
 #[no_mangle]
-pub fn transfer_nft_via_async_call() {
-    forwarder::endpoints::transfer_nft_via_async_call(elrond_wasm_node::arwen_api());
+pub fn nft_create() {
+    forwarder::endpoints::nft_create(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn transfer_nft_and_execute() {
-    forwarder::endpoints::transfer_nft_and_execute(elrond_wasm_node::arwen_api());
+pub fn nft_decode_complex_attributes() {
+    forwarder::endpoints::nft_decode_complex_attributes(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn create_and_send() {
-    forwarder::endpoints::create_and_send(elrond_wasm_node::arwen_api());
+pub fn nft_issue() {
+    forwarder::endpoints::nft_issue(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_egld() {
+    forwarder::endpoints::send_egld(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_esdt() {
+    forwarder::endpoints::send_esdt(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_esdt_direct_multi_transfer() {
+    forwarder::endpoints::send_esdt_direct_multi_transfer(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_esdt_twice() {
+    forwarder::endpoints::send_esdt_twice(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_esdt_with_fees() {
+    forwarder::endpoints::send_esdt_with_fees(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_funds_twice() {
+    forwarder::endpoints::send_funds_twice(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -263,21 +253,31 @@ pub fn setLocalRoles() {
 }
 
 #[no_mangle]
+pub fn sft_issue() {
+    forwarder::endpoints::sft_issue(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transfer_nft_and_execute() {
+    forwarder::endpoints::transfer_nft_and_execute(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transfer_nft_via_async_call() {
+    forwarder::endpoints::transfer_nft_via_async_call(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn unsetLocalRoles() {
     forwarder::endpoints::unsetLocalRoles(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn lastIssuedToken() {
-    forwarder::endpoints::lastIssuedToken(elrond_wasm_node::arwen_api());
+pub fn upgradeVault() {
+    forwarder::endpoints::upgradeVault(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn lastErrorMessage() {
-    forwarder::endpoints::lastErrorMessage(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    forwarder::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn upgrade_vault_from_source() {
+    forwarder::endpoints::upgrade_vault_from_source(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/forwarder/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder/wasm/src/lib.rs
@@ -13,8 +13,53 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn send_egld() {
-    forwarder::endpoints::send_egld(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    forwarder::endpoints::callBack(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn buy_nft() {
+    forwarder::endpoints::buy_nft(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn callback_data() {
+    forwarder::endpoints::callback_data(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn callback_data_at_index() {
+    forwarder::endpoints::callback_data_at_index(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn changeOwnerAddress() {
+    forwarder::endpoints::changeOwnerAddress(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn clear_callback_data() {
+    forwarder::endpoints::clear_callback_data(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn create_and_send() {
+    forwarder::endpoints::create_and_send(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn deploy_contract() {
+    forwarder::endpoints::deploy_contract(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn deploy_two_contracts() {
+    forwarder::endpoints::deploy_two_contracts(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn deploy_vault_from_source() {
+    forwarder::endpoints::deploy_vault_from_source(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -30,31 +75,6 @@ pub fn echo_arguments_sync_range() {
 #[no_mangle]
 pub fn echo_arguments_sync_twice() {
     forwarder::endpoints::echo_arguments_sync_twice(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_accept_funds() {
-    forwarder::endpoints::forward_sync_accept_funds(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_accept_funds_with_fees() {
-    forwarder::endpoints::forward_sync_accept_funds_with_fees(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_accept_funds_then_read() {
-    forwarder::endpoints::forward_sync_accept_funds_then_read(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_retrieve_funds() {
-    forwarder::endpoints::forward_sync_retrieve_funds(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_sync_accept_funds_multi_transfer() {
-    forwarder::endpoints::forward_sync_accept_funds_multi_transfer(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -78,28 +98,28 @@ pub fn forward_async_retrieve_funds() {
 }
 
 #[no_mangle]
-pub fn send_funds_twice() {
-    forwarder::endpoints::send_funds_twice(elrond_wasm_node::arwen_api());
+pub fn forward_sync_accept_funds() {
+    forwarder::endpoints::forward_sync_accept_funds(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn multi_transfer_via_async() {
-    forwarder::endpoints::multi_transfer_via_async(elrond_wasm_node::arwen_api());
+pub fn forward_sync_accept_funds_multi_transfer() {
+    forwarder::endpoints::forward_sync_accept_funds_multi_transfer(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callback_data() {
-    forwarder::endpoints::callback_data(elrond_wasm_node::arwen_api());
+pub fn forward_sync_accept_funds_then_read() {
+    forwarder::endpoints::forward_sync_accept_funds_then_read(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callback_data_at_index() {
-    forwarder::endpoints::callback_data_at_index(elrond_wasm_node::arwen_api());
+pub fn forward_sync_accept_funds_with_fees() {
+    forwarder::endpoints::forward_sync_accept_funds_with_fees(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn clear_callback_data() {
-    forwarder::endpoints::clear_callback_data(elrond_wasm_node::arwen_api());
+pub fn forward_sync_retrieve_funds() {
+    forwarder::endpoints::forward_sync_retrieve_funds(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -108,13 +128,8 @@ pub fn forward_transf_exec_accept_funds() {
 }
 
 #[no_mangle]
-pub fn forward_transf_execu_accept_funds_with_fees() {
-    forwarder::endpoints::forward_transf_execu_accept_funds_with_fees(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn forward_transf_exec_accept_funds_twice() {
-    forwarder::endpoints::forward_transf_exec_accept_funds_twice(elrond_wasm_node::arwen_api());
+pub fn forward_transf_exec_accept_funds_multi_transfer() {
+    forwarder::endpoints::forward_transf_exec_accept_funds_multi_transfer(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -123,43 +138,13 @@ pub fn forward_transf_exec_accept_funds_return_values() {
 }
 
 #[no_mangle]
-pub fn forward_transf_exec_accept_funds_multi_transfer() {
-    forwarder::endpoints::forward_transf_exec_accept_funds_multi_transfer(elrond_wasm_node::arwen_api());
+pub fn forward_transf_exec_accept_funds_twice() {
+    forwarder::endpoints::forward_transf_exec_accept_funds_twice(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn changeOwnerAddress() {
-    forwarder::endpoints::changeOwnerAddress(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn deploy_contract() {
-    forwarder::endpoints::deploy_contract(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn deploy_two_contracts() {
-    forwarder::endpoints::deploy_two_contracts(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn deploy_vault_from_source() {
-    forwarder::endpoints::deploy_vault_from_source(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn upgradeVault() {
-    forwarder::endpoints::upgradeVault(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn upgrade_vault_from_source() {
-    forwarder::endpoints::upgrade_vault_from_source(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getFungibleEsdtBalance() {
-    forwarder::endpoints::getFungibleEsdtBalance(elrond_wasm_node::arwen_api());
+pub fn forward_transf_execu_accept_funds_with_fees() {
+    forwarder::endpoints::forward_transf_execu_accept_funds_with_fees(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -168,43 +153,8 @@ pub fn getCurrentNftNonce() {
 }
 
 #[no_mangle]
-pub fn send_esdt() {
-    forwarder::endpoints::send_esdt(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn send_esdt_with_fees() {
-    forwarder::endpoints::send_esdt_with_fees(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn send_esdt_twice() {
-    forwarder::endpoints::send_esdt_twice(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn send_esdt_direct_multi_transfer() {
-    forwarder::endpoints::send_esdt_direct_multi_transfer(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn issue_fungible_token() {
-    forwarder::endpoints::issue_fungible_token(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn local_mint() {
-    forwarder::endpoints::local_mint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn local_burn() {
-    forwarder::endpoints::local_burn(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sft_issue() {
-    forwarder::endpoints::sft_issue(elrond_wasm_node::arwen_api());
+pub fn getFungibleEsdtBalance() {
+    forwarder::endpoints::getFungibleEsdtBalance(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -213,23 +163,33 @@ pub fn get_nft_balance() {
 }
 
 #[no_mangle]
-pub fn buy_nft() {
-    forwarder::endpoints::buy_nft(elrond_wasm_node::arwen_api());
+pub fn issue_fungible_token() {
+    forwarder::endpoints::issue_fungible_token(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn nft_issue() {
-    forwarder::endpoints::nft_issue(elrond_wasm_node::arwen_api());
+pub fn lastErrorMessage() {
+    forwarder::endpoints::lastErrorMessage(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn nft_create() {
-    forwarder::endpoints::nft_create(elrond_wasm_node::arwen_api());
+pub fn lastIssuedToken() {
+    forwarder::endpoints::lastIssuedToken(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn nft_decode_complex_attributes() {
-    forwarder::endpoints::nft_decode_complex_attributes(elrond_wasm_node::arwen_api());
+pub fn local_burn() {
+    forwarder::endpoints::local_burn(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn local_mint() {
+    forwarder::endpoints::local_mint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn multi_transfer_via_async() {
+    forwarder::endpoints::multi_transfer_via_async(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -243,18 +203,48 @@ pub fn nft_burn() {
 }
 
 #[no_mangle]
-pub fn transfer_nft_via_async_call() {
-    forwarder::endpoints::transfer_nft_via_async_call(elrond_wasm_node::arwen_api());
+pub fn nft_create() {
+    forwarder::endpoints::nft_create(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn transfer_nft_and_execute() {
-    forwarder::endpoints::transfer_nft_and_execute(elrond_wasm_node::arwen_api());
+pub fn nft_decode_complex_attributes() {
+    forwarder::endpoints::nft_decode_complex_attributes(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn create_and_send() {
-    forwarder::endpoints::create_and_send(elrond_wasm_node::arwen_api());
+pub fn nft_issue() {
+    forwarder::endpoints::nft_issue(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_egld() {
+    forwarder::endpoints::send_egld(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_esdt() {
+    forwarder::endpoints::send_esdt(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_esdt_direct_multi_transfer() {
+    forwarder::endpoints::send_esdt_direct_multi_transfer(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_esdt_twice() {
+    forwarder::endpoints::send_esdt_twice(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_esdt_with_fees() {
+    forwarder::endpoints::send_esdt_with_fees(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn send_funds_twice() {
+    forwarder::endpoints::send_funds_twice(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -263,21 +253,31 @@ pub fn setLocalRoles() {
 }
 
 #[no_mangle]
+pub fn sft_issue() {
+    forwarder::endpoints::sft_issue(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transfer_nft_and_execute() {
+    forwarder::endpoints::transfer_nft_and_execute(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transfer_nft_via_async_call() {
+    forwarder::endpoints::transfer_nft_via_async_call(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn unsetLocalRoles() {
     forwarder::endpoints::unsetLocalRoles(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn lastIssuedToken() {
-    forwarder::endpoints::lastIssuedToken(elrond_wasm_node::arwen_api());
+pub fn upgradeVault() {
+    forwarder::endpoints::upgradeVault(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn lastErrorMessage() {
-    forwarder::endpoints::lastErrorMessage(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    forwarder::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn upgrade_vault_from_source() {
+    forwarder::endpoints::upgrade_vault_from_source(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/local-esdt-and-nft/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/wasm/src/lib.rs
@@ -13,63 +13,13 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn issueFungibleToken() {
-    local_esdt_and_nft::endpoints::issueFungibleToken(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    local_esdt_and_nft::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn localMint() {
-    local_esdt_and_nft::endpoints::localMint(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn localBurn() {
-    local_esdt_and_nft::endpoints::localBurn(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn nftIssue() {
-    local_esdt_and_nft::endpoints::nftIssue(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn nftCreate() {
-    local_esdt_and_nft::endpoints::nftCreate(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn nftAddQuantity() {
-    local_esdt_and_nft::endpoints::nftAddQuantity(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn nftBurn() {
-    local_esdt_and_nft::endpoints::nftBurn(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn transferNftViaAsyncCall() {
-    local_esdt_and_nft::endpoints::transferNftViaAsyncCall(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn transfer_nft_and_execute() {
-    local_esdt_and_nft::endpoints::transfer_nft_and_execute(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn sftIssue() {
-    local_esdt_and_nft::endpoints::sftIssue(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn setLocalRoles() {
-    local_esdt_and_nft::endpoints::setLocalRoles(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn unsetLocalRoles() {
-    local_esdt_and_nft::endpoints::unsetLocalRoles(elrond_wasm_node::arwen_api());
+pub fn getCurrentNftNonce() {
+    local_esdt_and_nft::endpoints::getCurrentNftNonce(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -83,13 +33,8 @@ pub fn getNftBalance() {
 }
 
 #[no_mangle]
-pub fn getCurrentNftNonce() {
-    local_esdt_and_nft::endpoints::getCurrentNftNonce(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn lastIssuedToken() {
-    local_esdt_and_nft::endpoints::lastIssuedToken(elrond_wasm_node::arwen_api());
+pub fn issueFungibleToken() {
+    local_esdt_and_nft::endpoints::issueFungibleToken(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -98,6 +43,61 @@ pub fn lastErrorMessage() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    local_esdt_and_nft::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn lastIssuedToken() {
+    local_esdt_and_nft::endpoints::lastIssuedToken(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn localBurn() {
+    local_esdt_and_nft::endpoints::localBurn(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn localMint() {
+    local_esdt_and_nft::endpoints::localMint(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn nftAddQuantity() {
+    local_esdt_and_nft::endpoints::nftAddQuantity(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn nftBurn() {
+    local_esdt_and_nft::endpoints::nftBurn(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn nftCreate() {
+    local_esdt_and_nft::endpoints::nftCreate(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn nftIssue() {
+    local_esdt_and_nft::endpoints::nftIssue(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn setLocalRoles() {
+    local_esdt_and_nft::endpoints::setLocalRoles(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn sftIssue() {
+    local_esdt_and_nft::endpoints::sftIssue(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transferNftViaAsyncCall() {
+    local_esdt_and_nft::endpoints::transferNftViaAsyncCall(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn transfer_nft_and_execute() {
+    local_esdt_and_nft::endpoints::transfer_nft_and_execute(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn unsetLocalRoles() {
+    local_esdt_and_nft::endpoints::unsetLocalRoles(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/proxy-test-first/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm-no-managed-ei/src/lib.rs
@@ -13,13 +13,13 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn deploySecondContract() {
-    proxy_test_first::endpoints::deploySecondContract(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    proxy_test_first::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn upgradeSecondContract() {
-    proxy_test_first::endpoints::upgradeSecondContract(elrond_wasm_node::arwen_api());
+pub fn deploySecondContract() {
+    proxy_test_first::endpoints::deploySecondContract(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -43,6 +43,6 @@ pub fn messageOtherContractWithCallback() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    proxy_test_first::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn upgradeSecondContract() {
+    proxy_test_first::endpoints::upgradeSecondContract(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/proxy-test-first/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm/src/lib.rs
@@ -13,13 +13,13 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn deploySecondContract() {
-    proxy_test_first::endpoints::deploySecondContract(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    proxy_test_first::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn upgradeSecondContract() {
-    proxy_test_first::endpoints::upgradeSecondContract(elrond_wasm_node::arwen_api());
+pub fn deploySecondContract() {
+    proxy_test_first::endpoints::deploySecondContract(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -43,6 +43,6 @@ pub fn messageOtherContractWithCallback() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    proxy_test_first::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn upgradeSecondContract() {
+    proxy_test_first::endpoints::upgradeSecondContract(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/proxy-test-second/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm-no-managed-ei/src/lib.rs
@@ -13,13 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn payMe() {
-    proxy_test_second::endpoints::payMe(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn payMeWithResult() {
-    proxy_test_second::endpoints::payMeWithResult(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    proxy_test_second::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -28,6 +23,11 @@ pub fn messageMe() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    proxy_test_second::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn payMe() {
+    proxy_test_second::endpoints::payMe(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn payMeWithResult() {
+    proxy_test_second::endpoints::payMeWithResult(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/proxy-test-second/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm/src/lib.rs
@@ -13,13 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn payMe() {
-    proxy_test_second::endpoints::payMe(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn payMeWithResult() {
-    proxy_test_second::endpoints::payMeWithResult(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    proxy_test_second::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -28,6 +23,11 @@ pub fn messageMe() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    proxy_test_second::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn payMe() {
+    proxy_test_second::endpoints::payMe(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn payMeWithResult() {
+    proxy_test_second::endpoints::payMeWithResult(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/recursive-caller/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/recursive-caller/wasm-no-managed-ei/src/lib.rs
@@ -13,11 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn recursive_send_funds() {
-    recursive_caller::endpoints::recursive_send_funds(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    recursive_caller::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    recursive_caller::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn recursive_send_funds() {
+    recursive_caller::endpoints::recursive_send_funds(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/recursive-caller/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/recursive-caller/wasm/src/lib.rs
@@ -13,11 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn recursive_send_funds() {
-    recursive_caller::endpoints::recursive_send_funds(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    recursive_caller::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    recursive_caller::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn recursive_send_funds() {
+    recursive_caller::endpoints::recursive_send_funds(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/composability/vault/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/vault/wasm/src/lib.rs
@@ -13,23 +13,18 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn just_accept_funds() {
-    vault::endpoints::just_accept_funds(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_arguments() {
-    vault::endpoints::echo_arguments(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn echo_caller() {
-    vault::endpoints::echo_caller(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    vault::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
 pub fn accept_funds() {
     vault::endpoints::accept_funds(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn accept_funds_echo_payment() {
+    vault::endpoints::accept_funds_echo_payment(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -43,8 +38,33 @@ pub fn accept_multi_funds_echo() {
 }
 
 #[no_mangle]
-pub fn accept_funds_echo_payment() {
-    vault::endpoints::accept_funds_echo_payment(elrond_wasm_node::arwen_api());
+pub fn burn_and_create_retrive_async() {
+    vault::endpoints::burn_and_create_retrive_async(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn call_counts() {
+    vault::endpoints::call_counts(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_arguments() {
+    vault::endpoints::echo_arguments(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn echo_caller() {
+    vault::endpoints::echo_caller(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn get_owner_address() {
+    vault::endpoints::get_owner_address(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn just_accept_funds() {
+    vault::endpoints::just_accept_funds(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -60,24 +80,4 @@ pub fn retrieve_funds() {
 #[no_mangle]
 pub fn retrieve_multi_funds_async() {
     vault::endpoints::retrieve_multi_funds_async(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn burn_and_create_retrive_async() {
-    vault::endpoints::burn_and_create_retrive_async(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn get_owner_address() {
-    vault::endpoints::get_owner_address(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn call_counts() {
-    vault::endpoints::call_counts(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn callBack() {
-    vault::endpoints::callBack(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/panic-message-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/panic-message-features/wasm/src/lib.rs
@@ -13,11 +13,11 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn panicWithMessage() {
-    panic_message_features::endpoints::panicWithMessage(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    panic_message_features::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn callBack() {
-    panic_message_features::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn panicWithMessage() {
+    panic_message_features::endpoints::panicWithMessage(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/payable-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/payable-features/wasm/src/lib.rs
@@ -13,13 +13,13 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn echo_call_value() {
-    payable_features::endpoints::echo_call_value(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    payable_features::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn payment_multiple() {
-    payable_features::endpoints::payment_multiple(elrond_wasm_node::arwen_api());
+pub fn echo_call_value() {
+    payable_features::endpoints::echo_call_value(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -83,6 +83,6 @@ pub fn payable_token_4() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    payable_features::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn payment_multiple() {
+    payable_features::endpoints::payment_multiple(elrond_wasm_node::arwen_api());
 }

--- a/contracts/feature-tests/use-module/wasm/src/lib.rs
+++ b/contracts/feature-tests/use-module/wasm/src/lib.rs
@@ -13,13 +13,8 @@ pub fn init() {
 }
 
 #[no_mangle]
-pub fn checkFeatureGuard() {
-    use_module::endpoints::checkFeatureGuard(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn checkPause() {
-    use_module::endpoints::checkPause(elrond_wasm_node::arwen_api());
+pub fn callBack() {
+    use_module::endpoints::callBack(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -38,103 +33,18 @@ pub fn call_mod_c() {
 }
 
 #[no_mangle]
-pub fn dnsRegister() {
-    use_module::endpoints::dnsRegister(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn issueToken() {
-    use_module::endpoints::issueToken(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn setLocalRoles() {
-    use_module::endpoints::setLocalRoles(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn setFeatureFlag() {
-    use_module::endpoints::setFeatureFlag(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn depositTokensForAction() {
-    use_module::endpoints::depositTokensForAction(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn withdrawGovernanceTokens() {
-    use_module::endpoints::withdrawGovernanceTokens(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn propose() {
-    use_module::endpoints::propose(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn vote() {
-    use_module::endpoints::vote(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn downvote() {
-    use_module::endpoints::downvote(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn queue() {
-    use_module::endpoints::queue(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn execute() {
-    use_module::endpoints::execute(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
 pub fn cancel() {
     use_module::endpoints::cancel(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn getProposalStatus() {
-    use_module::endpoints::getProposalStatus(elrond_wasm_node::arwen_api());
+pub fn changeLockTimeAfterVotingEndsInBlocks() {
+    use_module::endpoints::changeLockTimeAfterVotingEndsInBlocks(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
-pub fn getProposer() {
-    use_module::endpoints::getProposer(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getProposalDescription() {
-    use_module::endpoints::getProposalDescription(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getProposalActions() {
-    use_module::endpoints::getProposalActions(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getTotalVotes() {
-    use_module::endpoints::getTotalVotes(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn getTotalDownvotes() {
-    use_module::endpoints::getTotalDownvotes(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn initGovernanceModule() {
-    use_module::endpoints::initGovernanceModule(elrond_wasm_node::arwen_api());
-}
-
-#[no_mangle]
-pub fn changeQuorum() {
-    use_module::endpoints::changeQuorum(elrond_wasm_node::arwen_api());
+pub fn changeMaxActionsPerProposal() {
+    use_module::endpoints::changeMaxActionsPerProposal(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -143,8 +53,8 @@ pub fn changeMinTokenBalanceForProposing() {
 }
 
 #[no_mangle]
-pub fn changeMaxActionsPerProposal() {
-    use_module::endpoints::changeMaxActionsPerProposal(elrond_wasm_node::arwen_api());
+pub fn changeQuorum() {
+    use_module::endpoints::changeQuorum(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -158,8 +68,33 @@ pub fn changeVotingPeriodInBlocks() {
 }
 
 #[no_mangle]
-pub fn changeLockTimeAfterVotingEndsInBlocks() {
-    use_module::endpoints::changeLockTimeAfterVotingEndsInBlocks(elrond_wasm_node::arwen_api());
+pub fn checkFeatureGuard() {
+    use_module::endpoints::checkFeatureGuard(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn checkPause() {
+    use_module::endpoints::checkPause(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn depositTokensForAction() {
+    use_module::endpoints::depositTokensForAction(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn dnsRegister() {
+    use_module::endpoints::dnsRegister(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn downvote() {
+    use_module::endpoints::downvote(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn execute() {
+    use_module::endpoints::execute(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -168,8 +103,13 @@ pub fn getGovernanceTokenId() {
 }
 
 #[no_mangle]
-pub fn getQuorum() {
-    use_module::endpoints::getQuorum(elrond_wasm_node::arwen_api());
+pub fn getLockTimeAfterVotingEndsInBlocks() {
+    use_module::endpoints::getLockTimeAfterVotingEndsInBlocks(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getMaxActionsPerProposal() {
+    use_module::endpoints::getMaxActionsPerProposal(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -178,8 +118,38 @@ pub fn getMinTokenBalanceForProposing() {
 }
 
 #[no_mangle]
-pub fn getMaxActionsPerProposal() {
-    use_module::endpoints::getMaxActionsPerProposal(elrond_wasm_node::arwen_api());
+pub fn getProposalActions() {
+    use_module::endpoints::getProposalActions(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getProposalDescription() {
+    use_module::endpoints::getProposalDescription(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getProposalStatus() {
+    use_module::endpoints::getProposalStatus(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getProposer() {
+    use_module::endpoints::getProposer(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getQuorum() {
+    use_module::endpoints::getQuorum(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getTotalDownvotes() {
+    use_module::endpoints::getTotalDownvotes(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn getTotalVotes() {
+    use_module::endpoints::getTotalVotes(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -193,8 +163,8 @@ pub fn getVotingPeriodInBlocks() {
 }
 
 #[no_mangle]
-pub fn getLockTimeAfterVotingEndsInBlocks() {
-    use_module::endpoints::getLockTimeAfterVotingEndsInBlocks(elrond_wasm_node::arwen_api());
+pub fn initGovernanceModule() {
+    use_module::endpoints::initGovernanceModule(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -203,8 +173,33 @@ pub fn isPaused() {
 }
 
 #[no_mangle]
+pub fn issueToken() {
+    use_module::endpoints::issueToken(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
 pub fn pause() {
     use_module::endpoints::pause(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn propose() {
+    use_module::endpoints::propose(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn queue() {
+    use_module::endpoints::queue(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn setFeatureFlag() {
+    use_module::endpoints::setFeatureFlag(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn setLocalRoles() {
+    use_module::endpoints::setLocalRoles(elrond_wasm_node::arwen_api());
 }
 
 #[no_mangle]
@@ -213,6 +208,11 @@ pub fn unpause() {
 }
 
 #[no_mangle]
-pub fn callBack() {
-    use_module::endpoints::callBack(elrond_wasm_node::arwen_api());
+pub fn vote() {
+    use_module::endpoints::vote(elrond_wasm_node::arwen_api());
+}
+
+#[no_mangle]
+pub fn withdrawGovernanceTokens() {
+    use_module::endpoints::withdrawGovernanceTokens(elrond_wasm_node::arwen_api());
 }


### PR DESCRIPTION
Simply re-generated wasm crate sources. The endpoints are now sorted for consistency.
The changed endpoint generator has been pushed previously.