### PR TITLE
`require!` macro redesign + Rust testing framework panic handling

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,7 +21,7 @@ jobs:
           source .github/workflows/env
           pip3 install erdpy
           mkdir $HOME/elrondsdk
-          erdpy config set dependencies.vmtools.tag v1.4.34
+          erdpy config set dependencies.vmtools.tag v1.4.36
           erdpy deps install vmtools
       - name: Build the wasm contracts
         run: |

--- a/contracts/examples/crowdfunding-esdt/src/crowdfunding_esdt.rs
+++ b/contracts/examples/crowdfunding-esdt/src/crowdfunding_esdt.rs
@@ -19,16 +19,16 @@ pub trait Crowdfunding {
         deadline: u64,
         token_identifier: TokenIdentifier,
     ) -> SCResult<()> {
-        require!(target > 0, "Target must be more than 0");
+        require_old!(target > 0, "Target must be more than 0");
         self.target().set(target);
 
-        require!(
+        require_old!(
             deadline > self.get_current_time(),
             "Deadline can't be in the past"
         );
         self.deadline().set(deadline);
 
-        require!(
+        require_old!(
             token_identifier.is_egld() || token_identifier.is_valid_esdt_identifier(),
             "Invalid token provided"
         );
@@ -44,11 +44,11 @@ pub trait Crowdfunding {
         #[payment_token] token: TokenIdentifier,
         #[payment] payment: BigUint,
     ) -> SCResult<()> {
-        require!(
+        require_old!(
             self.status() == Status::FundingPeriod,
             "cannot fund after deadline"
         );
-        require!(token == self.cf_token_identifier().get(), "wrong token");
+        require_old!(token == self.cf_token_identifier().get(), "wrong token");
 
         let caller = self.blockchain().get_caller();
         self.deposit(&caller).update(|deposit| *deposit += payment);
@@ -80,7 +80,7 @@ pub trait Crowdfunding {
             Status::FundingPeriod => sc_error!("cannot claim before deadline"),
             Status::Successful => {
                 let caller = self.blockchain().get_caller();
-                require!(
+                require_old!(
                     caller == self.blockchain().get_owner_address(),
                     "only owner can claim successful funding"
                 );

--- a/contracts/examples/crypto-bubbles/src/crypto_bubbles.rs
+++ b/contracts/examples/crypto-bubbles/src/crypto_bubbles.rs
@@ -29,7 +29,7 @@ pub trait CryptoBubbles {
     /// server calls withdraw on behalf of the player
     fn transfer_back_to_player_wallet(&self, player: &Address, amount: &BigUint) -> SCResult<()> {
         self.player_balance(player).update(|balance| {
-            require!(
+            require_old!(
                 amount <= balance,
                 "amount to withdraw must be less or equal to balance"
             );
@@ -55,7 +55,7 @@ pub trait CryptoBubbles {
         bet: &BigUint,
     ) -> SCResult<()> {
         self.player_balance(player).update(|balance| {
-            require!(bet <= balance, "insufficient funds to join game");
+            require_old!(bet <= balance, "insufficient funds to join game");
 
             *balance -= bet;
 

--- a/contracts/examples/digital-cash/tests/digital_cash_mandos_go_test.rs
+++ b/contracts/examples/digital-cash/tests/digital_cash_mandos_go_test.rs
@@ -1,14 +1,12 @@
-// TODO: uncomment after upgrading to VM 1.4.35
-// #[test]
-// fn claim_egld_go() {
-//     elrond_wasm_debug::mandos_go("mandos/claim-egld.scen.json");
-// }
+#[test]
+fn claim_egld_go() {
+    elrond_wasm_debug::mandos_go("mandos/claim-egld.scen.json");
+}
 
-// TODO: uncomment after upgrading to VM 1.4.35
-// #[test]
-// fn claim_esdt_go() {
-//     elrond_wasm_debug::mandos_go("mandos/claim-esdt.scen.json");
-// }
+#[test]
+fn claim_esdt_go() {
+    elrond_wasm_debug::mandos_go("mandos/claim-esdt.scen.json");
+}
 
 #[test]
 fn fund_egld_and_esdt_go() {

--- a/contracts/examples/digital-cash/tests/digital_cash_mandos_go_test.rs
+++ b/contracts/examples/digital-cash/tests/digital_cash_mandos_go_test.rs
@@ -29,4 +29,3 @@ fn withdraw_egld_go() {
 fn withdraw_esdt_go() {
     elrond_wasm_debug::mandos_go("mandos/withdraw-esdt.scen.json");
 }
-

--- a/contracts/examples/digital-cash/tests/digital_cash_mandos_rs_test.rs
+++ b/contracts/examples/digital-cash/tests/digital_cash_mandos_rs_test.rs
@@ -42,4 +42,3 @@ fn withdraw_egld_rs() {
 fn withdraw_esdt_rs() {
     elrond_wasm_debug::mandos_rs("mandos/withdraw-esdt.scen.json", world());
 }
-

--- a/contracts/feature-tests/basic-features/src/macro_features.rs
+++ b/contracts/feature-tests/basic-features/src/macro_features.rs
@@ -5,9 +5,10 @@ use elrond_wasm::String;
 /// Various macros provided by elrond-wasm.
 #[elrond_wasm::module]
 pub trait Macros {
+    #[allow(deprecated)]
     #[view]
     fn only_owner_legacy(&self) -> SCResult<()> {
-        only_owner!(self, "Caller must be owner");
+        elrond_wasm::only_owner!(self, "Caller must be owner");
         Ok(())
     }
 

--- a/contracts/feature-tests/formatted-message-features/src/formatted_message_features.rs
+++ b/contracts/feature-tests/formatted-message-features/src/formatted_message_features.rs
@@ -9,12 +9,12 @@ pub trait FormattedMessageFeatures {
 
     #[endpoint]
     fn static_message(&self) {
-        signal_error!("Static error");
+        sc_panic!("Static error");
     }
 
     #[endpoint]
     fn dynamic_message(&self, bytes: ManagedBuffer) {
-        signal_error!("Got this buffer: {:x}. I don't like it, ERROR!", bytes);
+        sc_panic!("Got this buffer: {:x}. I don't like it, ERROR!", bytes);
     }
 
     #[payable("*")]
@@ -25,7 +25,7 @@ pub trait FormattedMessageFeatures {
         #[payment_nonce] nonce: u64,
         #[payment_amount] amount: BigUint,
     ) {
-        signal_error!(
+        sc_panic!(
             "Got token {:x}, with nonce {:x}, amount {:x}. I prefer EGLD. ERROR!",
             token_id,
             nonce,
@@ -41,7 +41,7 @@ pub trait FormattedMessageFeatures {
         #[payment_nonce] nonce: u64,
         #[payment_amount] amount: BigUint,
     ) {
-        signal_error!(
+        sc_panic!(
             "Got token {}, with nonce {:x}, amount {:x}. I prefer EGLD. ERROR!",
             token_id,
             nonce,

--- a/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
@@ -30,7 +30,7 @@ pub trait RustTestingFrameworkTester: dummy_module::DummyModule {
 
     #[endpoint]
     fn sum_sc_result(&self, first: BigUint, second: BigUint) -> SCResult<BigUint> {
-        require!(first > 0 && second > 0, "Non-zero required");
+        require_old!(first > 0 && second > 0, "Non-zero required");
         Ok(first + second)
     }
 

--- a/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
@@ -29,9 +29,9 @@ pub trait RustTestingFrameworkTester: dummy_module::DummyModule {
     }
 
     #[endpoint]
-    fn sum_sc_result(&self, first: BigUint, second: BigUint) -> SCResult<BigUint> {
-        require_old!(first > 0 && second > 0, "Non-zero required");
-        Ok(first + second)
+    fn sum_sc_result(&self, first: BigUint, second: BigUint) -> BigUint {
+        require!(first > 0 && second > 0, "Non-zero required");
+        first + second
     }
 
     #[endpoint]

--- a/contracts/feature-tests/rust-testing-framework-tester/tests/rust_testing_framework-test.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/tests/rust_testing_framework-test.rs
@@ -3,12 +3,11 @@ use forwarder::call_sync::*;
 use num_traits::ToPrimitive;
 
 use elrond_wasm::types::{
-    BigInt, EsdtLocalRole, EsdtTokenPayment, EsdtTokenType, ManagedBuffer, ManagedVec, SCResult,
+    BigInt, EsdtLocalRole, EsdtTokenPayment, EsdtTokenType, ManagedBuffer, ManagedVec,
 };
 use elrond_wasm_debug::{
-    assert_sc_error, assert_values_eq, managed_address, managed_biguint, managed_buffer,
-    managed_token_id, rust_biguint, testing_framework::*, tx_mock::TxInputESDT, unwrap_or_panic,
-    DebugApi,
+    assert_values_eq, managed_address, managed_biguint, managed_buffer, managed_token_id,
+    rust_biguint, testing_framework::*, tx_mock::TxInputESDT, DebugApi,
 };
 use rust_testing_framework_tester::{dummy_module::DummyModule, *};
 
@@ -29,14 +28,16 @@ fn test_add() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let first = managed_biguint!(1000);
-        let second = managed_biguint!(2000);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let first = managed_biguint!(1000);
+            let second = managed_biguint!(2000);
 
-        let expected_result = first.clone() + second.clone();
-        let actual_result = sc.sum(first, second);
-        assert_values_eq!(expected_result, actual_result);
-    });
+            let expected_result = first.clone() + second.clone();
+            let actual_result = sc.sum(first, second);
+            assert_values_eq!(expected_result, actual_result);
+        })
+        .assert_ok();
 }
 
 #[should_panic]
@@ -50,14 +51,16 @@ fn test_add_wrong_expect() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let first = managed_biguint!(1000);
-        let second = managed_biguint!(2000);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let first = managed_biguint!(1000);
+            let second = managed_biguint!(2000);
 
-        let expected_result = first.clone() + second.clone() + 1u32;
-        let actual_result = sc.sum(first, second);
-        assert_values_eq!(expected_result, actual_result);
-    });
+            let expected_result = first.clone() + second.clone() + 1u32;
+            let actual_result = sc.sum(first, second);
+            assert_values_eq!(expected_result, actual_result);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -70,14 +73,16 @@ fn test_sc_result_ok() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let first = managed_biguint!(1000);
-        let second = managed_biguint!(2000);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let first = managed_biguint!(1000);
+            let second = managed_biguint!(2000);
 
-        let expected_result = SCResult::Ok(first.clone() + second.clone());
-        let actual_result = sc.sum_sc_result(first, second);
-        assert_eq!(expected_result, actual_result);
-    });
+            let expected_result = first.clone() + second.clone();
+            let actual_result = sc.sum_sc_result(first, second);
+            assert_eq!(expected_result, actual_result);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -90,14 +95,16 @@ fn test_sc_result_ok_unwrap() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let first = managed_biguint!(1000);
-        let second = managed_biguint!(2000);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let first = managed_biguint!(1000);
+            let second = managed_biguint!(2000);
 
-        let expected_result = first.clone() + second.clone();
-        let actual_result = unwrap_or_panic!(sc.sum_sc_result(first, second));
-        assert_eq!(expected_result, actual_result);
-    });
+            let expected_result = first.clone() + second.clone();
+            let actual_result = sc.sum_sc_result(first, second);
+            assert_eq!(expected_result, actual_result);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -110,13 +117,14 @@ fn test_sc_result_err() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let first = managed_biguint!(0);
-        let second = managed_biguint!(2000);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let first = managed_biguint!(0);
+            let second = managed_biguint!(2000);
 
-        let actual_result = sc.sum_sc_result(first, second);
-        assert_sc_error!(actual_result, "Non-zero required");
-    });
+            let _ = sc.sum_sc_result(first, second);
+        })
+        .assert_user_error("Non-zero required");
 }
 
 #[should_panic(expected = "Non-zero required")]
@@ -130,17 +138,18 @@ fn test_sc_result_err_unwrap() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let first = managed_biguint!(0);
-        let second = managed_biguint!(2000);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let first = managed_biguint!(0);
+            let second = managed_biguint!(2000);
 
-        let result_err = sc.sum_sc_result(first, second);
-        unwrap_or_panic!(result_err);
-    });
+            let _ = sc.sum_sc_result(first, second);
+        })
+        .assert_ok();
 }
 
 #[should_panic(
-    expected = "Expected SCError, but got SCResult::Ok: BigUint { handle: 0, hex-value-be: \"0bb8\" }"
+    expected = "Tx error message mismatch. Want status 4, message \"Non-zero required\". Have status 0, message \"\""
 )]
 #[test]
 fn test_assert_err_with_ok() {
@@ -152,13 +161,15 @@ fn test_assert_err_with_ok() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let first = managed_biguint!(1000);
-        let second = managed_biguint!(2000);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let first = managed_biguint!(1000);
+            let second = managed_biguint!(2000);
 
-        let actual_result = sc.sum_sc_result(first, second);
-        assert_sc_error!(actual_result, "Non-zero required");
-    });
+            let _ = sc.sum_sc_result(first, second);
+            // assert_sc_error!(actual_result, "Non-zero required");
+        })
+        .assert_user_error("Non-zero required");
 }
 
 #[test]
@@ -173,13 +184,15 @@ fn test_sc_payment_ok() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(1_000), |sc| {
-        let actual_payment = sc.receive_egld();
-        let expected_payment = managed_biguint!(1_000);
-        assert_eq!(actual_payment, expected_payment);
+    wrapper
+        .execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(1_000), |sc| {
+            let actual_payment = sc.receive_egld();
+            let expected_payment = managed_biguint!(1_000);
+            assert_eq!(actual_payment, expected_payment);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_egld_balance(&caller_addr, &rust_biguint!(0));
     wrapper.check_egld_balance(sc_wrapper.address_ref(), &rust_biguint!(3_000));
@@ -197,13 +210,15 @@ fn test_sc_payment_reverted() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(1_000), |sc| {
-        let actual_payment = sc.receive_egld();
-        let expected_payment = managed_biguint!(1_000);
-        assert_eq!(actual_payment, expected_payment);
+    wrapper
+        .execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(1_000), |sc| {
+            let actual_payment = sc.receive_egld();
+            let expected_payment = managed_biguint!(1_000);
+            assert_eq!(actual_payment, expected_payment);
 
-        StateChange::Revert
-    });
+            StateChange::Revert
+        })
+        .assert_ok();
 
     wrapper.check_egld_balance(&caller_addr, &rust_biguint!(1_000));
     wrapper.check_egld_balance(sc_wrapper.address_ref(), &rust_biguint!(2_000));
@@ -221,11 +236,13 @@ fn test_sc_half_payment() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(1_000), |sc| {
-        sc.recieve_egld_half();
+    wrapper
+        .execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(1_000), |sc| {
+            sc.recieve_egld_half();
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_egld_balance(&caller_addr, &rust_biguint!(500));
     wrapper.check_egld_balance(sc_wrapper.address_ref(), &rust_biguint!(2_500));
@@ -245,13 +262,15 @@ fn test_esdt_balance() {
     wrapper.set_esdt_balance(sc_wrapper.address_ref(), token_id, &rust_biguint!(1_000));
     wrapper.check_esdt_balance(sc_wrapper.address_ref(), token_id, &rust_biguint!(1_000));
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let managed_id = managed_token_id!(token_id);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let managed_id = managed_token_id!(token_id);
 
-        let actual_balance = sc.get_esdt_balance(managed_id, 0);
-        let expected_balance = managed_biguint!(1_000);
-        assert_eq!(expected_balance, actual_balance);
-    });
+            let actual_balance = sc.get_esdt_balance(managed_id, 0);
+            let expected_balance = managed_biguint!(1_000);
+            assert_eq!(expected_balance, actual_balance);
+        })
+        .assert_ok();
 
     wrapper.add_mandos_check_account(sc_wrapper.address_ref());
     wrapper.write_mandos_output(TEST_ESDT_OUTPUT_PATH);
@@ -274,22 +293,24 @@ fn test_esdt_payment_ok() {
     wrapper.set_esdt_balance(&caller_addr, token_id, &rust_biguint!(1_000));
     wrapper.set_esdt_balance(sc_wrapper.address_ref(), token_id, &rust_biguint!(2_000));
 
-    wrapper.execute_esdt_transfer(
-        &caller_addr,
-        &sc_wrapper,
-        token_id,
-        0,
-        &rust_biguint!(1_000),
-        |sc| {
-            let (actual_token_id, actual_payment) = sc.receive_esdt();
-            let expected_payment = managed_biguint!(1_000);
+    wrapper
+        .execute_esdt_transfer(
+            &caller_addr,
+            &sc_wrapper,
+            token_id,
+            0,
+            &rust_biguint!(1_000),
+            |sc| {
+                let (actual_token_id, actual_payment) = sc.receive_esdt();
+                let expected_payment = managed_biguint!(1_000);
 
-            assert_eq!(actual_token_id, managed_token_id!(token_id));
-            assert_eq!(actual_payment, expected_payment);
+                assert_eq!(actual_token_id, managed_token_id!(token_id));
+                assert_eq!(actual_payment, expected_payment);
 
-            StateChange::Commit
-        },
-    );
+                StateChange::Commit
+            },
+        )
+        .assert_ok();
 
     wrapper.check_esdt_balance(&caller_addr, token_id, &rust_zero);
     wrapper.check_esdt_balance(sc_wrapper.address_ref(), token_id, &rust_biguint!(3_000));
@@ -312,22 +333,24 @@ fn test_esdt_payment_reverted() {
     wrapper.set_esdt_balance(&caller_addr, token_id, &rust_biguint!(1_000));
     wrapper.set_esdt_balance(sc_wrapper.address_ref(), token_id, &rust_biguint!(2_000));
 
-    wrapper.execute_esdt_transfer(
-        &caller_addr,
-        &sc_wrapper,
-        token_id,
-        0,
-        &rust_biguint!(1_000),
-        |sc| {
-            let (actual_token_id, actual_payment) = sc.receive_esdt();
-            let expected_payment = managed_biguint!(1_000);
+    wrapper
+        .execute_esdt_transfer(
+            &caller_addr,
+            &sc_wrapper,
+            token_id,
+            0,
+            &rust_biguint!(1_000),
+            |sc| {
+                let (actual_token_id, actual_payment) = sc.receive_esdt();
+                let expected_payment = managed_biguint!(1_000);
 
-            assert_eq!(actual_token_id, managed_token_id!(token_id));
-            assert_eq!(actual_payment, expected_payment);
+                assert_eq!(actual_token_id, managed_token_id!(token_id));
+                assert_eq!(actual_payment, expected_payment);
 
-            StateChange::Revert
-        },
-    );
+                StateChange::Revert
+            },
+        )
+        .assert_ok();
 
     wrapper.check_esdt_balance(&caller_addr, token_id, &rust_biguint!(1_000));
     wrapper.check_esdt_balance(sc_wrapper.address_ref(), token_id, &rust_biguint!(2_000));
@@ -365,13 +388,15 @@ fn test_nft_balance() {
         &nft_attributes,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let managed_id = managed_token_id!(token_id);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let managed_id = managed_token_id!(token_id);
 
-        let actual_balance = sc.get_esdt_balance(managed_id, nft_nonce);
-        let expected_balance = managed_biguint!(1_000);
-        assert_eq!(expected_balance, actual_balance);
-    });
+            let actual_balance = sc.get_esdt_balance(managed_id, nft_nonce);
+            let expected_balance = managed_biguint!(1_000);
+            assert_eq!(expected_balance, actual_balance);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -407,14 +432,16 @@ fn test_sc_send_nft_to_user() {
         &nft_attributes,
     );
 
-    wrapper.execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
-        let managed_addr = managed_address!(&caller_addr);
-        let managed_id = managed_token_id!(token_id);
-        let managed_amt = managed_biguint!(400);
-        sc.send_nft(managed_addr, managed_id, nft_nonce, managed_amt);
+    wrapper
+        .execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
+            let managed_addr = managed_address!(&caller_addr);
+            let managed_id = managed_token_id!(token_id);
+            let managed_amt = managed_biguint!(400);
+            sc.send_nft(managed_addr, managed_id, nft_nonce, managed_amt);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_nft_balance(
         &caller_addr,
@@ -450,23 +477,27 @@ fn test_sc_esdt_mint_burn() {
         &[EsdtLocalRole::Mint, EsdtLocalRole::Burn][..],
     );
 
-    wrapper.execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
-        let managed_id = managed_token_id!(token_id);
-        let managed_amt = managed_biguint!(400);
-        sc.mint_esdt(managed_id, 0, managed_amt);
+    wrapper
+        .execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
+            let managed_id = managed_token_id!(token_id);
+            let managed_amt = managed_biguint!(400);
+            sc.mint_esdt(managed_id, 0, managed_amt);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_esdt_balance(sc_wrapper.address_ref(), token_id, &rust_biguint!(400));
 
-    wrapper.execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
-        let managed_id = managed_token_id!(token_id);
-        let managed_amt = managed_biguint!(100);
-        sc.burn_esdt(managed_id, 0, managed_amt);
+    wrapper
+        .execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
+            let managed_id = managed_token_id!(token_id);
+            let managed_amt = managed_biguint!(100);
+            sc.burn_esdt(managed_id, 0, managed_amt);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_esdt_balance(sc_wrapper.address_ref(), token_id, &rust_biguint!(300));
 }
@@ -497,22 +528,24 @@ fn test_sc_nft() {
         ][..],
     );
 
-    wrapper.execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
-        let managed_id = managed_token_id!(token_id);
-        let managed_amt = managed_biguint!(100);
+    wrapper
+        .execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
+            let managed_id = managed_token_id!(token_id);
+            let managed_amt = managed_biguint!(100);
 
-        let nft_nonce = sc.create_nft(
-            managed_id.clone(),
-            managed_amt.clone(),
-            nft_attributes.clone(),
-        );
-        assert_eq!(nft_nonce, 1u64);
+            let nft_nonce = sc.create_nft(
+                managed_id.clone(),
+                managed_amt.clone(),
+                nft_attributes.clone(),
+            );
+            assert_eq!(nft_nonce, 1u64);
 
-        let nft_nonce_second = sc.create_nft(managed_id, managed_amt, nft_attributes.clone());
-        assert_eq!(nft_nonce_second, 2u64);
+            let nft_nonce_second = sc.create_nft(managed_id, managed_amt, nft_attributes.clone());
+            assert_eq!(nft_nonce_second, 2u64);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_nft_balance(
         sc_wrapper.address_ref(),
@@ -529,13 +562,15 @@ fn test_sc_nft() {
         &nft_attributes,
     );
 
-    wrapper.execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
-        let managed_id = managed_token_id!(token_id);
-        let managed_amt = managed_biguint!(100);
-        sc.mint_esdt(managed_id, 1, managed_amt);
+    wrapper
+        .execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
+            let managed_id = managed_token_id!(token_id);
+            let managed_amt = managed_biguint!(100);
+            sc.mint_esdt(managed_id, 1, managed_amt);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_nft_balance(
         sc_wrapper.address_ref(),
@@ -552,13 +587,15 @@ fn test_sc_nft() {
         &nft_attributes,
     );
 
-    wrapper.execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
-        let managed_id = managed_token_id!(token_id);
-        let managed_amt = managed_biguint!(50);
-        sc.burn_esdt(managed_id, 2, managed_amt);
+    wrapper
+        .execute_tx(&caller_addr, &sc_wrapper, &rust_biguint!(0), |sc| {
+            let managed_id = managed_token_id!(token_id);
+            let managed_amt = managed_biguint!(50);
+            sc.burn_esdt(managed_id, 2, managed_amt);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_nft_balance(
         sc_wrapper.address_ref(),
@@ -606,42 +643,44 @@ fn test_esdt_multi_transfer() {
         },
     ];
 
-    wrapper.execute_esdt_multi_transfer(&caller_addr, &sc_wrapper, &transfers, |sc| {
-        let mut expected_transfers = Vec::new();
-        expected_transfers.push(EsdtTokenPayment::new(
-            managed_token_id!(token_id_1),
-            0,
-            managed_biguint!(100),
-        ));
-        expected_transfers.push(EsdtTokenPayment::new(
-            managed_token_id!(token_id_2),
-            nft_nonce,
-            managed_biguint!(1),
-        ));
+    wrapper
+        .execute_esdt_multi_transfer(&caller_addr, &sc_wrapper, &transfers, |sc| {
+            let mut expected_transfers = Vec::new();
+            expected_transfers.push(EsdtTokenPayment::new(
+                managed_token_id!(token_id_1),
+                0,
+                managed_biguint!(100),
+            ));
+            expected_transfers.push(EsdtTokenPayment::new(
+                managed_token_id!(token_id_2),
+                nft_nonce,
+                managed_biguint!(1),
+            ));
 
-        let actual_transfers = sc.receive_multi_esdt().into_vec();
-        assert_eq!(
-            expected_transfers[0].token_identifier,
-            actual_transfers[0].token_identifier
-        );
-        assert_eq!(
-            expected_transfers[0].token_nonce,
-            actual_transfers[0].token_nonce
-        );
-        assert_eq!(expected_transfers[0].amount, actual_transfers[0].amount);
+            let actual_transfers = sc.receive_multi_esdt().into_vec();
+            assert_eq!(
+                expected_transfers[0].token_identifier,
+                actual_transfers[0].token_identifier
+            );
+            assert_eq!(
+                expected_transfers[0].token_nonce,
+                actual_transfers[0].token_nonce
+            );
+            assert_eq!(expected_transfers[0].amount, actual_transfers[0].amount);
 
-        assert_eq!(
-            expected_transfers[1].token_identifier,
-            actual_transfers[1].token_identifier
-        );
-        assert_eq!(
-            expected_transfers[1].token_nonce,
-            actual_transfers[1].token_nonce
-        );
-        assert_eq!(expected_transfers[1].amount, actual_transfers[1].amount);
+            assert_eq!(
+                expected_transfers[1].token_identifier,
+                actual_transfers[1].token_identifier
+            );
+            assert_eq!(
+                expected_transfers[1].token_nonce,
+                actual_transfers[1].token_nonce
+            );
+            assert_eq!(expected_transfers[1].amount, actual_transfers[1].amount);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_esdt_balance(sc_wrapper.address_ref(), token_id_1, &rust_biguint!(100));
     wrapper.check_nft_balance(
@@ -683,44 +722,50 @@ fn storage_check_test() {
     );
 
     // simulate deploy
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        sc.init();
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            sc.init();
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        let total_before = sc.total_value().get();
-        let per_caller_before = sc.value_per_caller(&managed_address!(&user_addr)).get();
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            let total_before = sc.total_value().get();
+            let per_caller_before = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(total_before, managed_biguint!(1));
-        assert_eq!(per_caller_before, managed_biguint!(0));
+            assert_eq!(total_before, managed_biguint!(1));
+            assert_eq!(per_caller_before, managed_biguint!(0));
 
-        let added_value = managed_biguint!(50);
-        sc.add(added_value.clone());
+            let added_value = managed_biguint!(50);
+            sc.add(added_value.clone());
 
-        let expected_total_after = total_before + added_value.clone();
-        let expected_per_caller_after = per_caller_before + added_value;
+            let expected_total_after = total_before + added_value.clone();
+            let expected_per_caller_after = per_caller_before + added_value;
 
-        let actual_total_after = sc.total_value().get();
-        let actual_per_caller_after = sc.value_per_caller(&managed_address!(&user_addr)).get();
+            let actual_total_after = sc.total_value().get();
+            let actual_per_caller_after = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(expected_total_after, actual_total_after);
-        assert_eq!(expected_per_caller_after, actual_per_caller_after);
+            assert_eq!(expected_total_after, actual_total_after);
+            assert_eq!(expected_per_caller_after, actual_per_caller_after);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let expected_total = managed_biguint!(51);
-        let expected_per_caller = managed_biguint!(50);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let expected_total = managed_biguint!(51);
+            let expected_per_caller = managed_biguint!(50);
 
-        let actual_total = sc.total_value().get();
-        let actual_per_caller = sc.value_per_caller(&managed_address!(&user_addr)).get();
+            let actual_total = sc.total_value().get();
+            let actual_per_caller = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(expected_total, actual_total);
-        assert_eq!(expected_per_caller, actual_per_caller);
-    });
+            assert_eq!(expected_total, actual_total);
+            assert_eq!(expected_per_caller, actual_per_caller);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -736,44 +781,50 @@ fn storage_revert_test() {
     );
 
     // simulate deploy
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        sc.init();
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            sc.init();
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        let total_before = sc.total_value().get();
-        let per_caller_before = sc.value_per_caller(&managed_address!(&user_addr)).get();
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            let total_before = sc.total_value().get();
+            let per_caller_before = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(total_before, managed_biguint!(1));
-        assert_eq!(per_caller_before, managed_biguint!(0));
+            assert_eq!(total_before, managed_biguint!(1));
+            assert_eq!(per_caller_before, managed_biguint!(0));
 
-        let added_value = managed_biguint!(50);
-        sc.add(added_value.clone());
+            let added_value = managed_biguint!(50);
+            sc.add(added_value.clone());
 
-        let expected_total_after = total_before + added_value.clone();
-        let expected_per_caller_after = per_caller_before + added_value;
+            let expected_total_after = total_before + added_value.clone();
+            let expected_per_caller_after = per_caller_before + added_value;
 
-        let actual_total_after = sc.total_value().get();
-        let actual_per_caller_after = sc.value_per_caller(&managed_address!(&user_addr)).get();
+            let actual_total_after = sc.total_value().get();
+            let actual_per_caller_after = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(expected_total_after, actual_total_after);
-        assert_eq!(expected_per_caller_after, actual_per_caller_after);
+            assert_eq!(expected_total_after, actual_total_after);
+            assert_eq!(expected_per_caller_after, actual_per_caller_after);
 
-        StateChange::Revert
-    });
+            StateChange::Revert
+        })
+        .assert_ok();
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let expected_total = managed_biguint!(1);
-        let expected_per_caller = managed_biguint!(0);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let expected_total = managed_biguint!(1);
+            let expected_per_caller = managed_biguint!(0);
 
-        let actual_total = sc.total_value().get();
-        let actual_per_caller = sc.value_per_caller(&managed_address!(&user_addr)).get();
+            let actual_total = sc.total_value().get();
+            let actual_per_caller = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(expected_total, actual_total);
-        assert_eq!(expected_per_caller, actual_per_caller);
-    });
+            assert_eq!(expected_total, actual_total);
+            assert_eq!(expected_per_caller, actual_per_caller);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -789,29 +840,35 @@ fn storage_set_test() {
     );
 
     // simulate deploy
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        sc.init();
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            sc.init();
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        sc.total_value().set(&managed_biguint!(50));
-        sc.value_per_caller(&managed_address!(&user_addr))
-            .set(&managed_biguint!(50));
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            sc.total_value().set(&managed_biguint!(50));
+            sc.value_per_caller(&managed_address!(&user_addr))
+                .set(&managed_biguint!(50));
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let expected_value = managed_biguint!(50);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let expected_value = managed_biguint!(50);
 
-        let actual_total = sc.total_value().get();
-        let actual_per_caller = sc.value_per_caller(&managed_address!(&user_addr)).get();
+            let actual_total = sc.total_value().get();
+            let actual_per_caller = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(expected_value, actual_total);
-        assert_eq!(expected_value, actual_per_caller);
-    });
+            assert_eq!(expected_value, actual_total);
+            assert_eq!(expected_value, actual_per_caller);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -833,15 +890,17 @@ fn blockchain_state_test() {
     wrapper.set_block_nonce(expected_nonce);
     wrapper.set_block_timestamp(expected_timestamp);
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let actual_epoch = sc.get_block_epoch();
-        let actual_nonce = sc.get_block_nonce();
-        let actual_timestamp = sc.get_block_timestamp();
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let actual_epoch = sc.get_block_epoch();
+            let actual_nonce = sc.get_block_nonce();
+            let actual_timestamp = sc.get_block_timestamp();
 
-        assert_eq!(expected_epoch, actual_epoch);
-        assert_eq!(expected_nonce, actual_nonce);
-        assert_eq!(expected_timestamp, actual_timestamp);
-    });
+            assert_eq!(expected_epoch, actual_epoch);
+            assert_eq!(expected_nonce, actual_nonce);
+            assert_eq!(expected_timestamp, actual_timestamp);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -862,20 +921,24 @@ fn execute_on_dest_context_query_test() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_tx(&user_addr, &other_sc_wrapper, &rust_zero, |sc| {
-        sc.total_value().set(&managed_biguint!(5));
-        StateChange::Commit
-    });
+    wrapper
+        .execute_tx(&user_addr, &other_sc_wrapper, &rust_zero, |sc| {
+            sc.total_value().set(&managed_biguint!(5));
+            StateChange::Commit
+        })
+        .assert_ok();
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let expected_result = managed_biguint!(5);
-        let actual_result =
-            sc.call_other_contract_execute_on_dest(managed_address!(&other_sc_wrapper
-                .address_ref()
-                .clone()));
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let expected_result = managed_biguint!(5);
+            let actual_result =
+                sc.call_other_contract_execute_on_dest(managed_address!(&other_sc_wrapper
+                    .address_ref()
+                    .clone()));
 
-        assert_eq!(expected_result, actual_result);
-    });
+            assert_eq!(expected_result, actual_result);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -896,25 +959,31 @@ fn execute_on_dest_context_change_state_test() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_tx(&user_addr, &other_sc_wrapper, &rust_zero, |sc| {
-        sc.total_value().set(&managed_biguint!(5));
-        StateChange::Commit
-    });
+    wrapper
+        .execute_tx(&user_addr, &other_sc_wrapper, &rust_zero, |sc| {
+            sc.total_value().set(&managed_biguint!(5));
+            StateChange::Commit
+        })
+        .assert_ok();
 
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        sc.execute_on_dest_add_value(
-            managed_address!(&other_sc_wrapper.address_ref().clone()),
-            managed_biguint!(5),
-        );
-        StateChange::Commit
-    });
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            sc.execute_on_dest_add_value(
+                managed_address!(&other_sc_wrapper.address_ref().clone()),
+                managed_biguint!(5),
+            );
+            StateChange::Commit
+        })
+        .assert_ok();
 
-    wrapper.execute_query(&other_sc_wrapper, |sc| {
-        let expected_result = managed_biguint!(10);
-        let actual_result = sc.get_val();
+    wrapper
+        .execute_query(&other_sc_wrapper, |sc| {
+            let expected_result = managed_biguint!(10);
+            let actual_result = sc.get_val();
 
-        assert_eq!(expected_result, actual_result);
-    });
+            assert_eq!(expected_result, actual_result);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -930,11 +999,13 @@ fn test_mandos_generation() {
     );
 
     // simulate deploy
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        sc.init();
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            sc.init();
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
     wrapper.add_mandos_set_account(sc_wrapper.address_ref());
     wrapper.add_mandos_check_account(sc_wrapper.address_ref());
 
@@ -946,27 +1017,29 @@ fn test_mandos_generation() {
     let tx_expect = TxExpectMandos::new(0);
     wrapper.add_mandos_sc_call(sc_call_mandos, Some(tx_expect));
 
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        let total_before = sc.total_value().get();
-        let per_caller_before = sc.value_per_caller(&managed_address!(&user_addr)).get();
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            let total_before = sc.total_value().get();
+            let per_caller_before = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(total_before, managed_biguint!(1));
-        assert_eq!(per_caller_before, managed_biguint!(0));
+            assert_eq!(total_before, managed_biguint!(1));
+            assert_eq!(per_caller_before, managed_biguint!(0));
 
-        let added_value = managed_biguint!(50);
-        sc.add(added_value.clone());
+            let added_value = managed_biguint!(50);
+            sc.add(added_value.clone());
 
-        let expected_total_after = total_before + added_value.clone();
-        let expected_per_caller_after = per_caller_before + added_value;
+            let expected_total_after = total_before + added_value.clone();
+            let expected_per_caller_after = per_caller_before + added_value;
 
-        let actual_total_after = sc.total_value().get();
-        let actual_per_caller_after = sc.value_per_caller(&managed_address!(&user_addr)).get();
+            let actual_total_after = sc.total_value().get();
+            let actual_per_caller_after = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(expected_total_after, actual_total_after);
-        assert_eq!(expected_per_caller_after, actual_per_caller_after);
+            assert_eq!(expected_total_after, actual_total_after);
+            assert_eq!(expected_per_caller_after, actual_per_caller_after);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
     wrapper.add_mandos_check_account(sc_wrapper.address_ref());
 
     let expected_value = rust_biguint!(51);
@@ -977,16 +1050,18 @@ fn test_mandos_generation() {
 
     wrapper.add_mandos_sc_query(sc_query_mandos, Some(query_expect));
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let expected_total = managed_biguint!(51);
-        let expected_per_caller = managed_biguint!(50);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let expected_total = managed_biguint!(51);
+            let expected_per_caller = managed_biguint!(50);
 
-        let actual_total = sc.total_value().get();
-        let actual_per_caller = sc.value_per_caller(&managed_address!(&user_addr)).get();
+            let actual_total = sc.total_value().get();
+            let actual_per_caller = sc.value_per_caller(&managed_address!(&user_addr)).get();
 
-        assert_eq!(expected_total, actual_total);
-        assert_eq!(expected_per_caller, actual_per_caller);
-    });
+            assert_eq!(expected_total, actual_total);
+            assert_eq!(expected_per_caller, actual_per_caller);
+        })
+        .assert_ok();
 
     wrapper.write_mandos_output(TEST_OUTPUT_PATH);
 }
@@ -1027,24 +1102,30 @@ fn test_async_call() {
     let adder_wrapper =
         wrapper.create_sc_account(&rust_zero, None, adder::contract_obj, ADDER_WASM_PATH);
 
-    wrapper.execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
-        let adder_address = managed_address!(adder_wrapper.address_ref());
-        let value_to_add = managed_biguint!(10);
-        sc.call_other_contract_add_async_call(adder_address, value_to_add);
+    wrapper
+        .execute_tx(&user_addr, &sc_wrapper, &rust_zero, |sc| {
+            let adder_address = managed_address!(adder_wrapper.address_ref());
+            let value_to_add = managed_biguint!(10);
+            sc.call_other_contract_add_async_call(adder_address, value_to_add);
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let callback_executed = sc.callback_executed().get();
-        assert!(callback_executed);
-    });
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let callback_executed = sc.callback_executed().get();
+            assert!(callback_executed);
+        })
+        .assert_ok();
 
-    wrapper.execute_query(&adder_wrapper, |sc| {
-        let current_sum = sc.sum().get();
-        let expected_sum = BigInt::from(10);
-        assert_eq!(current_sum, expected_sum);
-    });
+    wrapper
+        .execute_query(&adder_wrapper, |sc| {
+            let current_sum = sc.sum().get();
+            let expected_sum = BigInt::from(10);
+            assert_eq!(current_sum, expected_sum);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -1116,11 +1197,13 @@ fn test_random_buffer() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let rand_buffer = sc.get_random_buffer_once(2);
-        let expected_buffer = managed_buffer!(&[0x8b, 0xdd]);
-        assert_eq!(rand_buffer, expected_buffer);
-    });
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let rand_buffer = sc.get_random_buffer_once(2);
+            let expected_buffer = managed_buffer!(&[0x8b, 0xdd]);
+            assert_eq!(rand_buffer, expected_buffer);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -1133,15 +1216,17 @@ fn test_random_buffer_twice() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let (rand_buffer_1, rand_buffer_2) = sc.get_random_buffer_twice(2, 2);
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let (rand_buffer_1, rand_buffer_2) = sc.get_random_buffer_twice(2, 2);
 
-        let expected_buffer_1 = managed_buffer!(&[0x8b, 0xdd]);
-        let expected_buffer_2 = managed_buffer!(&[0xbe, 0x24]);
+            let expected_buffer_1 = managed_buffer!(&[0x8b, 0xdd]);
+            let expected_buffer_2 = managed_buffer!(&[0xbe, 0x24]);
 
-        assert_eq!(rand_buffer_1, expected_buffer_1);
-        assert_eq!(rand_buffer_2, expected_buffer_2);
-    });
+            assert_eq!(rand_buffer_1, expected_buffer_1);
+            assert_eq!(rand_buffer_2, expected_buffer_2);
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -1154,9 +1239,11 @@ fn test_modules() {
         SC_WASM_PATH,
     );
 
-    wrapper.execute_query(&sc_wrapper, |sc| {
-        let _ = sc.some_function();
-    });
+    wrapper
+        .execute_query(&sc_wrapper, |sc| {
+            let _ = sc.some_function();
+        })
+        .assert_ok();
 }
 
 #[test]
@@ -1206,30 +1293,32 @@ fn test_back_and_forth_transfers() {
         value: second_token_amount.clone(),
     });
 
-    wrapper.execute_esdt_multi_transfer(&user, &forwarder_wrapper, &transfers, |sc| {
-        let mut managed_payments = ManagedVec::new();
-        managed_payments.push(EsdtTokenPayment {
-            token_type: EsdtTokenType::Fungible,
-            token_identifier: managed_token_id!(&first_token_id[..]),
-            token_nonce: 0,
-            amount: managed_biguint!(first_token_amount.to_u64().unwrap()),
-        });
-        managed_payments.push(EsdtTokenPayment {
-            token_type: EsdtTokenType::Fungible,
-            token_identifier: managed_token_id!(&second_token_id[..]),
-            token_nonce: 0,
-            amount: managed_biguint!(second_token_amount.to_u64().unwrap()),
-        });
+    wrapper
+        .execute_esdt_multi_transfer(&user, &forwarder_wrapper, &transfers, |sc| {
+            let mut managed_payments = ManagedVec::new();
+            managed_payments.push(EsdtTokenPayment {
+                token_type: EsdtTokenType::Fungible,
+                token_identifier: managed_token_id!(&first_token_id[..]),
+                token_nonce: 0,
+                amount: managed_biguint!(first_token_amount.to_u64().unwrap()),
+            });
+            managed_payments.push(EsdtTokenPayment {
+                token_type: EsdtTokenType::Fungible,
+                token_identifier: managed_token_id!(&second_token_id[..]),
+                token_nonce: 0,
+                amount: managed_biguint!(second_token_amount.to_u64().unwrap()),
+            });
 
-        sc.forward_sync_retrieve_funds_with_accept_func(
-            managed_payments,
-            managed_address!(vault_wrapper.address_ref()),
-            managed_token_id!(&third_token_id[..]),
-            managed_biguint!(third_token_amount.to_u64().unwrap()),
-        );
+            sc.forward_sync_retrieve_funds_with_accept_func(
+                managed_payments,
+                managed_address!(vault_wrapper.address_ref()),
+                managed_token_id!(&third_token_id[..]),
+                managed_biguint!(third_token_amount.to_u64().unwrap()),
+            );
 
-        StateChange::Commit
-    });
+            StateChange::Commit
+        })
+        .assert_ok();
 
     wrapper.check_esdt_balance(
         forwarder_wrapper.address_ref(),

--- a/contracts/feature-tests/use-module/use_module_expected_main.abi.json
+++ b/contracts/feature-tests/use-module/use_module_expected_main.abi.json
@@ -88,6 +88,7 @@
         },
         {
             "name": "dnsRegister",
+            "onlyOwner": true,
             "mutability": "mutable",
             "payableInTokens": [
                 "EGLD"
@@ -106,6 +107,7 @@
         },
         {
             "name": "issueToken",
+            "onlyOwner": true,
             "mutability": "mutable",
             "payableInTokens": [
                 "EGLD"
@@ -131,6 +133,7 @@
                 "optional address to set roles for. Defaults to SC's address."
             ],
             "name": "setLocalRoles",
+            "onlyOwner": true,
             "mutability": "mutable",
             "inputs": [
                 {
@@ -365,6 +368,7 @@
                 "to not modify parameters manually"
             ],
             "name": "initGovernanceModule",
+            "onlyOwner": true,
             "mutability": "mutable",
             "inputs": [
                 {

--- a/elrond-wasm-debug/src/mandos_step/transfer.rs
+++ b/elrond-wasm-debug/src/mandos_step/transfer.rs
@@ -20,5 +20,5 @@ pub fn execute(state: &mut Rc<BlockchainMock>, tx_transfer: &TxTransfer) {
         gas_price: tx_transfer.gas_price.value,
         tx_hash: H256::zero(),
     };
-    sc_call(tx_input, state, true);
+    let _ = sc_call(tx_input, state, true);
 }

--- a/elrond-wasm-debug/src/mandos_step/transfer.rs
+++ b/elrond-wasm-debug/src/mandos_step/transfer.rs
@@ -20,5 +20,5 @@ pub fn execute(state: &mut Rc<BlockchainMock>, tx_transfer: &TxTransfer) {
         gas_price: tx_transfer.gas_price.value,
         tx_hash: H256::zero(),
     };
-    let _ = sc_call(tx_input, state, true);
+    sc_call(tx_input, state, true).assert_ok();
 }

--- a/elrond-wasm-debug/src/testing_framework/contract_obj_wrapper.rs
+++ b/elrond-wasm-debug/src/testing_framework/contract_obj_wrapper.rs
@@ -8,7 +8,8 @@ use elrond_wasm::{
 
 use crate::{
     rust_biguint,
-    tx_mock::{TxCache, TxContext, TxContextStack, TxInput, TxInputESDT},
+    tx_execution::interpret_panic_as_tx_result,
+    tx_mock::{TxCache, TxContext, TxContextStack, TxInput, TxInputESDT, TxResult},
     world_mock::{AccountData, AccountEsdt, EsdtInstanceMetadata},
     BlockchainMock, DebugApi,
 };
@@ -499,20 +500,22 @@ impl BlockchainStateWrapper {
 }
 
 impl BlockchainStateWrapper {
-    pub fn execute_tx<CB, ContractObjBuilder, TxFn: FnOnce(CB) -> StateChange>(
+    pub fn execute_tx<CB, ContractObjBuilder, TxFn>(
         &mut self,
         caller: &Address,
         sc_wrapper: &ContractObjWrapper<CB, ContractObjBuilder>,
         egld_payment: &num_bigint::BigUint,
         tx_fn: TxFn,
-    ) where
+    ) -> TxResult
+    where
         CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
+        TxFn: FnOnce(CB) -> StateChange,
     {
-        self.execute_tx_any(caller, sc_wrapper, egld_payment, Vec::new(), tx_fn);
+        self.execute_tx_any(caller, sc_wrapper, egld_payment, Vec::new(), tx_fn)
     }
 
-    pub fn execute_esdt_transfer<CB, ContractObjBuilder, TxFn: FnOnce(CB) -> StateChange>(
+    pub fn execute_esdt_transfer<CB, ContractObjBuilder, TxFn>(
         &mut self,
         caller: &Address,
         sc_wrapper: &ContractObjWrapper<CB, ContractObjBuilder>,
@@ -520,16 +523,18 @@ impl BlockchainStateWrapper {
         esdt_nonce: u64,
         esdt_amount: &num_bigint::BigUint,
         tx_fn: TxFn,
-    ) where
+    ) -> TxResult
+    where
         CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
+        TxFn: FnOnce(CB) -> StateChange,
     {
         let esdt_transfer = vec![TxInputESDT {
             token_identifier: token_id.to_vec(),
             nonce: esdt_nonce,
             value: esdt_amount.clone(),
         }];
-        self.execute_tx_any(caller, sc_wrapper, &rust_biguint!(0), esdt_transfer, tx_fn);
+        self.execute_tx_any(caller, sc_wrapper, &rust_biguint!(0), esdt_transfer, tx_fn)
     }
 
     pub fn execute_esdt_multi_transfer<CB, ContractObjBuilder, TxFn: FnOnce(CB) -> StateChange>(
@@ -538,7 +543,8 @@ impl BlockchainStateWrapper {
         sc_wrapper: &ContractObjWrapper<CB, ContractObjBuilder>,
         esdt_transfers: &[TxInputESDT],
         tx_fn: TxFn,
-    ) where
+    ) -> TxResult
+    where
         CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
     {
@@ -548,14 +554,15 @@ impl BlockchainStateWrapper {
             &rust_biguint!(0),
             esdt_transfers.to_vec(),
             tx_fn,
-        );
+        )
     }
 
     pub fn execute_query<CB, ContractObjBuilder, TxFn: FnOnce(CB)>(
         &mut self,
         sc_wrapper: &ContractObjWrapper<CB, ContractObjBuilder>,
         query_fn: TxFn,
-    ) where
+    ) -> TxResult
+    where
         CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
     {
@@ -567,7 +574,7 @@ impl BlockchainStateWrapper {
                 query_fn(sc);
                 StateChange::Revert
             },
-        );
+        )
     }
 
     // deduplicates code for execution
@@ -578,7 +585,8 @@ impl BlockchainStateWrapper {
         egld_payment: &num_bigint::BigUint,
         esdt_payments: Vec<TxInputESDT>,
         tx_fn: TxFn,
-    ) where
+    ) -> TxResult
+    where
         CB: ContractBase<Api = DebugApi> + CallableContract + 'static,
         ContractObjBuilder: 'static + Copy + Fn() -> CB,
     {
@@ -614,17 +622,20 @@ impl BlockchainStateWrapper {
         TxContextStack::static_push(tx_context_rc);
 
         let sc = (sc_wrapper.obj_builder)();
-        let state_change = tx_fn(sc);
+        let result_state_change =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| tx_fn(sc)));
 
         let api_after_exec = Rc::try_unwrap(TxContextStack::static_pop()).unwrap();
         let updates = api_after_exec.into_blockchain_updates();
 
         let b_mock_ref = Rc::get_mut(&mut self.rc_b_mock).unwrap();
-        match state_change {
-            StateChange::Commit => {
+        match result_state_change {
+            Ok(StateChange::Commit) => {
                 updates.apply(b_mock_ref);
+                TxResult::empty()
             },
-            StateChange::Revert => {},
+            Ok(StateChange::Revert) => TxResult::empty(),
+            Err(panic_any) => interpret_panic_as_tx_result(panic_any),
         }
     }
 

--- a/elrond-wasm-debug/src/tx_execution/exec_contract_endpoint.rs
+++ b/elrond-wasm-debug/src/tx_execution/exec_contract_endpoint.rs
@@ -69,11 +69,15 @@ fn execute_contract_instance_endpoint(
     }));
     match result {
         Ok(tx_output) => tx_output,
-        Err(panic_any) => panic_result(panic_any),
+        Err(panic_any) => interpret_panic_as_tx_result(panic_any),
     }
 }
 
-fn panic_result(panic_any: Box<dyn std::any::Any + std::marker::Send>) -> TxResult {
+/// Interprets a panic thrown during execution as a tx failure.
+/// Note: specific tx outcomes from the debugger are signalled via specific panic objects.
+pub fn interpret_panic_as_tx_result(
+    panic_any: Box<dyn std::any::Any + std::marker::Send>,
+) -> TxResult {
     if panic_any.downcast_ref::<TxResult>().is_some() {
         // async calls panic with the tx output directly
         // it is not a failure, simply a way to kill the execution

--- a/elrond-wasm-debug/src/tx_mock/tx_result.rs
+++ b/elrond-wasm-debug/src/tx_mock/tx_result.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use super::{TxLog, TxPanic, TxResultCalls};
 
 #[derive(Clone, Default, Debug)]
+#[must_use]
 pub struct TxResult {
     pub result_status: u64,
     pub result_message: String,
@@ -90,5 +91,37 @@ impl TxResult {
             );
             self.result_calls.async_call = Some(sync_result_async.clone());
         }
+    }
+
+    pub fn assert_ok(&self) {
+        assert!(
+            self.result_status == 0,
+            "Tx success expected, but failed. Status: {}, message: \"{}\"",
+            self.result_status,
+            self.result_message.as_str()
+        );
+    }
+
+    pub fn assert_error(&self, expected_status: u64, expected_message: &str) {
+        assert!(
+            self.result_message.as_str() == expected_message,
+            "Tx error message mismatch. Want status {}, message \"{}\". Have status {}, message \"{}\"",
+            expected_status,
+            expected_message,
+            self.result_status,
+            self.result_message.as_str()
+        );
+        assert!(
+            self.result_status == expected_status,
+            "Tx error status mismatch. Want status {}, message \"{}\". Have status {}, message \"{}\"",
+            expected_status,
+            expected_message,
+            self.result_status,
+            self.result_message.as_str()
+        );
+    }
+
+    pub fn assert_user_error(&self, expected_message: &str) {
+        self.assert_error(4, expected_message);
     }
 }

--- a/elrond-wasm-derive/src/format/format_args_macro.rs
+++ b/elrond-wasm-derive/src/format/format_args_macro.rs
@@ -14,10 +14,14 @@ pub fn format_receiver_args_macro(input: proc_macro::TokenStream) -> proc_macro:
     let mut tokens_iter = tokens.into_iter();
 
     let accumulator_expr = tokens_iter.next().unwrap();
-    let format_string = if let proc_macro::TokenTree::Literal(lit) = tokens_iter.next().unwrap() {
+    let format_string_token = tokens_iter.next().unwrap();
+    let format_string = if let proc_macro::TokenTree::Literal(lit) = format_string_token {
         lit.to_string()
     } else {
-        panic!("First argument should be the format string");
+        panic!(
+            "Formatting requires that the first argument is a string. Found: {}",
+            format_string_token
+        );
     };
 
     let format_str_parts = parse_format_string(&format_string);

--- a/elrond-wasm-modules/src/dns.rs
+++ b/elrond-wasm-modules/src/dns.rs
@@ -22,18 +22,16 @@ pub trait DnsModule {
     fn dns_proxy(&self, to: ManagedAddress) -> dns_proxy::Proxy<Self::Api>;
 
     #[payable("EGLD")]
+    #[only_owner]
     #[endpoint(dnsRegister)]
     fn dns_register(
         &self,
         dns_address: ManagedAddress,
         name: BoxedBytes,
         #[payment] payment: BigUint,
-    ) -> SCResult<AsyncCall> {
-        only_owner!(self, "only owner can call dnsRegister");
-
-        Ok(self
-            .dns_proxy(dns_address)
+    ) -> AsyncCall {
+        self.dns_proxy(dns_address)
             .register(name, payment)
-            .async_call())
+            .async_call()
     }
 }

--- a/elrond-wasm-modules/src/esdt.rs
+++ b/elrond-wasm-modules/src/esdt.rs
@@ -17,6 +17,7 @@ pub trait EsdtModule {
     fn token_id(&self) -> SingleValueMapper<TokenIdentifier>;
 
     #[payable("EGLD")]
+    #[only_owner]
     #[endpoint(issueToken)]
     fn issue_token(
         &self,
@@ -24,14 +25,12 @@ pub trait EsdtModule {
         token_ticker: ManagedBuffer,
         num_decimals: usize,
         #[payment] issue_cost: BigUint,
-    ) -> SCResult<AsyncCall> {
-        only_owner!(self, "only owner can issue token");
+    ) -> AsyncCall {
         require!(self.token_id().is_empty(), "Token already issued");
 
         let initial_supply = BigUint::from(1u32);
 
-        Ok(self
-            .send()
+        self.send()
             .esdt_system_sc_proxy()
             .issue_fungible(
                 issue_cost,
@@ -51,17 +50,16 @@ pub trait EsdtModule {
                 },
             )
             .async_call()
-            .with_callback(self.callbacks().issue_callback()))
+            .with_callback(self.callbacks().issue_callback())
     }
 
     /// optional address to set roles for. Defaults to SC's address.
+    #[only_owner]
     #[endpoint(setLocalRoles)]
     fn set_local_roles(
         &self,
         #[var_args] opt_dest_address: OptionalArg<ManagedAddress>,
-    ) -> SCResult<AsyncCall> {
-        only_owner!(self, "only owner can set roles");
-
+    ) -> AsyncCall {
         let dest_address = match opt_dest_address {
             OptionalArg::Some(addr) => addr,
             OptionalArg::None => self.blockchain().get_sc_address(),
@@ -69,11 +67,10 @@ pub trait EsdtModule {
         let token_id = self.token_id().get();
         let roles = [EsdtLocalRole::Mint, EsdtLocalRole::Burn];
 
-        Ok(self
-            .send()
+        self.send()
             .esdt_system_sc_proxy()
             .set_special_roles(&dest_address, &token_id, (&roles[..]).into_iter().cloned())
-            .async_call())
+            .async_call()
     }
 
     #[callback]

--- a/elrond-wasm-modules/src/governance/governance_configurable.rs
+++ b/elrond-wasm-modules/src/governance/governance_configurable.rs
@@ -33,6 +33,7 @@ pub trait GovernanceConfigurablePropertiesModule {
 
     /// The module can't protect its storage from the main SC, so it's the developers responsibility
     /// to not modify parameters manually
+    #[only_owner]
     #[endpoint(initGovernanceModule)]
     fn init_governance_module(
         &self,
@@ -44,7 +45,6 @@ pub trait GovernanceConfigurablePropertiesModule {
         voting_period_in_blocks: u64,
         lock_time_after_voting_ends_in_blocks: u64,
     ) -> SCResult<()> {
-        only_owner!(self, "Only owner may initialize governance module");
         require!(
             governance_token_id.is_valid_esdt_identifier(),
             "Invalid ESDT token ID provided for governance_token_id"

--- a/elrond-wasm/src/contract_base/wrappers/error_helper.rs
+++ b/elrond-wasm/src/contract_base/wrappers/error_helper.rs
@@ -23,35 +23,33 @@ impl<M: ManagedTypeApi> ErrorHelper<M> {
 
     pub fn signal_error_with_message<T>(message: T) -> !
     where
-        T: IntoSignalErrorMessage<M>,
+        T: IntoSignalError<M>,
     {
         message.signal_error_with_message()
     }
-
-    pub fn signal_error_with_buffer_handle<T>(handle: i32) -> ! {
-        M::error_api_impl().signal_error_from_buffer(handle)
-    }
 }
 
-pub trait IntoSignalErrorMessage<M: ManagedTypeApi> {
+/// Indicates how an object can be used as the basis for performing `signal_error` with itself as message.
+pub trait IntoSignalError<M: ManagedTypeApi> {
     fn signal_error_with_message(self) -> !;
 }
 
-impl<M: ManagedTypeApi> IntoSignalErrorMessage<M> for &str {
+impl<M: ManagedTypeApi> IntoSignalError<M> for &str {
     #[inline]
     fn signal_error_with_message(self) -> ! {
         M::error_api_impl().signal_error(self.as_bytes())
     }
 }
 
-impl<M: ManagedTypeApi> IntoSignalErrorMessage<M> for &[u8] {
+impl<M: ManagedTypeApi> IntoSignalError<M> for &[u8] {
     #[inline]
     fn signal_error_with_message(self) -> ! {
         M::error_api_impl().signal_error(self)
     }
 }
 
-impl<M, B> IntoSignalErrorMessage<M> for B
+// Handles `ManagedBuffer`, `&ManagedBuffer` and `ManagedRef<ManagedBuffer>`.
+impl<M, B> IntoSignalError<M> for B
 where
     M: ManagedTypeApi,
     B: Borrow<ManagedBuffer<M>>,

--- a/elrond-wasm/src/contract_base/wrappers/error_helper.rs
+++ b/elrond-wasm/src/contract_base/wrappers/error_helper.rs
@@ -1,6 +1,9 @@
-use core::marker::PhantomData;
+use core::{borrow::Borrow, marker::PhantomData};
 
-use crate::{api::ManagedTypeApi, types::ManagedSCError};
+use crate::{
+    api::{ErrorApiImpl, ManagedTypeApi},
+    types::{ManagedBuffer, ManagedSCError, ManagedType},
+};
 
 #[derive(Default)]
 pub struct ErrorHelper<M: ManagedTypeApi> {
@@ -16,5 +19,44 @@ impl<M: ManagedTypeApi> ErrorHelper<M> {
 
     pub fn new_error(&self) -> ManagedSCError<M> {
         ManagedSCError::new_empty()
+    }
+
+    pub fn signal_error_with_message<T>(message: T) -> !
+    where
+        T: IntoSignalErrorMessage<M>,
+    {
+        message.signal_error_with_message()
+    }
+
+    pub fn signal_error_with_buffer_handle<T>(handle: i32) -> ! {
+        M::error_api_impl().signal_error_from_buffer(handle)
+    }
+}
+
+pub trait IntoSignalErrorMessage<M: ManagedTypeApi> {
+    fn signal_error_with_message(self) -> !;
+}
+
+impl<M: ManagedTypeApi> IntoSignalErrorMessage<M> for &str {
+    #[inline]
+    fn signal_error_with_message(self) -> ! {
+        M::error_api_impl().signal_error(self.as_bytes())
+    }
+}
+
+impl<M: ManagedTypeApi> IntoSignalErrorMessage<M> for &[u8] {
+    #[inline]
+    fn signal_error_with_message(self) -> ! {
+        M::error_api_impl().signal_error(self)
+    }
+}
+
+impl<M, B> IntoSignalErrorMessage<M> for B
+where
+    M: ManagedTypeApi,
+    B: Borrow<ManagedBuffer<M>>,
+{
+    fn signal_error_with_message(self) -> ! {
+        M::error_api_impl().signal_error_from_buffer(self.borrow().get_raw_handle())
     }
 }

--- a/elrond-wasm/src/macros.rs
+++ b/elrond-wasm/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! imports {
             io::*,
             non_zero_usize,
             non_zero_util::*,
-            only_owner, require, require_old, sc_error, sc_panic, sc_print,
+            require, require_old, sc_error, sc_panic, sc_print,
             storage::mappers::*,
             types::{
                 SCResult::{Err, Ok},
@@ -174,6 +174,10 @@ macro_rules! sc_try {
 /// }
 /// # }
 /// ```
+#[deprecated(
+    since = "0.26.0",
+    note = "Replace with the `#[only_owner]` attribute that can be placed on an endpoint. That one is more compact and shows up in the ABI."
+)]
 #[macro_export]
 macro_rules! only_owner {
     ($trait_self: expr, $error_msg:expr) => {

--- a/elrond-wasm/src/macros.rs
+++ b/elrond-wasm/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! imports {
             io::*,
             non_zero_usize,
             non_zero_util::*,
-            only_owner, require, sc_error, signal_error, sc_print,
+            only_owner, require, require_old, sc_error, sc_panic, sc_print,
             storage::mappers::*,
             types::{
                 SCResult::{Err, Ok},
@@ -58,16 +58,76 @@ macro_rules! sc_error {
     };
 }
 
+/// Allows us to write Solidity style `require!(<condition>, <error_msg>)` and avoid if statements.
+///
+/// It can only be used in a function that returns `SCResult<_>` where _ can be any type.
+///
+/// Example:
+///
+/// ```rust
+/// # use elrond_wasm::require_old;
+/// # use elrond_wasm::types::{*, SCResult::Ok};
+/// # pub trait ExampleContract: elrond_wasm::contract_base::ContractBase
+/// # {
+/// fn only_accept_positive_old(&self, x: i32) -> SCResult<()> {
+///     require_old!(x > 0, "only positive values accepted");
+///     Ok(())
+/// }
+/// # }
+/// ```
 #[macro_export]
-macro_rules! signal_error {
+macro_rules! require_old {
+    ($expression:expr, $error_msg:expr) => {
+        if (!($expression)) {
+            return elrond_wasm::sc_error!($error_msg);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! sc_panic {
     ($msg:tt, $($arg:expr),+) => {{
         let mut ___buffer___ =
             elrond_wasm::types::ManagedBufferCachedBuilder::<Self::Api>::new_from_slice(&[]);
         elrond_wasm::derive::format_receiver_args!(___buffer___, $msg, $($arg),+);
-        <Self::Api as elrond_wasm::api::ErrorApi>::error_api_impl().signal_error_from_buffer(___buffer___.into_managed_buffer().get_raw_handle());
+        elrond_wasm::contract_base::ErrorHelper::<Self::Api>::signal_error_with_message(___buffer___.into_managed_buffer());
     }};
     ($msg:tt) => {
-        <Self::Api as elrond_wasm::api::ErrorApi>::error_api_impl().signal_error($msg.as_bytes());
+        elrond_wasm::contract_base::ErrorHelper::<Self::Api>::signal_error_with_message($msg);
+    };
+}
+
+/// Allows us to write Solidity style `require!(<condition>, <error_msg>)` and avoid if statements.
+///
+/// The most common way to use it is to provide a string message with optional format arguments.
+///
+/// It is also possible to give the error as a variable of types such as `&str`, `&[u8]` or `ManagedBuffer`.
+///
+/// Examples:
+///
+/// ```rust
+/// # use elrond_wasm::{types::ManagedBuffer, require};
+/// # pub trait ExampleContract: elrond_wasm::contract_base::ContractBase
+/// # {
+/// fn only_accept_positive(&self, x: i32) {
+///     require!(x > 0, "only positive values accepted");
+/// }
+///
+/// fn only_accept_negative(&self, x: i32) {
+///     require!(x < 0, "only negative values accepted, {:x} is not negative", x);
+/// }
+///
+/// fn only_accept_zero(&self, x: i32, message: &ManagedBuffer<Self::Api>) {
+///     require!(x == 0, message);
+/// }
+/// # }
+/// ```
+#[macro_export]
+macro_rules! require {
+    ($expression:expr, $($msg_tokens:tt),+) => {
+        if (!($expression)) {
+            elrond_wasm::sc_panic!($($msg_tokens),+);
+        }
     };
 }
 
@@ -94,31 +154,6 @@ macro_rules! sc_try {
             elrond_wasm::types::SCResult::Err(e) => {
                 return elrond_wasm::types::SCResult::Err(e);
             },
-        }
-    };
-}
-
-/// Allows us to write Solidity style `require!(<condition>, <error_msg>)` and avoid if statements.
-///
-/// It can only be used in a function that returns `SCResult<_>` where _ can be any type.
-///
-/// ```rust
-/// # use elrond_wasm::*;
-/// # use elrond_wasm::api::BlockchainApi;
-/// # use elrond_wasm::types::{*, SCResult::Ok};
-/// # pub trait ExampleContract: elrond_wasm::contract_base::ContractBase
-/// # {
-/// fn only_callable_by_owner(&self) -> SCResult<()> {
-///     require!(self.blockchain().get_caller() == self.blockchain().get_owner_address(), "Caller must be owner");
-///     Ok(())
-/// }
-/// # }
-/// ```
-#[macro_export]
-macro_rules! require {
-    ($expression:expr, $error_msg:expr) => {
-        if (!($expression)) {
-            return sc_error!($error_msg);
         }
     };
 }


### PR DESCRIPTION
- `require!` calls signal_error immediately instead of return a sc error result
- the testing framework now handles panics