### PR TITLE
Hex literal features

### DIFF
--- a/elrond-wasm/Cargo.toml
+++ b/elrond-wasm/Cargo.toml
@@ -23,6 +23,9 @@ hashbrown = "0.11.2"
 hex-literal = "0.3.1"
 bitflags = "1.3.2"
 
+[features]
+hex = [ "hex-literal" ]
+
 [dependencies.elrond-wasm-derive]
 version = "=0.22.11"
 path = "../elrond-wasm-derive"

--- a/elrond-wasm/Cargo.toml
+++ b/elrond-wasm/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies", "development-t
 wee_alloc = "0.4"
 arrayvec = { version = "0.7.1", default-features = false }
 hashbrown = "0.11.2"
-hex-literal = "0.3.1"
+hex-literal = "=0.3.1"
 bitflags = "1.3.2"
 
 [features]

--- a/elrond-wasm/Cargo.toml
+++ b/elrond-wasm/Cargo.toml
@@ -13,9 +13,6 @@ description = "Elrond WebAssembly smart contract API"
 keywords = ["elrond", "wasm", "webassembly", "blockchain", "contract"]
 categories = ["no-std", "wasm", "cryptography::cryptocurrencies", "development-tools"]
 
-[features]
-cb_closure_managed_deser = []
-
 [dependencies]
 wee_alloc = "0.4"
 arrayvec = { version = "0.7.1", default-features = false }
@@ -24,7 +21,8 @@ hex-literal = "0.3.1"
 bitflags = "1.3.2"
 
 [features]
-hex = [ "hex-literal" ]
+cb_closure_managed_deser = []
+hex = []
 
 [dependencies.elrond-wasm-derive]
 version = "=0.22.11"

--- a/elrond-wasm/src/lib.rs
+++ b/elrond-wasm/src/lib.rs
@@ -29,3 +29,6 @@ pub mod types;
 pub use hex_call_data::*;
 pub use io::*;
 pub use storage::{storage_clear, storage_get, storage_get_len, storage_set};
+
+#[cfg(feature="hex")]
+pub use hex_literal;


### PR DESCRIPTION
- Adding [hex-literal](https://docs.rs/hex-literal/0.3.4/hex_literal/) as a feature to avoid having to include it since it is already a project dependency.
- Made elrond-wasm use [hex-literal](https://docs.rs/hex-literal/0.3.4/hex_literal/) version  `0.3.4` to avoid future possible breaking changes.

Inspired by [this example](https://github.com/ElrondNetwork/elrond-wasm-rs/blob/master/contracts/feature-tests/composability/proxy-test-first/src/proxy-test-first.rs#L8), my smart contract required a hardcoded address in it, thought this might be useful to others. Made it a feature so it's only optional.