### PR TITLE
ESDT module update

### DIFF
--- a/contracts/feature-tests/use-module/use_module_expected_main.abi.json
+++ b/contracts/feature-tests/use-module/use_module_expected_main.abi.json
@@ -122,23 +122,12 @@
                     "type": "bytes"
                 },
                 {
-                    "name": "num_decimals",
-                    "type": "u32"
-                }
-            ],
-            "outputs": []
-        },
-        {
-            "docs": [
-                "optional address to set roles for. Defaults to SC's address."
-            ],
-            "name": "setLocalRoles",
-            "onlyOwner": true,
-            "mutability": "mutable",
-            "inputs": [
+                    "name": "token_type",
+                    "type": "EsdtTokenType"
+                },
                 {
-                    "name": "opt_dest_address",
-                    "type": "optional<Address>",
+                    "name": "opt_num_decimals",
+                    "type": "optional<u32>",
                     "multi_arg": true
                 }
             ],
@@ -563,6 +552,31 @@
     ],
     "hasCallback": true,
     "types": {
+        "EsdtTokenType": {
+            "type": "enum",
+            "variants": [
+                {
+                    "name": "Fungible",
+                    "discriminant": 0
+                },
+                {
+                    "name": "NonFungible",
+                    "discriminant": 1
+                },
+                {
+                    "name": "SemiFungible",
+                    "discriminant": 2
+                },
+                {
+                    "name": "Meta",
+                    "discriminant": 3
+                },
+                {
+                    "name": "Invalid",
+                    "discriminant": 4
+                }
+            ]
+        },
         "GovernanceProposalStatus": {
             "type": "enum",
             "variants": [

--- a/contracts/feature-tests/use-module/use_module_expected_view.abi.json
+++ b/contracts/feature-tests/use-module/use_module_expected_view.abi.json
@@ -42,6 +42,31 @@
     ],
     "hasCallback": false,
     "types": {
+        "EsdtTokenType": {
+            "type": "enum",
+            "variants": [
+                {
+                    "name": "Fungible",
+                    "discriminant": 0
+                },
+                {
+                    "name": "NonFungible",
+                    "discriminant": 1
+                },
+                {
+                    "name": "SemiFungible",
+                    "discriminant": 2
+                },
+                {
+                    "name": "Meta",
+                    "discriminant": 3
+                },
+                {
+                    "name": "Invalid",
+                    "discriminant": 4
+                }
+            ]
+        },
         "GovernanceProposalStatus": {
             "type": "enum",
             "variants": [

--- a/contracts/feature-tests/use-module/wasm/src/lib.rs
+++ b/contracts/feature-tests/use-module/wasm/src/lib.rs
@@ -46,7 +46,6 @@ elrond_wasm_node::wasm_endpoints! {
         propose
         queue
         setFeatureFlag
-        setLocalRoles
         unpause
         vote
         withdrawGovernanceTokens

--- a/elrond-wasm-modules/src/esdt.rs
+++ b/elrond-wasm-modules/src/esdt.rs
@@ -90,7 +90,7 @@ pub trait EsdtModule {
 
         self.send().esdt_nft_create(
             &token_id,
-            &amount,
+            amount,
             &empty_buffer,
             &BigUint::zero(),
             &empty_buffer,


### PR DESCRIPTION
- use the new register and set all roles function
- add create NFT function

Note that this module is mostly going to be used in contracts that use the NFTs as a means of information, so we have no use for all the NFTCreate arguments.