### PR TITLE
CallableContractBuilder, CallableContract refactor

### DIFF
--- a/contracts/benchmarks/mappers/linked-list-repeat/tests/mandos_rs_test.rs
+++ b/contracts/benchmarks/mappers/linked-list-repeat/tests/mandos_rs_test.rs
@@ -6,7 +6,7 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/linked-list-repeat.wasm",
-        linked_list_repeat::contract_builder,
+        linked_list_repeat::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/benchmarks/mappers/map-repeat/tests/mandos_rs_test.rs
+++ b/contracts/benchmarks/mappers/map-repeat/tests/mandos_rs_test.rs
@@ -5,7 +5,7 @@ fn world() -> BlockchainMock {
     blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/map-repeat");
 
     blockchain
-        .register_contract_builder("file:output/map-repeat.wasm", map_repeat::contract_builder);
+        .register_contract_builder("file:output/map-repeat.wasm", map_repeat::ContractBuilder);
     blockchain
 }
 

--- a/contracts/benchmarks/mappers/queue-repeat/tests/mandos_rs_test.rs
+++ b/contracts/benchmarks/mappers/queue-repeat/tests/mandos_rs_test.rs
@@ -6,7 +6,7 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/queue-repeat.wasm",
-        queue_repeat::contract_builder,
+        queue_repeat::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/benchmarks/mappers/set-repeat/tests/mandos_rs_test.rs
+++ b/contracts/benchmarks/mappers/set-repeat/tests/mandos_rs_test.rs
@@ -5,7 +5,7 @@ fn world() -> BlockchainMock {
     blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/set-repeat");
 
     blockchain
-        .register_contract_builder("file:output/set-repeat.wasm", set_repeat::contract_builder);
+        .register_contract_builder("file:output/set-repeat.wasm", set_repeat::ContractBuilder);
     blockchain
 }
 

--- a/contracts/benchmarks/mappers/single-value-repeat/tests/mandos_rs_test.rs
+++ b/contracts/benchmarks/mappers/single-value-repeat/tests/mandos_rs_test.rs
@@ -6,7 +6,7 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/single-value-repeat.wasm",
-        single_value_repeat::contract_builder,
+        single_value_repeat::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/benchmarks/mappers/vec-repeat/tests/mandos_rs_test.rs
+++ b/contracts/benchmarks/mappers/vec-repeat/tests/mandos_rs_test.rs
@@ -5,7 +5,7 @@ fn world() -> BlockchainMock {
     blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/vec-repeat");
 
     blockchain
-        .register_contract_builder("file:output/vec-repeat.wasm", vec_repeat::contract_builder);
+        .register_contract_builder("file:output/vec-repeat.wasm", vec_repeat::ContractBuilder);
     blockchain
 }
 

--- a/contracts/benchmarks/send-tx-repeat/tests/mandos_rs_test.rs
+++ b/contracts/benchmarks/send-tx-repeat/tests/mandos_rs_test.rs
@@ -4,7 +4,7 @@ fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain.register_contract_builder(
         "file:output/send-tx-repeat.wasm",
-        send_tx_repeat::contract_builder,
+        send_tx_repeat::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/benchmarks/str-repeat/tests/mandos_rs_test.rs
+++ b/contracts/benchmarks/str-repeat/tests/mandos_rs_test.rs
@@ -3,7 +3,7 @@ use elrond_wasm_debug::*;
 fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain
-        .register_contract_builder("file:output/str-repeat.wasm", str_repeat::contract_builder);
+        .register_contract_builder("file:output/str-repeat.wasm", str_repeat::ContractBuilder);
     blockchain
 }
 

--- a/contracts/examples/adder/tests/adder_mandos_rs_test.rs
+++ b/contracts/examples/adder/tests/adder_mandos_rs_test.rs
@@ -4,7 +4,7 @@ fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain.set_current_dir_from_workspace("contracts/examples/adder");
 
-    blockchain.register_contract_builder("file:output/adder.wasm", adder::contract_builder);
+    blockchain.register_contract_builder("file:output/adder.wasm", adder::ContractBuilder);
     blockchain
 }
 

--- a/contracts/examples/crowdfunding-esdt/tests/crowdfunding_esdt_mandos_rs_test.rs
+++ b/contracts/examples/crowdfunding-esdt/tests/crowdfunding_esdt_mandos_rs_test.rs
@@ -6,7 +6,7 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/crowdfunding-esdt.wasm",
-        crowdfunding_esdt::contract_builder,
+        crowdfunding_esdt::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/examples/crypto-bubbles/tests/crypto_bubbles_mandos_rs_test.rs
+++ b/contracts/examples/crypto-bubbles/tests/crypto_bubbles_mandos_rs_test.rs
@@ -6,7 +6,7 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/crypto-bubbles.wasm",
-        crypto_bubbles::contract_builder,
+        crypto_bubbles::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/examples/crypto-kitties/kitty-auction/tests/kitty_auction_mandos_rs_test.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/tests/kitty_auction_mandos_rs_test.rs
@@ -5,11 +5,11 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:../kitty-ownership/output/kitty-ownership.wasm",
-        kitty_ownership::contract_builder,
+        kitty_ownership::ContractBuilder,
     );
     blockchain.register_contract_builder(
         "file:output/kitty-auction.wasm",
-        kitty_auction::contract_builder,
+        kitty_auction::ContractBuilder,
     );
 
     blockchain

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/tests/kitty_genetic_alg_mandos_rs_test.rs
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/tests/kitty_genetic_alg_mandos_rs_test.rs
@@ -4,7 +4,7 @@ fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain.register_contract_builder(
         "file:output/kitty-genetic-alg.wasm",
-        kitty_genetic_alg::contract_builder,
+        kitty_genetic_alg::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/examples/crypto-kitties/kitty-ownership/tests/kitty_ownership_mandos_rs_test.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/tests/kitty_ownership_mandos_rs_test.rs
@@ -5,11 +5,11 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:../kitty-genetic-alg/output/kitty-genetic-alg.wasm",
-        kitty_genetic_alg::contract_builder,
+        kitty_genetic_alg::ContractBuilder,
     );
     blockchain.register_contract_builder(
         "file:output/kitty-ownership.wasm",
-        kitty_ownership::contract_builder,
+        kitty_ownership::ContractBuilder,
     );
 
     blockchain

--- a/contracts/examples/egld-esdt-swap/tests/egld_esdt_swap_mandos_rs_test.rs
+++ b/contracts/examples/egld-esdt-swap/tests/egld_esdt_swap_mandos_rs_test.rs
@@ -4,7 +4,7 @@ fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain.register_contract_builder(
         "file:output/egld-esdt-swap.wasm",
-        egld_esdt_swap::contract_builder,
+        egld_esdt_swap::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/examples/lottery-esdt/tests/lottery_esdt_mandos_rs_test.rs
+++ b/contracts/examples/lottery-esdt/tests/lottery_esdt_mandos_rs_test.rs
@@ -6,7 +6,7 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/lottery-esdt.wasm",
-        lottery_esdt::contract_builder,
+        lottery_esdt::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/examples/multisig/tests/multisig_mandos_rs_test.rs
+++ b/contracts/examples/multisig/tests/multisig_mandos_rs_test.rs
@@ -4,13 +4,13 @@ fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain.set_current_dir_from_workspace("contracts/examples/multisig");
 
-    blockchain.register_contract_builder("file:output/multisig.wasm", multisig::contract_builder);
+    blockchain.register_contract_builder("file:output/multisig.wasm", multisig::ContractBuilder);
 
-    blockchain.register_contract_builder("file:test-contracts/adder.wasm", adder::contract_builder);
+    blockchain.register_contract_builder("file:test-contracts/adder.wasm", adder::ContractBuilder);
 
     blockchain.register_contract_builder(
         "file:test-contracts/factorial.wasm",
-        factorial::contract_builder,
+        factorial::ContractBuilder,
     );
 
     blockchain

--- a/contracts/examples/ping-pong-egld/tests/ping_pong_egld_mandos_rs_test.rs
+++ b/contracts/examples/ping-pong-egld/tests/ping_pong_egld_mandos_rs_test.rs
@@ -6,7 +6,7 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/ping-pong-egld.wasm",
-        ping_pong_egld::contract_builder,
+        ping_pong_egld::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/examples/proxy-pause/tests/proxy_pause_mandos_rs_test.rs
+++ b/contracts/examples/proxy-pause/tests/proxy_pause_mandos_rs_test.rs
@@ -4,14 +4,12 @@ fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain.set_current_dir_from_workspace("contracts/examples/proxy-pause");
 
-    blockchain.register_contract_builder(
-        "file:output/proxy-pause.wasm",
-        proxy_pause::contract_builder,
-    );
+    blockchain
+        .register_contract_builder("file:output/proxy-pause.wasm", proxy_pause::ContractBuilder);
 
     blockchain.register_contract_builder(
         "file:../../feature-tests/use-module/output/use-module.wasm",
-        use_module::contract_builder,
+        use_module::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/feature-tests/basic-features/tests/basic_features_mandos_rs_test.rs
+++ b/contracts/feature-tests/basic-features/tests/basic_features_mandos_rs_test.rs
@@ -6,7 +6,7 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/basic-features.wasm",
-        basic_features::contract_builder,
+        basic_features::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/feature-tests/composability/esdt-contract-pair/tests/mandos_rs_test.rs
+++ b/contracts/feature-tests/composability/esdt-contract-pair/tests/mandos_rs_test.rs
@@ -4,12 +4,12 @@ fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain.register_contract_builder(
         "file:first-contract/output/first-contract.wasm",
-        first_contract::contract_builder,
+        first_contract::ContractBuilder,
     );
 
     blockchain.register_contract_builder(
         "file:second-contract/output/second-contract.wasm",
-        second_contract::contract_builder,
+        second_contract::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/feature-tests/composability/tests/composability_mandos_rs_test.rs
+++ b/contracts/feature-tests/composability/tests/composability_mandos_rs_test.rs
@@ -6,25 +6,25 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:forwarder/output/forwarder.wasm",
-        forwarder::contract_builder,
+        forwarder::ContractBuilder,
     );
     blockchain.register_contract_builder(
         "file:forwarder-raw/output/forwarder-raw.wasm",
-        forwarder_raw::contract_builder,
+        forwarder_raw::ContractBuilder,
     );
     blockchain.register_contract_builder(
         "file:proxy-test-first/output/proxy-test-first.wasm",
-        proxy_test_first::contract_builder,
+        proxy_test_first::ContractBuilder,
     );
     blockchain.register_contract_builder(
         "file:proxy-test-second/output/proxy-test-second.wasm",
-        proxy_test_second::contract_builder,
+        proxy_test_second::ContractBuilder,
     );
     blockchain.register_contract_builder(
         "file:recursive-caller/output/recursive-caller.wasm",
-        recursive_caller::contract_builder,
+        recursive_caller::ContractBuilder,
     );
-    blockchain.register_contract_builder("file:vault/output/vault.wasm", vault::contract_builder);
+    blockchain.register_contract_builder("file:vault/output/vault.wasm", vault::ContractBuilder);
     blockchain
 }
 

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/tests/crowdfunding_erc20_mandos_rs_test.rs
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/tests/crowdfunding_erc20_mandos_rs_test.rs
@@ -8,11 +8,10 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/crowdfunding-erc20.wasm",
-        crowdfunding_erc20::contract_builder,
+        crowdfunding_erc20::ContractBuilder,
     );
 
-    blockchain
-        .register_contract_builder("file:../erc20/output/erc20.wasm", erc20::contract_builder);
+    blockchain.register_contract_builder("file:../erc20/output/erc20.wasm", erc20::ContractBuilder);
 
     blockchain
 }

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/tests/erc1155_marketplace_mandos_rs_test.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/tests/erc1155_marketplace_mandos_rs_test.rs
@@ -4,11 +4,11 @@ fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain.register_contract_builder(
         "file:output/erc1155-marketplace.wasm",
-        erc1155_marketplace::contract_builder,
+        erc1155_marketplace::ContractBuilder,
     );
     blockchain.register_contract_builder(
         "file:../erc1155/output/erc1155.wasm",
-        erc1155::contract_builder,
+        erc1155::ContractBuilder,
     );
 
     blockchain

--- a/contracts/feature-tests/erc-style-contracts/erc1155/tests/erc1155_mandos_rs_test.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/tests/erc1155_mandos_rs_test.rs
@@ -2,10 +2,10 @@ use elrond_wasm_debug::*;
 
 fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
-    blockchain.register_contract_builder("file:output/erc1155.wasm", erc1155::contract_builder);
+    blockchain.register_contract_builder("file:output/erc1155.wasm", erc1155::ContractBuilder);
     blockchain.register_contract_builder(
         "file:../erc1155-user-mock/output/erc1155-user-mock.wasm",
-        erc1155_user_mock::contract_builder,
+        erc1155_user_mock::ContractBuilder,
     );
 
     blockchain

--- a/contracts/feature-tests/erc-style-contracts/erc20/tests/erc20_mandos_rs_test.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc20/tests/erc20_mandos_rs_test.rs
@@ -4,7 +4,7 @@ fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain.set_current_dir_from_workspace("contracts/feature-tests/erc-style-contracts/erc20");
 
-    blockchain.register_contract_builder("file:output/erc20.wasm", erc20::contract_builder);
+    blockchain.register_contract_builder("file:output/erc20.wasm", erc20::ContractBuilder);
     blockchain
 }
 

--- a/contracts/feature-tests/erc-style-contracts/erc721/tests/nft_mandos_rs_test.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc721/tests/nft_mandos_rs_test.rs
@@ -2,7 +2,7 @@ use elrond_wasm_debug::*;
 
 fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
-    blockchain.register_contract_builder("file:output/erc721.wasm", erc721::contract_builder);
+    blockchain.register_contract_builder("file:output/erc721.wasm", erc721::ContractBuilder);
     blockchain
 }
 

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/tests/lottery_erc20_mandos_rs_test.rs
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/tests/lottery_erc20_mandos_rs_test.rs
@@ -8,11 +8,10 @@ fn world() -> BlockchainMock {
 
     blockchain.register_contract_builder(
         "file:output/lottery-erc20.wasm",
-        lottery_erc20::contract_builder,
+        lottery_erc20::ContractBuilder,
     );
 
-    blockchain
-        .register_contract_builder("file:../erc20/output/erc20.wasm", erc20::contract_builder);
+    blockchain.register_contract_builder("file:../erc20/output/erc20.wasm", erc20::ContractBuilder);
 
     blockchain
 }

--- a/contracts/feature-tests/payable-features/tests/payable_mandos_rs_test.rs
+++ b/contracts/feature-tests/payable-features/tests/payable_mandos_rs_test.rs
@@ -5,7 +5,7 @@ fn world() -> BlockchainMock {
     blockchain.set_current_dir_from_workspace("contracts/feature-tests/payable-features");
     blockchain.register_contract_builder(
         "file:output/payable-features.wasm",
-        payable_features::contract_builder,
+        payable_features::ContractBuilder,
     );
     blockchain
 }

--- a/contracts/feature-tests/use-module/tests/use_module_mandos_rs_test.rs
+++ b/contracts/feature-tests/use-module/tests/use_module_mandos_rs_test.rs
@@ -32,9 +32,9 @@ use elrond_wasm_debug::*;
 fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
     blockchain
-        .register_contract_builder("file:output/use-module.wasm", use_module::contract_builder);
+        .register_contract_builder("file:output/use-module.wasm", use_module::ContractBuilder);
 
-    blockchain.register_contract_builder("file:test-wasm/dns.wasm", dns_mock::contract_builder);
+    blockchain.register_contract_builder("file:test-wasm/dns.wasm", dns_mock::ContractBuilder);
 
     blockchain
 }

--- a/elrond-wasm-debug/src/contract_map.rs
+++ b/elrond-wasm-debug/src/contract_map.rs
@@ -6,19 +6,19 @@ use alloc::{boxed::Box, vec::Vec};
 use elrond_wasm::contract_base::CallableContract;
 use std::{collections::HashMap, fmt};
 
-pub type ContractCallFactory<A> = Box<dyn Fn(DebugApi) -> Box<dyn CallableContract<A>>>;
+pub type ContractCallFactory = Box<dyn Fn(DebugApi) -> Box<dyn CallableContract>>;
 
-pub struct ContractMap<A> {
-    contract_objs: HashMap<Vec<u8>, Box<dyn CallableContract<A>>>,
+pub struct ContractMap {
+    contract_objs: HashMap<Vec<u8>, Box<dyn CallableContract>>,
 }
 
-impl<A> fmt::Debug for ContractMap<A> {
+impl fmt::Debug for ContractMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ContractMap").finish()
     }
 }
 
-impl<A> ContractMap<A> {
+impl ContractMap {
     pub fn new() -> Self {
         ContractMap {
             contract_objs: HashMap::new(),
@@ -29,7 +29,7 @@ impl<A> ContractMap<A> {
         &self,
         contract_identifier: &[u8],
         _debug_api: DebugApi,
-    ) -> Box<dyn CallableContract<A>> {
+    ) -> Box<dyn CallableContract> {
         if let Some(contract_obj) = self.contract_objs.get(contract_identifier) {
             contract_obj.clone_obj()
         } else {
@@ -40,7 +40,7 @@ impl<A> ContractMap<A> {
     pub fn register_contract(
         &mut self,
         contract_bytes: Vec<u8>,
-        new_contract_obj: Box<dyn CallableContract<A>>,
+        new_contract_obj: Box<dyn CallableContract>,
     ) {
         let previous_entry = self.contract_objs.insert(contract_bytes, new_contract_obj);
         assert!(previous_entry.is_none(), "contract inserted twice");
@@ -62,7 +62,7 @@ fn unknown_contract_panic(contract_identifier: &[u8]) -> ! {
     }
 }
 
-impl<A> Default for ContractMap<A> {
+impl Default for ContractMap {
     fn default() -> Self {
         Self::new()
     }

--- a/elrond-wasm-debug/src/testing_framework/contract_obj_wrapper.rs
+++ b/elrond-wasm-debug/src/testing_framework/contract_obj_wrapper.rs
@@ -19,7 +19,7 @@ use super::{
 };
 
 pub struct ContractObjWrapper<
-    CB: ContractBase<Api = DebugApi> + CallableContract<DebugApi> + 'static,
+    CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
     ContractObjBuilder: 'static + Copy + Fn() -> CB,
 > {
     pub(crate) address: Address,
@@ -28,7 +28,7 @@ pub struct ContractObjWrapper<
 
 impl<CB, ContractObjBuilder> ContractObjWrapper<CB, ContractObjBuilder>
 where
-    CB: ContractBase<Api = DebugApi> + CallableContract<DebugApi> + 'static,
+    CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
     ContractObjBuilder: 'static + Copy + Fn() -> CB,
 {
     pub(crate) fn new(address: Address, obj_builder: ContractObjBuilder) -> Self {
@@ -179,7 +179,7 @@ impl BlockchainStateWrapper {
         contract_wasm_path: &str,
     ) -> ContractObjWrapper<CB, ContractObjBuilder>
     where
-        CB: ContractBase<Api = DebugApi> + CallableContract<DebugApi> + 'static,
+        CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
     {
         let address = self.address_factory.new_sc_address();
@@ -506,7 +506,7 @@ impl BlockchainStateWrapper {
         egld_payment: &num_bigint::BigUint,
         tx_fn: TxFn,
     ) where
-        CB: ContractBase<Api = DebugApi> + CallableContract<DebugApi> + 'static,
+        CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
     {
         self.execute_tx_any(caller, sc_wrapper, egld_payment, Vec::new(), tx_fn);
@@ -521,7 +521,7 @@ impl BlockchainStateWrapper {
         esdt_amount: &num_bigint::BigUint,
         tx_fn: TxFn,
     ) where
-        CB: ContractBase<Api = DebugApi> + CallableContract<DebugApi> + 'static,
+        CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
     {
         let esdt_transfer = vec![TxInputESDT {
@@ -539,7 +539,7 @@ impl BlockchainStateWrapper {
         esdt_transfers: &[TxInputESDT],
         tx_fn: TxFn,
     ) where
-        CB: ContractBase<Api = DebugApi> + CallableContract<DebugApi> + 'static,
+        CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
     {
         self.execute_tx_any(
@@ -556,7 +556,7 @@ impl BlockchainStateWrapper {
         sc_wrapper: &ContractObjWrapper<CB, ContractObjBuilder>,
         query_fn: TxFn,
     ) where
-        CB: ContractBase<Api = DebugApi> + CallableContract<DebugApi> + 'static,
+        CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
     {
         self.execute_tx(
@@ -579,7 +579,7 @@ impl BlockchainStateWrapper {
         esdt_payments: Vec<TxInputESDT>,
         tx_fn: TxFn,
     ) where
-        CB: ContractBase<Api = DebugApi> + CallableContract<DebugApi> + 'static,
+        CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
     {
         let sc_address = sc_wrapper.address_ref();
@@ -717,9 +717,9 @@ fn serialize_attributes<T: TopEncode>(attributes: &T) -> Vec<u8> {
 
 fn create_contract_obj_box<CB, ContractObjBuilder>(
     func: ContractObjBuilder,
-) -> Box<dyn CallableContract<DebugApi>>
+) -> Box<dyn CallableContract>
 where
-    CB: ContractBase<Api = DebugApi> + CallableContract<DebugApi> + 'static,
+    CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
     ContractObjBuilder: 'static + Fn() -> CB,
 {
     let c_base = func();

--- a/elrond-wasm-debug/src/testing_framework/contract_obj_wrapper.rs
+++ b/elrond-wasm-debug/src/testing_framework/contract_obj_wrapper.rs
@@ -216,7 +216,7 @@ impl BlockchainStateWrapper {
 
             let b_mock_ref = Rc::get_mut(&mut self.rc_b_mock).unwrap();
             // let contract_obj = closure(DebugApi::new_from_static());
-            b_mock_ref.register_contract_old(&wasm_full_path_as_expr, contract_obj);
+            b_mock_ref.register_contract_obj(&wasm_full_path_as_expr, contract_obj);
         }
 
         ContractObjWrapper::new(address, obj_builder)

--- a/elrond-wasm-debug/src/tx_execution/exec_contract_endpoint.rs
+++ b/elrond-wasm-debug/src/tx_execution/exec_contract_endpoint.rs
@@ -54,7 +54,7 @@ fn get_contract_identifier(tx_context: &TxContext) -> Vec<u8> {
 
 /// The actual execution and the extraction/wrapping of results.
 fn execute_contract_instance_endpoint(
-    contract_instance: Box<dyn CallableContract<DebugApi>>,
+    contract_instance: Box<dyn CallableContract>,
     endpoint_name: &[u8],
 ) -> TxResult {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/elrond-wasm-debug/src/world_mock/blockchain_mock.rs
+++ b/elrond-wasm-debug/src/world_mock/blockchain_mock.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, path::PathBuf, rc::Rc};
 
 use crate::{
     tx_mock::{BlockchainUpdate, TxCache},
-    ContractMap, DebugApi,
+    ContractMap,
 };
 
 use super::{AccountData, BlockInfo};
@@ -19,7 +19,7 @@ pub struct BlockchainMock {
     pub new_addresses: HashMap<(Address, u64), Address>,
     pub previous_block_info: BlockInfo,
     pub current_block_info: BlockInfo,
-    pub contract_map: ContractMap<DebugApi>,
+    pub contract_map: ContractMap,
     pub current_dir: PathBuf,
 }
 

--- a/elrond-wasm-debug/src/world_mock/blockchain_mock_init.rs
+++ b/elrond-wasm-debug/src/world_mock/blockchain_mock_init.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use elrond_wasm::contract_base::CallableContract;
+use elrond_wasm::contract_base::{CallableContract, CallableContractBuilder};
 use mandos::{interpret_trait::InterpreterContext, value_interpreter::interpret_string};
 
 use crate::DebugApi;
@@ -35,7 +35,7 @@ impl BlockchainMock {
     pub fn register_contract_old(
         &mut self,
         expression: &str,
-        new_contract_obj: Box<dyn CallableContract<DebugApi>>,
+        new_contract_obj: Box<dyn CallableContract>,
     ) {
         let contract_bytes = interpret_string(
             expression,
@@ -45,11 +45,19 @@ impl BlockchainMock {
             .register_contract(contract_bytes, new_contract_obj);
     }
 
-    pub fn register_contract_builder(
+    // pub fn register_contract_builder(
+    //     &mut self,
+    //     expression: &str,
+    //     contract_builder: fn() -> Box<dyn CallableContract>,
+    // ) {
+    //     self.register_contract_old(expression, contract_builder())
+    // }
+
+    pub fn register_contract_builder<B: CallableContractBuilder>(
         &mut self,
         expression: &str,
-        contract_builder: fn() -> Box<dyn CallableContract<DebugApi>>,
+        contract_builder: B,
     ) {
-        self.register_contract_old(expression, contract_builder())
+        self.register_contract_old(expression, contract_builder.new_contract_obj::<DebugApi>())
     }
 }

--- a/elrond-wasm-debug/src/world_mock/blockchain_mock_init.rs
+++ b/elrond-wasm-debug/src/world_mock/blockchain_mock_init.rs
@@ -32,7 +32,7 @@ impl BlockchainMock {
         self.current_dir = path;
     }
 
-    pub fn register_contract_old(
+    pub fn register_contract_obj(
         &mut self,
         expression: &str,
         new_contract_obj: Box<dyn CallableContract>,
@@ -45,19 +45,11 @@ impl BlockchainMock {
             .register_contract(contract_bytes, new_contract_obj);
     }
 
-    // pub fn register_contract_builder(
-    //     &mut self,
-    //     expression: &str,
-    //     contract_builder: fn() -> Box<dyn CallableContract>,
-    // ) {
-    //     self.register_contract_old(expression, contract_builder())
-    // }
-
     pub fn register_contract_builder<B: CallableContractBuilder>(
         &mut self,
         expression: &str,
         contract_builder: B,
     ) {
-        self.register_contract_old(expression, contract_builder.new_contract_obj::<DebugApi>())
+        self.register_contract_obj(expression, contract_builder.new_contract_obj::<DebugApi>())
     }
 }

--- a/elrond-wasm-debug/tests/sample_adder.rs
+++ b/elrond-wasm-debug/tests/sample_adder.rs
@@ -434,10 +434,6 @@ fn test_add() {
 
 fn world() -> elrond_wasm_debug::BlockchainMock {
     let mut blockchain = elrond_wasm_debug::BlockchainMock::new();
-    // blockchain.register_contract_old(
-    //     "file:../contracts/examples/adder/output/adder.wasm",
-    //     sample_adder::ContractBuilder::<DebugApi>(),
-    // );
     blockchain.register_contract_builder(
         "file:../contracts/examples/adder/output/adder.wasm",
         sample_adder::ContractBuilder,

--- a/elrond-wasm-derive/src/generate/snippets.rs
+++ b/elrond-wasm-derive/src/generate/snippets.rs
@@ -31,13 +31,16 @@ pub fn new_contract_object_fn() -> proc_macro2::TokenStream {
             }
         }
 
-        pub fn contract_builder<A>() -> elrond_wasm::Box<dyn elrond_wasm::contract_base::CallableContract<A>>
-        where
-            A: elrond_wasm::api::VMApi,
-        {
-            elrond_wasm::Box::new(ContractObj {
-                _phantom: core::marker::PhantomData,
-            })
+        pub struct ContractBuilder;
+
+        impl elrond_wasm::contract_base::CallableContractBuilder for self::ContractBuilder {
+            fn new_contract_obj<A: elrond_wasm::api::VMApi>(
+                &self,
+            ) -> elrond_wasm::Box<dyn elrond_wasm::contract_base::CallableContract> {
+                elrond_wasm::Box::new(ContractObj::<A> {
+                    _phantom: core::marker::PhantomData,
+                })
+            }
         }
     }
 }
@@ -59,7 +62,7 @@ pub fn impl_auto_impl() -> proc_macro2::TokenStream {
 
 pub fn impl_callable_contract() -> proc_macro2::TokenStream {
     quote! {
-        impl<A> elrond_wasm::contract_base::CallableContract<A> for ContractObj<A>
+        impl<A> elrond_wasm::contract_base::CallableContract for ContractObj<A>
         where
             A: elrond_wasm::api::VMApi,
         {
@@ -67,8 +70,10 @@ pub fn impl_callable_contract() -> proc_macro2::TokenStream {
                 EndpointWrappers::call(self, fn_name)
             }
 
-            fn clone_obj(&self) -> elrond_wasm::Box<dyn elrond_wasm::contract_base::CallableContract<A>> {
-                self::contract_builder()
+            fn clone_obj(&self) -> elrond_wasm::Box<dyn elrond_wasm::contract_base::CallableContract> {
+                elrond_wasm::Box::new(ContractObj::<A> {
+                    _phantom: core::marker::PhantomData,
+                })
             }
         }
     }

--- a/elrond-wasm/src/contract_base/callable_contract.rs
+++ b/elrond-wasm/src/contract_base/callable_contract.rs
@@ -1,8 +1,15 @@
 use alloc::boxed::Box;
 
+use crate::api::VMApi;
+
 /// CallableContract is the means by which the debugger calls methods in the contract.
-pub trait CallableContract<A> {
+pub trait CallableContract {
     fn call(&self, fn_name: &[u8]) -> bool;
 
-    fn clone_obj(&self) -> Box<dyn CallableContract<A>>;
+    fn clone_obj(&self) -> Box<dyn CallableContract>;
+}
+
+/// Describes objects that can create instances of contract objects, with the given API.
+pub trait CallableContractBuilder {
+    fn new_contract_obj<A: VMApi>(&self) -> Box<dyn CallableContract>;
 }

--- a/elrond-wasm/src/contract_base/mod.rs
+++ b/elrond-wasm/src/contract_base/mod.rs
@@ -5,7 +5,7 @@ mod proxy_obj_base;
 mod proxy_obj_callback_base;
 mod wrappers;
 
-pub use callable_contract::CallableContract;
+pub use callable_contract::{CallableContract, CallableContractBuilder};
 pub use contract_abi_provider::ContractAbiProvider;
 pub use contract_base_trait::ContractBase;
 pub use proxy_obj_base::ProxyObjBase;


### PR DESCRIPTION
Removed the API generic from CallableContract and ContractMap. This means we can insert contracts with different APIs in the structure.

Using `CallableContractBuilder` instead of a `fn() -> Box<dyn CallableContract<A>>` to instance contract objects allows easier instantiation of contracts with different APIs.