### PR TITLE
API refactor - renamed StaticBufferApi to StaticVarApi

### DIFF
--- a/elrond-wasm-debug/src/api/managed_types/static_buffer_api_mock.rs
+++ b/elrond-wasm-debug/src/api/managed_types/static_buffer_api_mock.rs
@@ -1,18 +1,18 @@
 use crate::DebugApi;
 use elrond_wasm::{
-    api::{StaticBufferApi, StaticBufferApiImpl},
+    api::{StaticVarApi, StaticVarApiImpl},
     types::LockableStaticBuffer,
 };
 
-impl StaticBufferApi for DebugApi {
-    type StaticBufferApiImpl = DebugApi;
+impl StaticVarApi for DebugApi {
+    type StaticVarApiImpl = DebugApi;
 
-    fn static_buffer_api_impl() -> DebugApi {
+    fn static_var_api_impl() -> DebugApi {
         DebugApi::new_from_static()
     }
 }
 
-impl StaticBufferApiImpl for DebugApi {
+impl StaticVarApiImpl for DebugApi {
     fn with_lockable_static_buffer<R, F: FnOnce(&mut LockableStaticBuffer) -> R>(&self, f: F) -> R {
         let mut lockable_static_buffer = self.lockable_static_buffer_cell.borrow_mut();
         f(&mut lockable_static_buffer)

--- a/elrond-wasm-node/src/api/managed_types/static_buffer_api_node.rs
+++ b/elrond-wasm-node/src/api/managed_types/static_buffer_api_node.rs
@@ -1,5 +1,5 @@
 use elrond_wasm::{
-    api::{StaticBufferApi, StaticBufferApiImpl},
+    api::{StaticVarApi, StaticVarApiImpl},
     types::LockableStaticBuffer,
 };
 
@@ -7,15 +7,15 @@ use crate::VmApiImpl;
 
 static mut STATIC_BUFFER: LockableStaticBuffer = LockableStaticBuffer::new();
 
-impl StaticBufferApi for VmApiImpl {
-    type StaticBufferApiImpl = VmApiImpl;
+impl StaticVarApi for VmApiImpl {
+    type StaticVarApiImpl = VmApiImpl;
 
-    fn static_buffer_api_impl() -> Self::StaticBufferApiImpl {
+    fn static_var_api_impl() -> Self::StaticVarApiImpl {
         VmApiImpl {}
     }
 }
 
-impl StaticBufferApiImpl for VmApiImpl {
+impl StaticVarApiImpl for VmApiImpl {
     fn with_lockable_static_buffer<R, F: FnOnce(&mut LockableStaticBuffer) -> R>(&self, f: F) -> R {
         unsafe { f(&mut STATIC_BUFFER) }
     }

--- a/elrond-wasm/src/api/managed_types/managed_type_api.rs
+++ b/elrond-wasm/src/api/managed_types/managed_type_api.rs
@@ -1,8 +1,8 @@
 use crate::api::ErrorApi;
 
-use super::{ManagedTypeApiImpl, StaticBufferApi};
+use super::{ManagedTypeApiImpl, StaticVarApi};
 
-pub trait ManagedTypeApi: StaticBufferApi + ErrorApi + Clone + 'static {
+pub trait ManagedTypeApi: StaticVarApi + ErrorApi + Clone + 'static {
     type ManagedTypeApiImpl: ManagedTypeApiImpl;
 
     fn managed_type_impl() -> Self::ManagedTypeApiImpl;

--- a/elrond-wasm/src/api/managed_types/mod.rs
+++ b/elrond-wasm/src/api/managed_types/mod.rs
@@ -3,11 +3,11 @@ mod elliptic_curve_api;
 mod managed_buffer_api;
 mod managed_type_api;
 mod managed_type_api_impl;
-mod static_buffer_api;
+mod static_var_api;
 
 pub use big_int_api::*;
 pub use elliptic_curve_api::*;
 pub use managed_buffer_api::*;
 pub use managed_type_api::*;
 pub use managed_type_api_impl::*;
-pub use static_buffer_api::*;
+pub use static_var_api::*;

--- a/elrond-wasm/src/api/managed_types/static_var_api.rs
+++ b/elrond-wasm/src/api/managed_types/static_var_api.rs
@@ -1,14 +1,14 @@
 use crate::types::LockableStaticBuffer;
 
-pub trait StaticBufferApi {
-    type StaticBufferApiImpl: StaticBufferApiImpl;
+pub trait StaticVarApi {
+    type StaticVarApiImpl: StaticVarApiImpl;
 
-    fn static_buffer_api_impl() -> Self::StaticBufferApiImpl;
+    fn static_var_api_impl() -> Self::StaticVarApiImpl;
 }
 
 /// A raw bytes buffer stored statically:
 /// - in wasm as a static variable
 /// - in debug mode on the thread local context
-pub trait StaticBufferApiImpl {
+pub trait StaticVarApiImpl {
     fn with_lockable_static_buffer<R, F: FnOnce(&mut LockableStaticBuffer) -> R>(&self, f: F) -> R;
 }

--- a/elrond-wasm/src/api/uncallable/static_buffer_api_uncallable.rs
+++ b/elrond-wasm/src/api/uncallable/static_buffer_api_uncallable.rs
@@ -1,19 +1,19 @@
 use crate::{
-    api::{StaticBufferApi, StaticBufferApiImpl},
+    api::{StaticVarApi, StaticVarApiImpl},
     types::LockableStaticBuffer,
 };
 
 use super::UncallableApi;
 
-impl StaticBufferApi for UncallableApi {
-    type StaticBufferApiImpl = UncallableApi;
+impl StaticVarApi for UncallableApi {
+    type StaticVarApiImpl = UncallableApi;
 
-    fn static_buffer_api_impl() -> Self::StaticBufferApiImpl {
+    fn static_var_api_impl() -> Self::StaticVarApiImpl {
         unreachable!()
     }
 }
 
-impl StaticBufferApiImpl for UncallableApi {
+impl StaticVarApiImpl for UncallableApi {
     fn with_lockable_static_buffer<R, F: FnOnce(&mut LockableStaticBuffer) -> R>(
         &self,
         _f: F,

--- a/elrond-wasm/src/types/static_buffer/static_buffer_ref.rs
+++ b/elrond-wasm/src/types/static_buffer/static_buffer_ref.rs
@@ -1,19 +1,19 @@
 use core::marker::PhantomData;
 
-use crate::api::{InvalidSliceError, StaticBufferApi, StaticBufferApiImpl};
+use crate::api::{InvalidSliceError, StaticVarApi, StaticVarApiImpl};
 
 use super::LockableStaticBuffer;
 
 pub struct StaticBufferRef<M>
 where
-    M: StaticBufferApi,
+    M: StaticVarApi,
 {
     _phantom: PhantomData<M>,
 }
 
 impl<M> StaticBufferRef<M>
 where
-    M: StaticBufferApi,
+    M: StaticVarApi,
 {
     fn new() -> Self {
         StaticBufferRef {
@@ -25,7 +25,7 @@ where
         len: usize,
         copy_bytes: F,
     ) -> Option<Self> {
-        M::static_buffer_api_impl().with_lockable_static_buffer(|lsb| {
+        M::static_var_api_impl().with_lockable_static_buffer(|lsb| {
             if lsb.try_lock_with_copy_bytes(len, copy_bytes) {
                 Some(StaticBufferRef::new())
             } else {
@@ -39,21 +39,21 @@ where
     }
 }
 
-impl<M: StaticBufferApi> Drop for StaticBufferRef<M> {
+impl<M: StaticVarApi> Drop for StaticBufferRef<M> {
     fn drop(&mut self) {
-        M::static_buffer_api_impl().with_lockable_static_buffer(|lsb| {
+        M::static_var_api_impl().with_lockable_static_buffer(|lsb| {
             lsb.unlock();
         })
     }
 }
 
-impl<M: StaticBufferApi> StaticBufferRef<M> {
+impl<M: StaticVarApi> StaticBufferRef<M> {
     pub fn len(&self) -> usize {
-        M::static_buffer_api_impl().with_lockable_static_buffer(|lsb| lsb.len())
+        M::static_var_api_impl().with_lockable_static_buffer(|lsb| lsb.len())
     }
 
     pub fn is_empty(&self) -> bool {
-        M::static_buffer_api_impl().with_lockable_static_buffer(|lsb| lsb.is_empty())
+        M::static_var_api_impl().with_lockable_static_buffer(|lsb| lsb.is_empty())
     }
 
     pub fn capacity(&self) -> usize {
@@ -61,15 +61,15 @@ impl<M: StaticBufferApi> StaticBufferRef<M> {
     }
 
     pub fn remaining_capacity(&self) -> usize {
-        M::static_buffer_api_impl().with_lockable_static_buffer(|lsb| lsb.remaining_capacity())
+        M::static_var_api_impl().with_lockable_static_buffer(|lsb| lsb.remaining_capacity())
     }
 
     pub fn with_buffer_contents<R, F: FnMut(&[u8]) -> R>(&self, mut f: F) -> R {
-        M::static_buffer_api_impl().with_lockable_static_buffer(|lsb| f(lsb.as_slice()))
+        M::static_var_api_impl().with_lockable_static_buffer(|lsb| f(lsb.as_slice()))
     }
 
     pub fn contents_eq(&self, bytes: &[u8]) -> bool {
-        M::static_buffer_api_impl().with_lockable_static_buffer(|lsb| lsb.as_slice() == bytes)
+        M::static_var_api_impl().with_lockable_static_buffer(|lsb| lsb.as_slice() == bytes)
     }
 
     pub fn load_slice(
@@ -77,7 +77,7 @@ impl<M: StaticBufferApi> StaticBufferRef<M> {
         starting_position: usize,
         dest: &mut [u8],
     ) -> Result<(), InvalidSliceError> {
-        M::static_buffer_api_impl()
+        M::static_var_api_impl()
             .with_lockable_static_buffer(|lsb| lsb.load_slice(starting_position, dest))
     }
 
@@ -90,7 +90,7 @@ impl<M: StaticBufferApi> StaticBufferRef<M> {
         len: usize,
         copy_bytes: F,
     ) -> bool {
-        M::static_buffer_api_impl()
+        M::static_var_api_impl()
             .with_lockable_static_buffer(|lsb| lsb.try_extend_from_copy_bytes(len, copy_bytes))
     }
 }


### PR DESCRIPTION
The reason is: there will be more static variables there, beside the static buffer.