### PR TITLE
Preprocessor span fix

### DIFF
--- a/contracts/examples/token-release/src/token_release.rs
+++ b/contracts/examples/token-release/src/token_release.rs
@@ -264,7 +264,7 @@ pub trait TokenRelease {
 
     // private functions
 
-    fn calculate_claimable_tokens(&self, address: &ManagedAddress) -> (BigUint) {
+    fn calculate_claimable_tokens(&self, address: &ManagedAddress) -> BigUint {
         let starting_timestamp = self.activation_timestamp().get();
         let current_timestamp = self.blockchain().get_block_timestamp();
         let address_groups = self.user_groups(address).get();

--- a/contracts/feature-tests/basic-features/src/storage_mapper_single.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_single.rs
@@ -10,7 +10,7 @@ pub trait SingleValueMapperFeatures {
     #[endpoint]
     fn my_single_value_mapper_increment_1(&self, amount: BigInt) {
         let my_single_value_mapper = self.map_my_single_value_mapper();
-        my_single_value_mapper.set((my_single_value_mapper.get() + amount));
+        my_single_value_mapper.set(my_single_value_mapper.get() + amount);
     }
 
     /// Same as my_single_value_mapper_increment_1, but expressed more compactly.

--- a/elrond-wasm-derive/src/generate/method_gen.rs
+++ b/elrond-wasm-derive/src/generate/method_gen.rs
@@ -19,7 +19,7 @@ pub fn generate_sig(m: &Method) -> proc_macro2::TokenStream {
     let arg_decl = arg_declarations(&m.method_args);
     let ret_tok = match &m.return_type {
         syn::ReturnType::Default => quote! {},
-        syn::ReturnType::Type(_, ty) => quote! { -> #ty },
+        syn::ReturnType::Type(r_arrow_token, ty) => quote! { #r_arrow_token #ty },
     };
     let result = quote! {
         #[allow(clippy::too_many_arguments)]

--- a/elrond-wasm-derive/src/preprocessing/substitution_algorithm.rs
+++ b/elrond-wasm-derive/src/preprocessing/substitution_algorithm.rs
@@ -28,10 +28,12 @@ pub(super) fn perform_substitutions(
         if let Some(tt) = tt_iter.next() {
             match tt {
                 TokenTree::Group(g) => {
-                    result.push(TokenTree::Group(Group::new(
+                    let mut substituted_group = TokenTree::Group(Group::new(
                         g.delimiter(),
                         perform_substitutions(g.stream(), substitutions),
-                    )));
+                    ));
+                    substituted_group.set_span(g.span());
+                    result.push(substituted_group);
                     continue;
                 },
                 _ => result.push(tt),

--- a/elrond-wasm-derive/src/preprocessing/substitution_list.rs
+++ b/elrond-wasm-derive/src/preprocessing/substitution_list.rs
@@ -9,7 +9,11 @@ pub fn substitutions() -> SubstitutionsMap {
     substitutions
 }
 
+#[rustfmt::skip]
 fn add_managed_type(substitutions: &mut SubstitutionsMap, type_name: &proc_macro2::TokenStream) {
+    substitutions.add_substitution(
+        quote!(#type_name<Self::Api>), 
+        quote!(#type_name<Self::Api>));
     substitutions.add_substitution(
         quote!(#type_name::),
         quote!(elrond_wasm::types::#type_name::<Self::Api>::),


### PR DESCRIPTION
This should fix the broken error messages.

The substitution algorithm can be further improved a little bit, but I think the current code gets all errors right.