### PR TITLE
Implement `ExactSizeIterator` for `ManagedVecIterator`

### DIFF
--- a/elrond-wasm-debug/tests/managed_vec_test.rs
+++ b/elrond-wasm-debug/tests/managed_vec_test.rs
@@ -26,6 +26,25 @@ fn test_managed_vec_iter_rev() {
 }
 
 #[test]
+fn test_managed_vec_iter_exact_size_trait() {
+    let context = DebugApi::dummy();
+
+    let mut managed_vec = ManagedVec::new(context.clone());
+    for i in 1..=10 {
+        managed_vec.push(i);
+    }
+    assert!(managed_vec.len() == 10);
+    let it = managed_vec.iter();
+    assert!(it.size_hint() == (10, Some(10)));
+    assert!(it.len() == 10);
+    let it2 = it.skip(2);
+    assert!(it2.len() == 8);
+    let it3 = it2.clone();
+    assert!(it2.skip(3).len() == 5);
+    assert!(it3.skip(5).len() == 3);
+}
+
+#[test]
 fn test_into_vec() {
     let context = DebugApi::dummy();
 

--- a/elrond-wasm-derive/src/preprocessing/substitution_list.rs
+++ b/elrond-wasm-derive/src/preprocessing/substitution_list.rs
@@ -44,6 +44,7 @@ fn add_managed_types(substitutions: &mut SubstitutionsMap) {
     add_managed_type(substitutions, &quote!(ManagedAsyncCallError));
 
     add_managed_type_with_generics(substitutions, &quote!(ManagedVec));
+    add_managed_type_with_generics(substitutions, &quote!(ManagedVecIterator));
     add_managed_type_with_generics(substitutions, &quote!(ManagedVarArgs));
     add_managed_type_with_generics(substitutions, &quote!(ManagedMultiResultVec));
     add_managed_type_with_generics(substitutions, &quote!(ManagedAsyncCallResult));

--- a/elrond-wasm/src/types/managed/managed_vec_iter.rs
+++ b/elrond-wasm/src/types/managed/managed_vec_iter.rs
@@ -65,6 +65,18 @@ where
         self.byte_start = next_byte_start;
         Some(result)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = (self.byte_end - self.byte_start) / T::PAYLOAD_SIZE;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a, M, T> ExactSizeIterator for ManagedVecIterator<'a, M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
 }
 
 impl<'a, M, T> DoubleEndedIterator for ManagedVecIterator<'a, M, T>
@@ -86,5 +98,20 @@ where
         });
 
         Some(result)
+    }
+}
+
+impl<'a, M, T> Clone for ManagedVecIterator<'a, M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedVecItem<M>,
+{
+    #[allow(clippy::clone_double_ref)]
+    fn clone(&self) -> Self {
+        Self {
+            managed_vec: self.managed_vec,
+            byte_start: self.byte_start,
+            byte_end: self.byte_end,
+        }
     }
 }


### PR DESCRIPTION
- add `size_hint` implementation, which is needed for `ExactSizeIterator`
- add `Clone` for `ManagedVecIterator`
- update macro replacement rules for `ManagedVecIterator` to allow skipping `Self::Api` when passing an iterator as a function argument
- add tests