### PR TITLE
Add `wasm-opt` to GitHub Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,13 +16,15 @@ jobs:
         with:
           default: true
           toolchain: nightly-2022-01-17
-      - name: Install erdpy and vmtools
+      - name: Install erdpy, vmtools and wasm-opt
         run: |
           source .github/workflows/env
           pip3 install erdpy
           mkdir $HOME/elrondsdk
           erdpy config set dependencies.vmtools.tag v1.4.36
           erdpy deps install vmtools
+          erdpy deps install nodejs
+          erdpy deps install wasm-opt
       - name: Build the wasm contracts
         run: |
           source .github/workflows/env

--- a/contracts/examples/ping-pong-egld/mandos/ping-pong-call-pong-all-interrupted-1.scen.json
+++ b/contracts/examples/ping-pong-egld/mandos/ping-pong-call-pong-all-interrupted-1.scen.json
@@ -21,7 +21,7 @@
                 "to": "sc:ping-pong",
                 "function": "pongAll",
                 "arguments": [],
-                "gasLimit": "7,000,000",
+                "gasLimit": "6,000,000",
                 "gasPrice": "0"
             },
             "expect": {

--- a/contracts/examples/ping-pong-egld/mandos/ping-pong-call-pong-all-interrupted-2.scen.json
+++ b/contracts/examples/ping-pong-egld/mandos/ping-pong-call-pong-all-interrupted-2.scen.json
@@ -21,7 +21,7 @@
                 "to": "sc:ping-pong",
                 "function": "pongAll",
                 "arguments": [],
-                "gasLimit": "8,000,000",
+                "gasLimit": "7,000,000",
                 "gasPrice": "0"
             },
             "expect": {


### PR DESCRIPTION
- Enable `wasm-opt` optimizations by first installing the dependencies through erdpy
- Update the `pongAll` interrupt tests, which now require less gas for a single pong