### PR TITLE
generate tx data

### DIFF
--- a/tools/erdpy-snippet-generator/src/cmd_builder.rs
+++ b/tools/erdpy-snippet-generator/src/cmd_builder.rs
@@ -32,10 +32,14 @@ impl CmdBuilder {
         self.cmd += flag_name;
     }
 
-    pub fn add_standalone_argument<T: TopEncode>(&mut self, arg: &T) {
+    pub fn to_hex<T: TopEncode>(arg: &T) -> String {
         let mut arg_bytes = Vec::new();
         arg.top_encode(&mut arg_bytes).unwrap();
-        let arg_as_hex = hex::encode(&arg_bytes);
+        hex::encode(&arg_bytes)
+    }
+
+    pub fn add_standalone_argument<T: TopEncode>(&mut self, arg: &T) {
+        let arg_as_hex = Self::to_hex(arg);
 
         self.add_space();
         self.cmd += HEX_PREFIX;


### PR DESCRIPTION
Add option in erdpy snippet generator to generate tx data in the `endpointName@arg1hex@arg2hex...` format as well 