### PR TITLE
Non-specialized decode for managed types

### DIFF
--- a/contracts/feature-tests/basic-features/src/types/codec_err_test_type.rs
+++ b/contracts/feature-tests/basic-features/src/types/codec_err_test_type.rs
@@ -13,24 +13,24 @@ pub struct CodecErrorTestType;
 impl TopEncode for CodecErrorTestType {
     #[inline]
     fn top_encode<O: TopEncodeOutput>(&self, _output: O) -> Result<(), EncodeError> {
-        Err(EncodeError::from(&b"deliberate top encode error"[..]))
+        Err(EncodeError::from("deliberate top encode error"))
     }
 }
 
 impl NestedEncode for CodecErrorTestType {
     fn dep_encode<O: NestedEncodeOutput>(&self, _dest: &mut O) -> Result<(), EncodeError> {
-        Err(EncodeError::from(&b"deliberate nested encode error"[..]))
+        Err(EncodeError::from("deliberate nested encode error"))
     }
 }
 
 impl TopDecode for CodecErrorTestType {
     fn top_decode<I: TopDecodeInput>(_input: I) -> Result<Self, DecodeError> {
-        Err(DecodeError::from(&b"deliberate top decode error"[..]))
+        Err(DecodeError::from("deliberate top decode error"))
     }
 }
 
 impl NestedDecode for CodecErrorTestType {
     fn dep_decode<I: NestedDecodeInput>(_input: &mut I) -> Result<Self, DecodeError> {
-        Err(DecodeError::from(&b"deliberate nested decode error"[..]))
+        Err(DecodeError::from("deliberate nested decode error"))
     }
 }

--- a/elrond-codec/src/codec_err.rs
+++ b/elrond-codec/src/codec_err.rs
@@ -1,9 +1,9 @@
 #[derive(Debug, PartialEq, Eq)]
-pub struct EncodeError(&'static [u8]);
+pub struct EncodeError(&'static str);
 
-impl From<&'static [u8]> for EncodeError {
+impl From<&'static str> for EncodeError {
     #[inline]
-    fn from(message_bytes: &'static [u8]) -> Self {
+    fn from(message_bytes: &'static str) -> Self {
         EncodeError(message_bytes)
     }
 }
@@ -11,18 +11,18 @@ impl From<&'static [u8]> for EncodeError {
 impl EncodeError {
     #[inline]
     pub fn message_bytes(&self) -> &'static [u8] {
-        self.0
+        self.0.as_bytes()
     }
 
-    pub const UNSUPPORTED_OPERATION: EncodeError = EncodeError(b"unsupported operation");
+    pub const UNSUPPORTED_OPERATION: EncodeError = EncodeError("unsupported operation");
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DecodeError(&'static [u8]);
+pub struct DecodeError(&'static str);
 
-impl From<&'static [u8]> for DecodeError {
+impl From<&'static str> for DecodeError {
     #[inline]
-    fn from(message_bytes: &'static [u8]) -> Self {
+    fn from(message_bytes: &'static str) -> Self {
         DecodeError(message_bytes)
     }
 }
@@ -30,15 +30,15 @@ impl From<&'static [u8]> for DecodeError {
 impl DecodeError {
     #[inline]
     pub fn message_bytes(&self) -> &'static [u8] {
-        self.0
+        self.0.as_bytes()
     }
 
-    pub const INPUT_TOO_SHORT: DecodeError = DecodeError(b"input too short");
-    pub const INPUT_TOO_LONG: DecodeError = DecodeError(b"input too long");
-    pub const INPUT_OUT_OF_RANGE: DecodeError = DecodeError(b"input out of range");
-    pub const INVALID_VALUE: DecodeError = DecodeError(b"invalid value");
-    pub const UNSUPPORTED_OPERATION: DecodeError = DecodeError(b"unsupported operation");
-    pub const ARRAY_DECODE_ERROR: DecodeError = DecodeError(b"array decode error");
-    pub const UTF8_DECODE_ERROR: DecodeError = DecodeError(b"utf-8 decode error");
-    pub const CAPACITY_EXCEEDED_ERROR: DecodeError = DecodeError(b"capacity exceeded");
+    pub const INPUT_TOO_SHORT: DecodeError = DecodeError("input too short");
+    pub const INPUT_TOO_LONG: DecodeError = DecodeError("input too long");
+    pub const INPUT_OUT_OF_RANGE: DecodeError = DecodeError("input out of range");
+    pub const INVALID_VALUE: DecodeError = DecodeError("invalid value");
+    pub const UNSUPPORTED_OPERATION: DecodeError = DecodeError("unsupported operation");
+    pub const ARRAY_DECODE_ERROR: DecodeError = DecodeError("array decode error");
+    pub const UTF8_DECODE_ERROR: DecodeError = DecodeError("utf-8 decode error");
+    pub const CAPACITY_EXCEEDED_ERROR: DecodeError = DecodeError("capacity exceeded");
 }

--- a/elrond-wasm-debug/src/managed_test_util.rs
+++ b/elrond-wasm-debug/src/managed_test_util.rs
@@ -1,6 +1,6 @@
 use elrond_wasm::{
     contract_base::ManagedSerializer,
-    elrond_codec::{test_util::check_top_encode, DecodeError, TopDecode, TopEncode},
+    elrond_codec::{test_util::check_top_encode, TopDecode, TopEncode},
     types::{BoxedBytes, ManagedBuffer},
 };
 
@@ -28,8 +28,6 @@ pub fn check_managed_top_encode<T: TopEncode>(_api: DebugApi, obj: &T) -> BoxedB
 
 /// Uses the managed types api to test encoding.
 /// Can be used on any type, but managed types are especially relevant.
-/// Also works on types that have no un-managed decoding,
-/// by allowing DecodeError::UNSUPPORTED_OPERATION result.
 pub fn check_managed_top_decode<T: TopDecode + PartialEq + Debug>(
     _api: DebugApi,
     bytes: &[u8],
@@ -43,9 +41,6 @@ pub fn check_managed_top_decode<T: TopDecode + PartialEq + Debug>(
     match T::top_decode(bytes) {
         Ok(from_unmanaged) => {
             assert_eq!(from_unmanaged, from_mb);
-        },
-        Err(DecodeError::UNSUPPORTED_OPERATION) => {
-            // Ok
         },
         Err(err) => {
             panic!(

--- a/elrond-wasm/src/types/general/h256.rs
+++ b/elrond-wasm/src/types/general/h256.rs
@@ -2,7 +2,7 @@ use crate::{abi::TypeAbi, types::BoxedBytes};
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt::Debug;
 
-const ERR_BAD_H256_LENGTH: &[u8] = b"bad H256 length";
+const ERR_BAD_H256_LENGTH: &str = "bad H256 length";
 const ZERO_32: &[u8] = &[0u8; 32];
 
 /// Type that holds 32 bytes of data.

--- a/elrond-wasm/src/types/io/sc_result.rs
+++ b/elrond-wasm/src/types/io/sc_result.rs
@@ -194,7 +194,7 @@ mod tests {
         assert!(sc_result_ok.unwrap() == 5);
 
         let result_err: Result<i32, DecodeError> =
-            Result::Err(DecodeError::from(&b"Decode Error"[..]).into());
+            Result::Err(DecodeError::from("Decode Error").into());
         let sc_result_err: SCResult<i32> = result_err.into();
 
         assert!(sc_result_err.err().unwrap().as_bytes() == &b"Decode Error"[..]);

--- a/elrond-wasm/src/types/managed/big_uint.rs
+++ b/elrond-wasm/src/types/managed/big_uint.rs
@@ -190,7 +190,10 @@ impl<M: ManagedTypeApi> NestedEncode for BigUint<M> {
 
 impl<M: ManagedTypeApi> NestedDecode for BigUint<M> {
     fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        input.read_specialized((), |_| Err(DecodeError::UNSUPPORTED_OPERATION))
+        input.read_specialized((), |input| {
+            let boxed_bytes = BoxedBytes::dep_decode(input)?;
+            Ok(Self::from_bytes_be(boxed_bytes.as_slice()))
+        })
     }
 
     fn dep_decode_or_exit<I: NestedDecodeInput, ExitCtx: Clone>(
@@ -198,15 +201,19 @@ impl<M: ManagedTypeApi> NestedDecode for BigUint<M> {
         c: ExitCtx,
         exit: fn(ExitCtx, DecodeError) -> !,
     ) -> Self {
-        input.read_specialized_or_exit((), c, exit, |_, c| {
-            exit(c, DecodeError::UNSUPPORTED_OPERATION)
+        input.read_specialized_or_exit((), c, exit, |input, c| {
+            let boxed_bytes = BoxedBytes::dep_decode_or_exit(input, c, exit);
+            Self::from_bytes_be(boxed_bytes.as_slice())
         })
     }
 }
 
 impl<M: ManagedTypeApi> TopDecode for BigUint<M> {
     fn top_decode<I: TopDecodeInput>(input: I) -> Result<Self, DecodeError> {
-        input.into_specialized(|_| Err(DecodeError::UNSUPPORTED_OPERATION))
+        input.into_specialized(|input| {
+            let boxed_bytes = BoxedBytes::top_decode(input)?;
+            Ok(Self::from_bytes_be(boxed_bytes.as_slice()))
+        })
     }
 }
 

--- a/elrond-wasm/src/types/managed/managed_byte_array.rs
+++ b/elrond-wasm/src/types/managed/managed_byte_array.rs
@@ -12,7 +12,7 @@ use elrond_codec::{
     TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput, TryStaticCast,
 };
 
-const DECODE_ERROR_BAD_LENGTH: &[u8] = b"bad array length";
+const DECODE_ERROR_BAD_LENGTH: &str = "bad array length";
 
 /// A list of items that lives inside a managed buffer.
 /// Items can be either stored there in full (e.g. `u32`),

--- a/elrond-wasm/src/types/managed/managed_byte_array.rs
+++ b/elrond-wasm/src/types/managed/managed_byte_array.rs
@@ -171,9 +171,10 @@ where
     M: ManagedTypeApi,
 {
     fn dep_decode<I: NestedDecodeInput>(input: &mut I) -> Result<Self, DecodeError> {
-        let buffer: ManagedBuffer<M> = input
-            .read_specialized(ManagedBufferSizeContext(N), |_| {
-                Err(DecodeError::UNSUPPORTED_OPERATION)
+        let buffer: ManagedBuffer<M> =
+            input.read_specialized(ManagedBufferSizeContext(N), |input| {
+                let byte_array = <[u8; N]>::dep_decode(input)?;
+                Ok(byte_array.as_ref().into())
             })?;
         Ok(ManagedByteArray { buffer })
     }

--- a/elrond-wasm/src/types/managed/managed_multi_result_vec_counted.rs
+++ b/elrond-wasm/src/types/managed/managed_multi_result_vec_counted.rs
@@ -131,7 +131,7 @@ where
     T: ManagedVecItem + ContractCallArg + TopEncode,
 {
     fn push_dyn_arg<O: DynArgOutput>(&self, output: &mut O) {
-        self.borrow().push_dyn_arg(output)
+        (&self).push_dyn_arg(output)
     }
 }
 


### PR DESCRIPTION
Despite much refactoring, somehow several managed types still had their non-specialized decodes left not unimplemented.