### PR TITLE
abi - nested type bugfix

### DIFF
--- a/contracts/feature-tests/abi-tester/abi_tester_expected_main.abi.json
+++ b/contracts/feature-tests/abi-tester/abi_tester_expected_main.abi.json
@@ -80,6 +80,18 @@
             ]
         },
         {
+            "name": "take_managed_type",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "_arg",
+                    "type": "AbiManagedType"
+                }
+            ],
+            "outputs": []
+        },
+        {
             "name": "multi_result_3",
             "mutability": "mutable",
             "inputs": [],
@@ -253,7 +265,100 @@
             "inputs": [],
             "outputs": [
                 {
-                    "type": "OnlyShowsUpAsNested10"
+                    "type": "OnlyShowsUpAsNestedInSingleValueMapper"
+                }
+            ]
+        },
+        {
+            "name": "item_for_vec",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "List<OnlyShowsUpAsNestedInVec>"
+                }
+            ]
+        },
+        {
+            "name": "item_for_array_vec",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "List<OnlyShowsUpAsNestedInArrayVec>"
+                }
+            ]
+        },
+        {
+            "name": "item_for_managed_vec",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "List<AbiManagedVecItem>"
+                }
+            ]
+        },
+        {
+            "name": "item_for_array",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "_array",
+                    "type": "array5<OnlyShowsUpAsNestedInArray>"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "item_for_box",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "OnlyShowsUpAsNestedInBox"
+                }
+            ]
+        },
+        {
+            "name": "item_for_boxed_slice",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "List<OnlyShowsUpAsNestedInBoxedSlice>"
+                }
+            ]
+        },
+        {
+            "name": "item_for_ref",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "_ref",
+                    "type": "OnlyShowsUpAsNestedInRef"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "item_for_slice",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "_ref",
+                    "type": "List<OnlyShowsUpAsNestedInSlice>"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "item_for_option",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "Option<OnlyShowsUpAsNestedInOption>"
                 }
             ]
         },
@@ -334,6 +439,42 @@
                             "type": "OnlyShowsUpAsNested09"
                         }
                     ]
+                }
+            ]
+        },
+        "AbiManagedType": {
+            "type": "struct",
+            "docs": [
+                "Its only purpose is to test that the ABI generator works fine."
+            ],
+            "fields": [
+                {
+                    "name": "big_uint",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "integer",
+                    "type": "i32"
+                },
+                {
+                    "name": "managed_buffer",
+                    "type": "bytes"
+                }
+            ]
+        },
+        "AbiManagedVecItem": {
+            "type": "struct",
+            "docs": [
+                "Its only purpose is to test that the ABI generator works fine."
+            ],
+            "fields": [
+                {
+                    "name": "value1",
+                    "type": "u32"
+                },
+                {
+                    "name": "value2",
+                    "type": "u32"
                 }
             ]
         },
@@ -543,7 +684,55 @@
                 "Tests that the ABI generator also fetches types that only appear as fields."
             ]
         },
-        "OnlyShowsUpAsNested10": {
+        "OnlyShowsUpAsNestedInArray": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInArrayVec": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInBox": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInBoxedSlice": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInOption": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInRef": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInSingleValueMapper": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInSlice": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInVec": {
             "type": "struct",
             "docs": [
                 "Tests that the ABI generator also fetches types that only appear as fields."

--- a/contracts/feature-tests/abi-tester/abi_tester_expected_view.abi.json
+++ b/contracts/feature-tests/abi-tester/abi_tester_expected_view.abi.json
@@ -84,6 +84,42 @@
                 }
             ]
         },
+        "AbiManagedType": {
+            "type": "struct",
+            "docs": [
+                "Its only purpose is to test that the ABI generator works fine."
+            ],
+            "fields": [
+                {
+                    "name": "big_uint",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "integer",
+                    "type": "i32"
+                },
+                {
+                    "name": "managed_buffer",
+                    "type": "bytes"
+                }
+            ]
+        },
+        "AbiManagedVecItem": {
+            "type": "struct",
+            "docs": [
+                "Its only purpose is to test that the ABI generator works fine."
+            ],
+            "fields": [
+                {
+                    "name": "value1",
+                    "type": "u32"
+                },
+                {
+                    "name": "value2",
+                    "type": "u32"
+                }
+            ]
+        },
         "AbiTestType": {
             "type": "struct",
             "docs": [
@@ -290,7 +326,55 @@
                 "Tests that the ABI generator also fetches types that only appear as fields."
             ]
         },
-        "OnlyShowsUpAsNested10": {
+        "OnlyShowsUpAsNestedInArray": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInArrayVec": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInBox": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInBoxedSlice": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInOption": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInRef": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInSingleValueMapper": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInSlice": {
+            "type": "struct",
+            "docs": [
+                "Tests that the ABI generator also fetches types that only appear as fields."
+            ]
+        },
+        "OnlyShowsUpAsNestedInVec": {
             "type": "struct",
             "docs": [
                 "Tests that the ABI generator also fetches types that only appear as fields."

--- a/contracts/feature-tests/abi-tester/src/abi_test_type.rs
+++ b/contracts/feature-tests/abi-tester/src/abi_test_type.rs
@@ -1,5 +1,9 @@
 use crate::only_nested::*;
-use elrond_wasm::Box;
+use elrond_wasm::{
+    api::ManagedTypeApi,
+    types::{BigUint, ManagedBuffer},
+    Box,
+};
 elrond_wasm::derive_imports!();
 
 /// Its only purpose is to test that the ABI generator works fine.
@@ -14,4 +18,19 @@ pub struct AbiTestType {
     /// Tests that tuples tell the ABI of their component types even if they appear nowhere else.
     /// Also, just like above, recursive types need to work even when nested into a tuple.
     pub tuple_madness: (OnlyShowsUpAsNested02, Option<Box<AbiTestType>>),
+}
+
+/// Its only purpose is to test that the ABI generator works fine.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
+pub struct AbiManagedType<M: ManagedTypeApi> {
+    pub big_uint: BigUint<M>,
+    pub integer: i32,
+    pub managed_buffer: ManagedBuffer<M>,
+}
+
+/// Its only purpose is to test that the ABI generator works fine.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi, ManagedVecItem)]
+pub struct AbiManagedVecItem {
+    pub value1: u32,
+    pub value2: u32,
 }

--- a/contracts/feature-tests/abi-tester/src/abi_tester.rs
+++ b/contracts/feature-tests/abi-tester/src/abi_tester.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(generic_associated_types)]
 
 elrond_wasm::imports!();
 
@@ -35,6 +36,10 @@ pub trait AbiTester {
     fn echo_enum(&self, e: AbiEnum) -> AbiEnum {
         e
     }
+
+    #[endpoint]
+    #[only_owner]
+    fn take_managed_type(&self, _arg: AbiManagedType<Self::Api>) {}
 
     #[endpoint]
     #[output_name("multi-result-1")]
@@ -109,7 +114,46 @@ pub trait AbiTester {
 
     #[view]
     #[storage_mapper("sample_storage_mapper")]
-    fn sample_storage_mapper(&self) -> SingleValueMapper<OnlyShowsUpAsNested10>;
+    fn sample_storage_mapper(&self) -> SingleValueMapper<OnlyShowsUpAsNestedInSingleValueMapper>;
+
+    #[view]
+    fn item_for_vec(&self) -> Vec<OnlyShowsUpAsNestedInVec> {
+        Vec::new()
+    }
+
+    #[view]
+    fn item_for_array_vec(&self) -> ArrayVec<OnlyShowsUpAsNestedInArrayVec, 3> {
+        ArrayVec::new()
+    }
+
+    #[view]
+    fn item_for_managed_vec(&self) -> ManagedVec<AbiManagedVecItem> {
+        ManagedVec::new()
+    }
+
+    #[view]
+    fn item_for_array(&self, _array: &[OnlyShowsUpAsNestedInArray; 5]) {}
+
+    #[view]
+    fn item_for_box(&self) -> Box<OnlyShowsUpAsNestedInBox> {
+        Box::new(OnlyShowsUpAsNestedInBox)
+    }
+
+    #[view]
+    fn item_for_boxed_slice(&self) -> Box<[OnlyShowsUpAsNestedInBoxedSlice]> {
+        Vec::new().into_boxed_slice()
+    }
+
+    #[view]
+    fn item_for_ref(&self, _ref: &OnlyShowsUpAsNestedInRef) {}
+
+    #[view]
+    fn item_for_slice(&self, _ref: &[OnlyShowsUpAsNestedInSlice]) {}
+
+    #[view]
+    fn item_for_option(&self) -> Option<OnlyShowsUpAsNestedInOption> {
+        None
+    }
 
     #[endpoint]
     #[payable("EGLD")]

--- a/contracts/feature-tests/abi-tester/src/only_nested.rs
+++ b/contracts/feature-tests/abi-tester/src/only_nested.rs
@@ -46,4 +46,36 @@ pub struct OnlyShowsUpAsNested09;
 
 /// Tests that the ABI generator also fetches types that only appear as fields.
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
-pub struct OnlyShowsUpAsNested10;
+pub struct OnlyShowsUpAsNestedInSingleValueMapper;
+
+/// Tests that the ABI generator also fetches types that only appear as fields.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
+pub struct OnlyShowsUpAsNestedInVec;
+
+/// Tests that the ABI generator also fetches types that only appear as fields.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
+pub struct OnlyShowsUpAsNestedInArrayVec;
+
+/// Tests that the ABI generator also fetches types that only appear as fields.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
+pub struct OnlyShowsUpAsNestedInArray;
+
+/// Tests that the ABI generator also fetches types that only appear as fields.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
+pub struct OnlyShowsUpAsNestedInBox;
+
+/// Tests that the ABI generator also fetches types that only appear as fields.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
+pub struct OnlyShowsUpAsNestedInBoxedSlice;
+
+/// Tests that the ABI generator also fetches types that only appear as fields.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
+pub struct OnlyShowsUpAsNestedInRef;
+
+/// Tests that the ABI generator also fetches types that only appear as fields.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
+pub struct OnlyShowsUpAsNestedInSlice;
+
+/// Tests that the ABI generator also fetches types that only appear as fields.
+#[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi)]
+pub struct OnlyShowsUpAsNestedInOption;

--- a/elrond-wasm/src/abi/type_abi.rs
+++ b/elrond-wasm/src/abi/type_abi.rs
@@ -95,11 +95,19 @@ impl<T: TypeAbi> TypeAbi for &[T] {
         repr.push('>');
         repr
     }
+
+    fn provide_type_descriptions<TDC: TypeDescriptionContainer>(accumulator: &mut TDC) {
+        T::provide_type_descriptions(accumulator);
+    }
 }
 
 impl<T: TypeAbi> TypeAbi for Vec<T> {
     fn type_name() -> String {
         <&[T]>::type_name()
+    }
+
+    fn provide_type_descriptions<TDC: TypeDescriptionContainer>(accumulator: &mut TDC) {
+        T::provide_type_descriptions(accumulator);
     }
 }
 
@@ -107,11 +115,19 @@ impl<T: TypeAbi, const CAP: usize> TypeAbi for ArrayVec<T, CAP> {
     fn type_name() -> String {
         <&[T]>::type_name()
     }
+
+    fn provide_type_descriptions<TDC: TypeDescriptionContainer>(accumulator: &mut TDC) {
+        T::provide_type_descriptions(accumulator);
+    }
 }
 
 impl<T: TypeAbi> TypeAbi for Box<[T]> {
     fn type_name() -> String {
         <&[T]>::type_name()
+    }
+
+    fn provide_type_descriptions<TDC: TypeDescriptionContainer>(accumulator: &mut TDC) {
+        T::provide_type_descriptions(accumulator);
     }
 }
 

--- a/elrond-wasm/src/types/managed/managed_vec.rs
+++ b/elrond-wasm/src/types/managed/managed_vec.rs
@@ -1,6 +1,6 @@
 use super::{ManagedBuffer, ManagedType, ManagedVecItem, ManagedVecRef, ManagedVecRefIterator};
 use crate::{
-    abi::TypeAbi,
+    abi::{TypeAbi, TypeDescriptionContainer},
     api::{ErrorApiImpl, Handle, InvalidSliceError, ManagedTypeApi},
     types::{ArgBuffer, BoxedBytes, ManagedBufferNestedDecodeInput},
 };
@@ -364,6 +364,10 @@ where
     /// It is semantically equivalent to any list of `T`.
     fn type_name() -> String {
         <&[T] as TypeAbi>::type_name()
+    }
+
+    fn provide_type_descriptions<TDC: TypeDescriptionContainer>(accumulator: &mut TDC) {
+        T::provide_type_descriptions(accumulator);
     }
 }
 


### PR DESCRIPTION
ABI was not being provided for contents of Vec, ManagedBec, boxed slice and slice.