### PR TITLE
Examples cleanup

### DIFF
--- a/contracts/examples/adder/src/adder.rs
+++ b/contracts/examples/adder/src/adder.rs
@@ -17,9 +17,7 @@ pub trait Adder {
 
     /// Add desired amount to the storage variable.
     #[endpoint]
-    fn add(&self, value: BigInt) -> SCResult<()> {
+    fn add(&self, value: BigInt) {
         self.sum().update(|sum| *sum += value);
-
-        Ok(())
     }
 }

--- a/contracts/examples/adder/src/adder.rs
+++ b/contracts/examples/adder/src/adder.rs
@@ -8,16 +8,16 @@ elrond_wasm::imports!();
 pub trait Adder {
     #[view(getSum)]
     #[storage_mapper("sum")]
-    fn sum(&self) -> SingleValueMapper<BigInt>;
+    fn sum(&self) -> SingleValueMapper<BigUint>;
 
     #[init]
-    fn init(&self, initial_value: BigInt) {
+    fn init(&self, initial_value: BigUint) {
         self.sum().set(initial_value);
     }
 
     /// Add desired amount to the storage variable.
     #[endpoint]
-    fn add(&self, value: BigInt) {
+    fn add(&self, value: BigUint) {
         self.sum().update(|sum| *sum += value);
     }
 }

--- a/contracts/examples/adder/tests/adder_test.rs
+++ b/contracts/examples/adder/tests/adder_test.rs
@@ -1,5 +1,5 @@
 use adder::*;
-use elrond_wasm::types::BigInt;
+use elrond_wasm::types::BigUint;
 use elrond_wasm_debug::DebugApi;
 
 #[test]
@@ -8,12 +8,12 @@ fn test_add() {
 
     let adder = adder::contract_obj::<DebugApi>();
 
-    adder.init(BigInt::from(5));
-    assert_eq!(BigInt::from(5), adder.sum().get());
+    adder.init(BigUint::from(5u32));
+    assert_eq!(BigUint::from(5u32), adder.sum().get());
 
-    let _ = adder.add(BigInt::from(7));
-    assert_eq!(BigInt::from(12), adder.sum().get());
+    let _ = adder.add(BigUint::from(7u32));
+    assert_eq!(BigUint::from(12u32), adder.sum().get());
 
-    let _ = adder.add(BigInt::from(1));
-    assert_eq!(BigInt::from(13), adder.sum().get());
+    let _ = adder.add(BigUint::from(1u32));
+    assert_eq!(BigUint::from(13u32), adder.sum().get());
 }

--- a/contracts/examples/crowdfunding-esdt/src/crowdfunding_esdt.rs
+++ b/contracts/examples/crowdfunding-esdt/src/crowdfunding_esdt.rs
@@ -32,7 +32,9 @@ pub trait Crowdfunding {
 
     #[endpoint]
     #[payable("*")]
-    fn fund(&self, #[payment_token] token: TokenIdentifier, #[payment] payment: BigUint) {
+    fn fund(&self) {
+        let (payment, token) = self.call_value().payment_token_pair();
+
         require!(
             self.status() == Status::FundingPeriod,
             "cannot fund after deadline"

--- a/contracts/examples/crowdfunding-esdt/tests/crowdfunding_esdt_rust_test.rs
+++ b/contracts/examples/crowdfunding-esdt/tests/crowdfunding_esdt_rust_test.rs
@@ -84,7 +84,7 @@ fn fund_test() {
             0,
             &rust_biguint!(1_000),
             |sc| {
-                sc.fund(managed_token_id!(CF_TOKEN_ID), managed_biguint!(1_000));
+                sc.fund();
 
                 let user_deposit = sc.deposit(&managed_address!(user_addr)).get();
                 let expected_deposit = managed_biguint!(1_000);
@@ -141,7 +141,7 @@ fn test_sc_error() {
             &cf_setup.cf_wrapper,
             &rust_biguint!(1_000),
             |sc| {
-                sc.fund(managed_token_id!(b""), managed_biguint!(1_000));
+                sc.fund();
             },
         )
         .assert_user_error("wrong token");
@@ -184,7 +184,7 @@ fn test_successful_cf() {
             0,
             &rust_biguint!(1_000),
             |sc| {
-                sc.fund(managed_token_id!(CF_TOKEN_ID), managed_biguint!(1_000));
+                sc.fund();
 
                 let user_deposit = sc.deposit(&managed_address!(first_user)).get();
                 let expected_deposit = managed_biguint!(1_000);
@@ -202,7 +202,7 @@ fn test_successful_cf() {
             0,
             &rust_biguint!(1_000),
             |sc| {
-                sc.fund(managed_token_id!(CF_TOKEN_ID), managed_biguint!(1_000));
+                sc.fund();
 
                 let user_deposit = sc.deposit(&managed_address!(second_user)).get();
                 let expected_deposit = managed_biguint!(1_000);
@@ -258,7 +258,7 @@ fn test_failed_cf() {
             0,
             &rust_biguint!(300),
             |sc| {
-                sc.fund(managed_token_id!(CF_TOKEN_ID), managed_biguint!(300));
+                sc.fund();
 
                 let user_deposit = sc.deposit(&managed_address!(first_user)).get();
                 let expected_deposit = managed_biguint!(300);
@@ -276,7 +276,7 @@ fn test_failed_cf() {
             0,
             &rust_biguint!(600),
             |sc| {
-                sc.fund(managed_token_id!(CF_TOKEN_ID), managed_biguint!(600));
+                sc.fund();
 
                 let user_deposit = sc.deposit(&managed_address!(second_user)).get();
                 let expected_deposit = managed_biguint!(600);

--- a/contracts/examples/crypto-kitties/documentation.md
+++ b/contracts/examples/crypto-kitties/documentation.md
@@ -68,7 +68,7 @@ The contract has only one function:
 
 ```
 #[endpoint(generateKittyGenes)]
-fn generate_kitty_genes(matron: Kitty, sire: Kitty) -> SCResult<KittyGenes>
+fn generate_kitty_genes(matron: Kitty, sire: Kitty) -> KittyGenes
 ```
 
 It takes two kitties, the matron and the sire, and generates a *KittyGenes* instance. In the current implementation, this simply combines their `fur_color` and `eye_color` using a random percentage of each, and the average of their `meow_power`s.
@@ -123,7 +123,7 @@ The last argument is the address of the `Kitty Ownership` contract, which can ei
 
 ## Owner-only
 
-The following throw an error if the caller isn't the contract owner, so we will omit the `SCResult`.
+The following throw an error if the caller isn't the contract owner.
 
 `#[endpoint(setKittyOwnershipContractAddress)]`  
 `fn set_kitty_ownership_contract_address_endpoint(address: Address)`
@@ -147,12 +147,12 @@ Owner claims funds.
 Returns `true` if the kitty is up for auction, `false` otherwise.
 
 `#[view(getAuctionStatus)]`  
-`fn get_auction_status(kitty_id: u32) -> SCResult<Auction>`
+`fn get_auction_status(kitty_id: u32) -> Auction`
 
 Returns the relevant `Auction` struct (described above) if it exists, throws an error otherwise.
 
 `#[view(getCurrentWinningBid)]`  
-`fn get_current_winning_bid(kitty_id: u32) -> SCResult<BigUint>`
+`fn get_current_winning_bid(kitty_id: u32) -> BigUint`
 
 Returns the current winning bid for a kitty's auction if it exists, throws an error otherwise. Cheaper version of `get_auction_status` is you're only interested in the winning bid.
 
@@ -165,7 +165,7 @@ fn create_sale_auction(
 	starting_price: BigUint,
 	ending_price: BigUint,
 	duration: u64,
-) -> SCResult<()>
+)
 ```
 
 Puts the kitty up for a sale auction. Only the owner of the kitty may call this function,
@@ -177,12 +177,12 @@ fn create_siring_auction(
 	starting_price: BigUint,
 	ending_price: BigUint,
 	duration: u64,
-) -> SCResult<()>
+)
 ```
 
 Puts the kitty up for siring auction. Only the owner of the kitty may call this function.
 
-`fn bid(kitty_id: u32) -> SCResult<()>`
+`fn bid(kitty_id: u32)`
 
 Payable function. Bid must abide the following rule:
 `current_bid < payment <= ending_price`
@@ -193,7 +193,7 @@ If this is the first bid in the auction, the rule changes to:
 If the bid is valid, the `current_bid` is sent back to the `current_winner`, `current_bid` is set to `payment`, and `current_winner` is set to the caller's address.
 
 `#[endpoint(endAuction)]`  
-`fn end_auction(kitty_id: u32) -> SCResult<()>`
+`fn end_auction(kitty_id: u32)`
 
 This function ends the auction for the kitty if one of the end conditions has been met:
 1) `deadline` has passed
@@ -216,9 +216,9 @@ Kitty Ownership also implements the ERC721 interface. We won't be going over the
 `fn total_supply() -> u32`  
 `fn balance_of(address: Address) -> u32`  
 `fn owner_of(kitty_id: u32) -> Address`  
-`fn approve(to: Address, kitty_id: u32) -> SCResult<()>`  
-`fn transfer(to: Address, kitty_id: u32) -> SCResult<()>`  
-`fn transfer_from(from: Address, to: Address, kitty_id: u32) -> SCResult<()>`  
+`fn approve(to: Address, kitty_id: u32) `  
+`fn transfer(to: Address, kitty_id: u32) `  
+`fn transfer_from(from: Address, to: Address, kitty_id: u32) `  
 `fn tokens_of_owner(address: Address) -> Vec<u32>`  
 
 ## Deployment
@@ -242,22 +242,22 @@ The next two arguments are the addresses of the other two contracts: the kitty-a
 The following throw an error if the kitty does not exist.
 
 `#[view(getKittyById)]`  
-`fn get_kitty_by_id_endpoint(kitty_id: u32) -> SCResult<Kitty>`
+`fn get_kitty_by_id_endpoint(kitty_id: u32) -> Kitty`
 
 Gets a kitty by id.
 
 `#[view(isReadyToBreed)]`  
-`fn is_ready_to_breed(kitty_id: u32) -> SCResult<bool>`
+`fn is_ready_to_breed(kitty_id: u32) -> bool`
 
 Checks if the kitty is ready to breed by checking if `siring_with_id` is 0 and cooldown period has passed.
 
 `#[view(isPregnant)]`  
-`fn is_pregnant(kitty_id: u32) -> SCResult<bool>`
+`fn is_pregnant(kitty_id: u32) -> bool`
 
 Checks if the kitty is pregnant by checking if `siring_with_id` is not 0.
 
 `#[view(canBreedWith)]`  
-`fn can_breed_with(matron_id: u32, sire_id: u32) -> SCResult<bool>`
+`fn can_breed_with(matron_id: u32, sire_id: u32) -> bool`
 
 Checks if the matron can breed with the sire. Kitties can't breed with themselves, their parents, nor their siblings/half-siblings.
 
@@ -269,7 +269,7 @@ Gets the `birth_fee` set by the owner.
 ## Endpoints
 
 `#[endpoint(approveSiring)]`  
-`fn approve_siring(&self, address: Address, kitty_id: u32) -> SCResult<()>`
+`fn approve_siring(&self, address: Address, kitty_id: u32) `
 
 Approves an address to use the kitty as a sire. Only the owner of `kitty_id` may call this function, and it may not override an already existing approved address.
 
@@ -277,10 +277,9 @@ Approves an address to use the kitty as a sire. Only the owner of `kitty_id` may
 #[payable("EGLD")]
 #[endpoint(breedWith)]
 fn breed_with(
-	#[payment] payment: BigUint,
 	matron_id: u32,
 	sire_id: u32,
-) -> SCResult<()>
+)
 ```
 
 Breeds `matron_id` with `sire_id`. The `payment` must be equal to the `birth_fee` set by the contract owner. Only the owner of the `matron` may call this function, and the `sire` must either be owned the by the same account that owns the `matron` OR the caller must be the `sire_allowed_address` for the sire.
@@ -288,7 +287,7 @@ Breeds `matron_id` with `sire_id`. The `payment` must be equal to the `birth_fee
 If the call is successful, the `cooldown` period is triggered and the `sire_allowed_address` is reset for both kitties.
 
 `#[endpoint(giveBirth)]`  
-`fn give_birth(matron_id: u32) -> SCResult<()>`
+`fn give_birth(matron_id: u32)`
 
 If the kitty is pregant and the gestation period has passed, a new kitty is created by the `Kitty Genetic Alg` contract and its ownership is given to the `matron`'s owner. Anyone may call this function.
 

--- a/contracts/examples/crypto-kitties/kitty-auction/src/auction.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/src/auction.rs
@@ -25,17 +25,17 @@ pub struct Auction<M: ManagedTypeApi> {
 impl<M: ManagedTypeApi> Auction<M> {
     pub fn new(
         auction_type: AuctionType,
-        starting_price: &BigUint<M>,
-        ending_price: &BigUint<M>,
+        starting_price: BigUint<M>,
+        ending_price: BigUint<M>,
         deadline: u64,
-        kitty_owner: &ManagedAddress<M>,
+        kitty_owner: ManagedAddress<M>,
     ) -> Self {
         Auction {
             auction_type,
-            starting_price: starting_price.clone(), // TODO: pass owned objects and let the caller clone if needed
-            ending_price: ending_price.clone(), // TODO: pass owned objects and let the caller clone if needed
+            starting_price: starting_price,
+            ending_price: ending_price,
             deadline,
-            kitty_owner: kitty_owner.clone(), // TODO: pass owned objects and let the caller clone if needed
+            kitty_owner: kitty_owner,
             current_bid: BigUint::zero(),
             current_winner: ManagedAddress::zero(),
         }

--- a/contracts/examples/crypto-kitties/kitty-auction/src/auction.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/src/auction.rs
@@ -32,10 +32,10 @@ impl<M: ManagedTypeApi> Auction<M> {
     ) -> Self {
         Auction {
             auction_type,
-            starting_price: starting_price,
-            ending_price: ending_price,
+            starting_price,
+            ending_price,
             deadline,
-            kitty_owner: kitty_owner,
+            kitty_owner,
             current_bid: BigUint::zero(),
             current_winner: ManagedAddress::zero(),
         }

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/src/lib.rs
@@ -13,7 +13,7 @@ pub trait KittyGeneticAlg {
     // endpoints
 
     #[endpoint(generateKittyGenes)]
-    fn generate_kitty_genes(&self, matron: Kitty, sire: Kitty) -> SCResult<KittyGenes> {
+    fn generate_kitty_genes(&self, matron: Kitty, sire: Kitty) -> KittyGenes {
         let mut random = Random::new(
             *self.blockchain().get_block_random_seed_legacy(),
             self.blockchain().get_tx_hash_legacy().as_bytes(),
@@ -39,10 +39,10 @@ pub trait KittyGeneticAlg {
 
         let kitty_meow_power = matron.get_meow_power() / 2 + sire.get_meow_power() / 2;
 
-        Ok(KittyGenes {
+        KittyGenes {
             fur_color: kitty_fur_color,
             eye_color: kitty_eye_color,
             meow_power: kitty_meow_power,
-        })
+        }
     }
 }

--- a/contracts/examples/crypto-kitties/kitty-ownership/mandos/query.scen.json
+++ b/contracts/examples/crypto-kitties/kitty-ownership/mandos/query.scen.json
@@ -88,7 +88,7 @@
             },
             "expect": {
                 "out": [
-                    "u32:1"
+                    "1"
                 ],
                 "status": "0",
                 "message": "",

--- a/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
@@ -285,10 +285,11 @@ pub trait KittyOwnership {
 
     #[payable("EGLD")]
     #[endpoint(breedWith)]
-    fn breed_with(&self, #[payment] payment: BigUint, matron_id: u32, sire_id: u32) {
+    fn breed_with(&self, matron_id: u32, sire_id: u32) {
         require!(self.is_valid_id(matron_id), "Invalid matron id!");
         require!(self.is_valid_id(sire_id), "Invalid sire id!");
 
+        let payment = self.call_value().egld_value();
         let auto_birth_fee = self.birth_fee().get();
         let caller = self.blockchain().get_caller();
 

--- a/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
@@ -223,9 +223,8 @@ pub trait KittyOwnership {
             self.blockchain().get_tx_hash_legacy().as_bytes(),
         );
         let genes = KittyGenes::get_random(&mut random);
-        let kitty_id = self.create_new_gen_zero_kitty(&genes);
 
-        kitty_id
+        self.create_new_gen_zero_kitty(&genes)
     }
 
     // views - Kitty Breeding

--- a/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
@@ -17,184 +17,167 @@ pub trait KittyOwnership {
         #[var_args] opt_gene_science_contract_address: OptionalArg<ManagedAddress>,
         #[var_args] opt_kitty_auction_contract_address: OptionalArg<ManagedAddress>,
     ) {
-        self.set_birth_fee(birth_fee);
+        self.birth_fee().set(birth_fee);
 
         match opt_gene_science_contract_address {
-            OptionalArg::Some(addr) => self.set_gene_science_contract_address(&addr),
+            OptionalArg::Some(addr) => self.gene_science_contract_address().set(&addr),
             OptionalArg::None => {},
         };
 
         match opt_kitty_auction_contract_address {
-            OptionalArg::Some(addr) => self.set_kitty_auction_contract_address(&addr),
+            OptionalArg::Some(addr) => self.kitty_auction_contract_address().set(&addr),
             OptionalArg::None => {},
         };
 
-        self._create_genesis_kitty();
+        self.create_genesis_kitty();
     }
 
     // endpoints - owner-only
 
     #[only_owner]
     #[endpoint(setGeneScienceContractAddress)]
-    fn set_gene_science_contract_address_endpoint(&self, address: ManagedAddress) -> SCResult<()> {
-        self.set_gene_science_contract_address(&address);
-
-        Ok(())
+    fn set_gene_science_contract_address_endpoint(&self, address: ManagedAddress) {
+        self.gene_science_contract_address().set(&address);
     }
 
     #[only_owner]
     #[endpoint(setKittyAuctionContractAddress)]
-    fn set_kitty_auction_contract_address_endpoint(&self, address: ManagedAddress) -> SCResult<()> {
-        self.set_kitty_auction_contract_address(&address);
-
-        Ok(())
+    fn set_kitty_auction_contract_address_endpoint(&self, address: ManagedAddress) {
+        self.kitty_auction_contract_address().set(&address);
     }
 
     #[only_owner]
     #[endpoint]
-    fn claim(&self) -> SCResult<()> {
-        self.send().direct_egld(
-            &self.blockchain().get_caller(),
-            &self
-                .blockchain()
-                .get_sc_balance(&TokenIdentifier::egld(), 0),
-            b"claim",
-        );
+    fn claim(&self) {
+        let caller = self.blockchain().get_caller();
+        let egld_balance = self
+            .blockchain()
+            .get_sc_balance(&TokenIdentifier::egld(), 0);
 
-        Ok(())
+        self.send().direct_egld(&caller, &egld_balance, b"claim");
     }
 
     // views/endpoints - ERC721 required
 
     #[view(totalSupply)]
     fn total_supply(&self) -> u32 {
-        self.get_total_kitties() - 1 // not counting genesis Kitty
+        self.total_kitties().get() - 1 // not counting genesis Kitty
     }
 
     #[view(balanceOf)]
     fn balance_of(&self, address: ManagedAddress) -> u32 {
-        self.get_nr_owned_kitties(&address)
+        self.nr_owned_kitties(&address).get()
     }
 
     #[view(ownerOf)]
     fn owner_of(&self, kitty_id: u32) -> ManagedAddress {
-        if self._is_valid_id(kitty_id) {
-            self.get_kitty_owner(kitty_id)
+        if self.is_valid_id(kitty_id) {
+            self.kitty_owner(kitty_id).get()
         } else {
             ManagedAddress::zero()
         }
     }
 
     #[endpoint]
-    fn approve(&self, to: ManagedAddress, kitty_id: u32) -> SCResult<()> {
+    fn approve(&self, to: ManagedAddress, kitty_id: u32) {
         let caller = self.blockchain().get_caller();
 
-        require!(self._is_valid_id(kitty_id), "Invalid kitty id!");
+        require!(self.is_valid_id(kitty_id), "Invalid kitty id!");
         require!(
-            self.get_kitty_owner(kitty_id) == caller,
+            self.kitty_owner(kitty_id).get() == caller,
             "You are not the owner of that kitty!"
         );
 
-        self.set_approved_address(kitty_id, &to);
+        self.approved_address(kitty_id).set(&to);
         self.approve_event(&caller, &to, kitty_id);
-
-        Ok(())
     }
 
     #[endpoint]
-    fn transfer(&self, to: ManagedAddress, kitty_id: u32) -> SCResult<()> {
+    fn transfer(&self, to: ManagedAddress, kitty_id: u32) {
         let caller = self.blockchain().get_caller();
 
-        require!(self._is_valid_id(kitty_id), "Invalid kitty id!");
+        require!(self.is_valid_id(kitty_id), "Invalid kitty id!");
         require!(!to.is_zero(), "Can't transfer to default address 0x0!");
         require!(
             to != self.blockchain().get_sc_address(),
             "Can't transfer to this contract!"
         );
         require!(
-            self.get_kitty_owner(kitty_id) == caller,
+            self.kitty_owner(kitty_id).get() == caller,
             "You are not the owner of that kitty!"
         );
 
-        self._transfer(&caller, &to, kitty_id);
-
-        Ok(())
+        self.perform_transfer(&caller, &to, kitty_id);
     }
 
     #[endpoint]
-    fn transfer_from(
-        &self,
-        from: ManagedAddress,
-        to: ManagedAddress,
-        kitty_id: u32,
-    ) -> SCResult<()> {
+    fn transfer_from(&self, from: ManagedAddress, to: ManagedAddress, kitty_id: u32) {
         let caller = self.blockchain().get_caller();
 
-        require!(self._is_valid_id(kitty_id), "Invalid kitty id!");
+        require!(self.is_valid_id(kitty_id), "Invalid kitty id!");
         require!(!to.is_zero(), "Can't transfer to default address 0x0!");
         require!(
             to != self.blockchain().get_sc_address(),
             "Can't transfer to this contract!"
         );
         require!(
-            self.get_kitty_owner(kitty_id) == from,
+            self.kitty_owner(kitty_id).get() == from,
             "ManagedAddress _from_ is not the owner!"
         );
         require!(
-            self.get_kitty_owner(kitty_id) == caller
-                || self._get_approved_address_or_default(kitty_id) == caller,
+            self.kitty_owner(kitty_id).get() == caller
+                || self.get_approved_address_or_default(kitty_id) == caller,
             "You are not the owner of that kitty nor the approved address!"
         );
 
-        self._transfer(&from, &to, kitty_id);
-
-        Ok(())
+        self.perform_transfer(&from, &to, kitty_id);
     }
 
     #[view(tokensOfOwner)]
-    fn tokens_of_owner(&self, address: ManagedAddress) -> Vec<u32> {
-        let nr_owned_kitties = self.get_nr_owned_kitties(&address);
-        let total_kitties = self.get_total_kitties();
-        let mut kitty_list = Vec::new();
+    fn tokens_of_owner(&self, address: ManagedAddress) -> ManagedMultiResultVec<u32> {
+        let nr_owned_kitties = self.nr_owned_kitties(&address).get();
+        let total_kitties = self.total_kitties().get();
+        let mut kitty_list = ManagedVec::new();
+        let mut list_len = 0; // more efficient than calling the API over and over
 
         for kitty_id in 1..total_kitties {
-            if nr_owned_kitties as usize == kitty_list.len() {
+            if nr_owned_kitties as usize == list_len {
                 break;
             }
 
-            if self.get_kitty_owner(kitty_id) == address {
+            if self.kitty_owner(kitty_id).get() == address {
                 kitty_list.push(kitty_id);
+                list_len += 1;
             }
         }
 
-        kitty_list
+        kitty_list.into()
     }
 
     // endpoints - kitty-auction contract only
 
     #[endpoint(allowAuctioning)]
-    fn allow_auctioning(&self, by: ManagedAddress, kitty_id: u32) -> SCResult<()> {
-        let kitty_auction_addr = self._get_kitty_auction_contract_address_or_default();
+    fn allow_auctioning(&self, by: ManagedAddress, kitty_id: u32) {
+        let kitty_auction_addr = self.get_kitty_auction_contract_address_or_default();
 
         require!(
             self.blockchain().get_caller() == kitty_auction_addr,
             "Only auction contract may call this function!"
         );
-        require!(self._is_valid_id(kitty_id), "Invalid kitty id!");
+        require!(self.is_valid_id(kitty_id), "Invalid kitty id!");
         require!(
-            by == self.get_kitty_owner(kitty_id)
-                || by == self._get_approved_address_or_default(kitty_id),
-            "_by_ is not the owner of that kitty nor the approved address!"
+            by == self.kitty_owner(kitty_id).get()
+                || by == self.get_approved_address_or_default(kitty_id),
+            "{:x} is not the owner of that kitty nor the approved address!",
+            by
         );
         require!(
-            !self.get_kitty_by_id(kitty_id).is_pregnant(),
+            !self.kitty_by_id(kitty_id).get().is_pregnant(),
             "Can't auction a pregnant kitty!"
         );
 
         // transfers ownership to the auction contract
-        self._transfer(&by, &kitty_auction_addr, kitty_id);
-
-        Ok(())
+        self.perform_transfer(&by, &kitty_auction_addr, kitty_id);
     }
 
     #[endpoint(approveSiringAndReturnKitty)]
@@ -203,33 +186,32 @@ pub trait KittyOwnership {
         approved_address: ManagedAddress,
         kitty_owner: ManagedAddress,
         kitty_id: u32,
-    ) -> SCResult<()> {
-        let kitty_auction_addr = self._get_kitty_auction_contract_address_or_default();
+    ) {
+        let kitty_auction_addr = self.get_kitty_auction_contract_address_or_default();
 
         require!(
             self.blockchain().get_caller() == kitty_auction_addr,
             "Only auction contract may call this function!"
         );
-        require!(self._is_valid_id(kitty_id), "Invalid kitty id!");
+        require!(self.is_valid_id(kitty_id), "Invalid kitty id!");
         require!(
-            kitty_auction_addr == self.get_kitty_owner(kitty_id)
-                || kitty_auction_addr == self._get_approved_address_or_default(kitty_id),
-            "_by_ is not the owner of that kitty nor the approved address!"
+            kitty_auction_addr == self.kitty_owner(kitty_id).get()
+                || kitty_auction_addr == self.get_approved_address_or_default(kitty_id),
+            "{:x} is not the owner of that kitty nor the approved address!",
+            kitty_auction_addr
         );
 
         // return kitty to its original owner after siring auction is complete
-        self._transfer(&kitty_auction_addr, &kitty_owner, kitty_id);
+        self.perform_transfer(&kitty_auction_addr, &kitty_owner, kitty_id);
 
-        self.set_sire_allowed_address(kitty_id, &approved_address);
-
-        Ok(())
+        self.sire_allowed_address(kitty_id).set(&approved_address);
     }
 
     // create gen zero kitty
     // returns new kitty id
     #[endpoint(createGenZeroKitty)]
-    fn create_gen_zero_kitty(&self) -> SCResult<u32> {
-        let kitty_auction_addr = self._get_kitty_auction_contract_address_or_default();
+    fn create_gen_zero_kitty(&self) -> u32 {
+        let kitty_auction_addr = self.get_kitty_auction_contract_address_or_default();
 
         require!(
             self.blockchain().get_caller() == kitty_auction_addr,
@@ -241,168 +223,160 @@ pub trait KittyOwnership {
             self.blockchain().get_tx_hash_legacy().as_bytes(),
         );
         let genes = KittyGenes::get_random(&mut random);
-        let kitty_id = self._create_new_gen_zero_kitty(&genes);
+        let kitty_id = self.create_new_gen_zero_kitty(&genes);
 
-        Ok(kitty_id)
+        kitty_id
     }
 
     // views - Kitty Breeding
 
     #[view(getKittyById)]
-    fn get_kitty_by_id_endpoint(&self, kitty_id: u32) -> SCResult<Kitty> {
-        if self._is_valid_id(kitty_id) {
-            Ok(self.get_kitty_by_id(kitty_id))
+    fn get_kitty_by_id_endpoint(&self, kitty_id: u32) -> Kitty {
+        if self.is_valid_id(kitty_id) {
+            self.kitty_by_id(kitty_id).get()
         } else {
-            sc_error!("kitty does not exist!")
+            sc_panic!("kitty does not exist!")
         }
     }
 
     #[view(isReadyToBreed)]
-    fn is_ready_to_breed(&self, kitty_id: u32) -> SCResult<bool> {
-        require!(self._is_valid_id(kitty_id), "Invalid kitty id!");
+    fn is_ready_to_breed(&self, kitty_id: u32) -> bool {
+        require!(self.is_valid_id(kitty_id), "Invalid kitty id!");
 
-        let kitty = self.get_kitty_by_id(kitty_id);
+        let kitty = self.kitty_by_id(kitty_id).get();
 
-        Ok(self._is_ready_to_breed(&kitty))
+        self.is_kitty_ready_to_breed(&kitty)
     }
 
     #[view(isPregnant)]
-    fn is_pregnant(&self, kitty_id: u32) -> SCResult<bool> {
-        require!(self._is_valid_id(kitty_id), "Invalid kitty id!");
+    fn is_pregnant(&self, kitty_id: u32) -> bool {
+        require!(self.is_valid_id(kitty_id), "Invalid kitty id!");
 
-        let kitty = self.get_kitty_by_id(kitty_id);
+        let kitty = self.kitty_by_id(kitty_id).get();
 
-        Ok(kitty.is_pregnant())
+        kitty.is_pregnant()
     }
 
     #[view(canBreedWith)]
-    fn can_breed_with(&self, matron_id: u32, sire_id: u32) -> SCResult<bool> {
-        require!(self._is_valid_id(matron_id), "Invalid matron id!");
-        require!(self._is_valid_id(sire_id), "Invalid sire id!");
+    fn can_breed_with(&self, matron_id: u32, sire_id: u32) -> bool {
+        require!(self.is_valid_id(matron_id), "Invalid matron id!");
+        require!(self.is_valid_id(sire_id), "Invalid sire id!");
 
-        Ok(self._is_valid_mating_pair(matron_id, sire_id)
-            && self._is_siring_permitted(matron_id, sire_id))
+        self.is_valid_mating_pair(matron_id, sire_id)
+            && self.is_siring_permitted(matron_id, sire_id)
     }
 
     // endpoints - Kitty Breeding
 
     #[endpoint(approveSiring)]
-    fn approve_siring(&self, address: ManagedAddress, kitty_id: u32) -> SCResult<()> {
-        require!(self._is_valid_id(kitty_id), "Invalid kitty id!");
+    fn approve_siring(&self, address: ManagedAddress, kitty_id: u32) {
+        require!(self.is_valid_id(kitty_id), "Invalid kitty id!");
         require!(
-            self.get_kitty_owner(kitty_id) == self.blockchain().get_caller(),
+            self.kitty_owner(kitty_id).get() == self.blockchain().get_caller(),
             "You are not the owner of the kitty!"
         );
         require!(
-            self._get_sire_allowed_address_or_default(kitty_id)
-                .is_zero(),
+            self.get_sire_allowed_address_or_default(kitty_id).is_zero(),
             "Can't overwrite approved sire address!"
         );
 
-        self.set_sire_allowed_address(kitty_id, &address);
-
-        Ok(())
+        self.sire_allowed_address(kitty_id).set(&address);
     }
 
     #[payable("EGLD")]
     #[endpoint(breedWith)]
-    fn breed_with(
-        &self,
-        #[payment] payment: BigUint,
-        matron_id: u32,
-        sire_id: u32,
-    ) -> SCResult<()> {
-        require!(self._is_valid_id(matron_id), "Invalid matron id!");
-        require!(self._is_valid_id(sire_id), "Invalid sire id!");
+    fn breed_with(&self, #[payment] payment: BigUint, matron_id: u32, sire_id: u32) {
+        require!(self.is_valid_id(matron_id), "Invalid matron id!");
+        require!(self.is_valid_id(sire_id), "Invalid sire id!");
 
-        let auto_birth_fee = self.get_birth_fee();
+        let auto_birth_fee = self.birth_fee().get();
         let caller = self.blockchain().get_caller();
 
         require!(payment == auto_birth_fee, "Wrong fee!");
         require!(
-            caller == self.get_kitty_owner(matron_id),
+            caller == self.kitty_owner(matron_id).get(),
             "Only the owner of the matron can call this function!"
         );
         require!(
-            self._is_siring_permitted(matron_id, sire_id),
+            self.is_siring_permitted(matron_id, sire_id),
             "Siring not permitted!"
         );
 
-        let matron = self.get_kitty_by_id(matron_id);
-        let sire = self.get_kitty_by_id(sire_id);
+        let matron = self.kitty_by_id(matron_id).get();
+        let sire = self.kitty_by_id(sire_id).get();
 
         require!(
-            self._is_ready_to_breed(&matron),
+            self.is_kitty_ready_to_breed(&matron),
             "Matron not ready to breed!"
         );
-        require!(self._is_ready_to_breed(&sire), "Sire not ready to breed!");
         require!(
-            self._is_valid_mating_pair(matron_id, sire_id),
+            self.is_kitty_ready_to_breed(&sire),
+            "Sire not ready to breed!"
+        );
+        require!(
+            self.is_valid_mating_pair(matron_id, sire_id),
             "Not a valid mating pair!"
         );
 
-        self._breed(matron_id, sire_id);
-
-        Ok(())
+        self.breed(matron_id, sire_id);
     }
 
     #[endpoint(giveBirth)]
-    fn give_birth(&self, matron_id: u32) -> SCResult<AsyncCall> {
-        require!(self._is_valid_id(matron_id), "Invalid kitty id!");
+    fn give_birth(&self, matron_id: u32) -> AsyncCall {
+        require!(self.is_valid_id(matron_id), "Invalid kitty id!");
 
-        let matron = self.get_kitty_by_id(matron_id);
+        let matron = self.kitty_by_id(matron_id).get();
 
         require!(
-            self._is_ready_to_give_birth(&matron),
+            self.is_ready_to_give_birth(&matron),
             "Matron not ready to give birth!"
         );
 
         let sire_id = matron.siring_with_id;
-        let sire = self.get_kitty_by_id(sire_id);
+        let sire = self.kitty_by_id(sire_id).get();
 
-        let gene_science_contract_address = self._get_gene_science_contract_address_or_default();
+        let gene_science_contract_address = self.get_gene_science_contract_address_or_default();
         if !gene_science_contract_address.is_zero() {
-            Ok(self
-                .kitty_genetic_alg_proxy(gene_science_contract_address)
+            self.kitty_genetic_alg_proxy(gene_science_contract_address)
                 .generate_kitty_genes(matron, sire)
                 .async_call()
                 .with_callback(
                     self.callbacks()
                         .generate_kitty_genes_callback(matron_id, self.blockchain().get_caller()),
-                ))
+                )
         } else {
-            sc_error!("Gene science contract address not set!")
+            sc_panic!("Gene science contract address not set!")
         }
     }
 
     // private
 
-    fn _transfer(&self, from: &ManagedAddress, to: &ManagedAddress, kitty_id: u32) {
+    fn perform_transfer(&self, from: &ManagedAddress, to: &ManagedAddress, kitty_id: u32) {
         if from == to {
             return;
         }
 
-        let mut nr_owned_to = self.get_nr_owned_kitties(to);
+        let mut nr_owned_to = self.nr_owned_kitties(to).get();
         nr_owned_to += 1;
 
         if !from.is_zero() {
-            let mut nr_owned_from = self.get_nr_owned_kitties(from);
+            let mut nr_owned_from = self.nr_owned_kitties(from).get();
             nr_owned_from -= 1;
 
-            self.set_nr_owned_kitties(from, nr_owned_from);
-            self.clear_sire_allowed_address(kitty_id);
-            self.clear_approved_address(kitty_id);
+            self.nr_owned_kitties(from).set(nr_owned_from);
+            self.sire_allowed_address(kitty_id).clear();
+            self.approved_address(kitty_id).clear();
         }
 
-        self.set_nr_owned_kitties(to, nr_owned_to);
-        self.set_kitty_owner(kitty_id, to);
+        self.nr_owned_kitties(to).set(nr_owned_to);
+        self.kitty_owner(kitty_id).set(to);
 
         self.transfer_event(from, to, kitty_id);
     }
 
     // checks should be done in the caller function
     // returns the newly created kitten id
-    fn _create_new_kitty(
+    fn create_new_kitty(
         &self,
         matron_id: u32,
         sire_id: u32,
@@ -410,7 +384,7 @@ pub trait KittyOwnership {
         genes: &KittyGenes,
         owner: &ManagedAddress,
     ) -> u32 {
-        let mut total_kitties = self.get_total_kitties();
+        let mut total_kitties = self.total_kitties().get();
         let new_kitty_id = total_kitties;
         let kitty = Kitty::new(
             genes,
@@ -421,22 +395,23 @@ pub trait KittyOwnership {
         );
 
         total_kitties += 1;
-        self.set_total_kitties(total_kitties);
-        self.set_kitty_at_id(new_kitty_id, &kitty);
+        self.total_kitties().set(total_kitties);
+        self.kitty_by_id(new_kitty_id).set(&kitty);
 
-        self._transfer(&ManagedAddress::zero(), owner, new_kitty_id);
+        self.perform_transfer(&ManagedAddress::zero(), owner, new_kitty_id);
 
         new_kitty_id
     }
 
-    fn _create_new_gen_zero_kitty(&self, genes: &KittyGenes) -> u32 {
-        self._create_new_kitty(0, 0, 0, genes, &self.get_kitty_auction_contract_address())
+    fn create_new_gen_zero_kitty(&self, genes: &KittyGenes) -> u32 {
+        let kitty_auction_addr = self.kitty_auction_contract_address().get();
+        self.create_new_kitty(0, 0, 0, genes, &kitty_auction_addr)
     }
 
-    fn _create_genesis_kitty(&self) {
+    fn create_genesis_kitty(&self) {
         let genesis_kitty = Kitty::default();
 
-        self._create_new_kitty(
+        self.create_new_kitty(
             genesis_kitty.matron_id,
             genesis_kitty.sire_id,
             genesis_kitty.generation,
@@ -445,54 +420,54 @@ pub trait KittyOwnership {
         );
     }
 
-    fn _trigger_cooldown(&self, kitty: &mut Kitty) {
+    fn trigger_cooldown(&self, kitty: &mut Kitty) {
         let cooldown = kitty.get_next_cooldown_time();
         kitty.cooldown_end = self.blockchain().get_block_timestamp() + cooldown;
     }
 
-    fn _breed(&self, matron_id: u32, sire_id: u32) {
-        let mut matron = self.get_kitty_by_id(matron_id);
-        let mut sire = self.get_kitty_by_id(sire_id);
+    fn breed(&self, matron_id: u32, sire_id: u32) {
+        let mut matron = self.kitty_by_id(matron_id).get();
+        let mut sire = self.kitty_by_id(sire_id).get();
 
         // mark matron as pregnant
         matron.siring_with_id = sire_id;
 
-        self._trigger_cooldown(&mut matron);
-        self._trigger_cooldown(&mut sire);
+        self.trigger_cooldown(&mut matron);
+        self.trigger_cooldown(&mut sire);
 
-        self.clear_sire_allowed_address(matron_id);
-        self.clear_sire_allowed_address(sire_id);
+        self.sire_allowed_address(matron_id).clear();
+        self.sire_allowed_address(sire_id).clear();
 
-        self.set_kitty_at_id(matron_id, &matron);
-        self.set_kitty_at_id(sire_id, &sire);
+        self.kitty_by_id(matron_id).set(&matron);
+        self.kitty_by_id(sire_id).set(&sire);
     }
 
     // private - Kitty checks. These should be in the Kitty struct,
     // but unfortunately, they need access to the contract-only functions
 
-    fn _is_valid_id(&self, kitty_id: u32) -> bool {
-        kitty_id != 0 && kitty_id < self.get_total_kitties()
+    fn is_valid_id(&self, kitty_id: u32) -> bool {
+        kitty_id != 0 && kitty_id < self.total_kitties().get()
     }
 
-    fn _is_ready_to_breed(&self, kitty: &Kitty) -> bool {
+    fn is_kitty_ready_to_breed(&self, kitty: &Kitty) -> bool {
         kitty.siring_with_id == 0 && kitty.cooldown_end < self.blockchain().get_block_timestamp()
     }
 
-    fn _is_siring_permitted(&self, matron_id: u32, sire_id: u32) -> bool {
-        let sire_owner = self.get_kitty_owner(sire_id);
-        let matron_owner = self.get_kitty_owner(matron_id);
-        let sire_approved_address = self._get_sire_allowed_address_or_default(sire_id);
+    fn is_siring_permitted(&self, matron_id: u32, sire_id: u32) -> bool {
+        let sire_owner = self.kitty_owner(sire_id).get();
+        let matron_owner = self.kitty_owner(matron_id).get();
+        let sire_approved_address = self.get_sire_allowed_address_or_default(sire_id);
 
         sire_owner == matron_owner || matron_owner == sire_approved_address
     }
 
-    fn _is_ready_to_give_birth(&self, matron: &Kitty) -> bool {
+    fn is_ready_to_give_birth(&self, matron: &Kitty) -> bool {
         matron.siring_with_id != 0 && matron.cooldown_end < self.blockchain().get_block_timestamp()
     }
 
-    fn _is_valid_mating_pair(&self, matron_id: u32, sire_id: u32) -> bool {
-        let matron = self.get_kitty_by_id(matron_id);
-        let sire = self.get_kitty_by_id(sire_id);
+    fn is_valid_mating_pair(&self, matron_id: u32, sire_id: u32) -> bool {
+        let matron = self.kitty_by_id(matron_id).get();
+        let sire = self.kitty_by_id(sire_id).get();
 
         // can't breed with itself
         if matron_id == sire_id {
@@ -525,35 +500,35 @@ pub trait KittyOwnership {
 
     // getters
 
-    fn _get_gene_science_contract_address_or_default(&self) -> ManagedAddress {
-        if self.is_empty_gene_science_contract_address() {
+    fn get_gene_science_contract_address_or_default(&self) -> ManagedAddress {
+        if self.gene_science_contract_address().is_empty() {
             ManagedAddress::zero()
         } else {
-            self.get_gene_science_contract_address()
+            self.gene_science_contract_address().get()
         }
     }
 
-    fn _get_kitty_auction_contract_address_or_default(&self) -> ManagedAddress {
-        if self.is_empty_kitty_auction_contract_address() {
+    fn get_kitty_auction_contract_address_or_default(&self) -> ManagedAddress {
+        if self.kitty_auction_contract_address().is_empty() {
             ManagedAddress::zero()
         } else {
-            self.get_kitty_auction_contract_address()
+            self.kitty_auction_contract_address().get()
         }
     }
 
-    fn _get_approved_address_or_default(&self, kitty_id: u32) -> ManagedAddress {
-        if self.is_empty_approved_address(kitty_id) {
+    fn get_approved_address_or_default(&self, kitty_id: u32) -> ManagedAddress {
+        if self.approved_address(kitty_id).is_empty() {
             ManagedAddress::zero()
         } else {
-            self.get_approved_address(kitty_id)
+            self.approved_address(kitty_id).get()
         }
     }
 
-    fn _get_sire_allowed_address_or_default(&self, kitty_id: u32) -> ManagedAddress {
-        if self.is_empty_sire_allowed_address(kitty_id) {
+    fn get_sire_allowed_address_or_default(&self, kitty_id: u32) -> ManagedAddress {
+        if self.sire_allowed_address(kitty_id).is_empty() {
             ManagedAddress::zero()
         } else {
-            self.get_sire_allowed_address(kitty_id)
+            self.sire_allowed_address(kitty_id).get()
         }
     }
 
@@ -568,15 +543,15 @@ pub trait KittyOwnership {
     ) {
         match result {
             ManagedAsyncCallResult::Ok(genes) => {
-                let mut matron = self.get_kitty_by_id(matron_id);
+                let mut matron = self.kitty_by_id(matron_id).get();
                 let sire_id = matron.siring_with_id;
-                let mut sire = self.get_kitty_by_id(sire_id);
+                let mut sire = self.kitty_by_id(sire_id).get();
 
                 let new_kitty_generation = max(matron.generation, sire.generation) + 1;
 
                 // new kitty goes to the owner of the matron
-                let new_kitty_owner = self.get_kitty_owner(matron_id);
-                let _new_kitty_id = self._create_new_kitty(
+                let new_kitty_owner = self.kitty_owner(matron_id).get();
+                let _new_kitty_id = self.create_new_kitty(
                     matron_id,
                     sire_id,
                     new_kitty_generation,
@@ -587,14 +562,14 @@ pub trait KittyOwnership {
                 // update matron kitty
                 matron.siring_with_id = 0;
                 matron.nr_children += 1;
-                self.set_kitty_at_id(matron_id, &matron);
+                self.kitty_by_id(matron_id).set(&matron);
 
                 // update sire kitty
                 sire.nr_children += 1;
-                self.set_kitty_at_id(sire_id, &sire);
+                self.kitty_by_id(sire_id).set(&sire);
 
                 // send birth fee to caller
-                let fee = self.get_birth_fee();
+                let fee = self.birth_fee().get();
                 self.send()
                     .direct_egld(&original_caller, &fee, b"birth fee");
             },
@@ -612,80 +587,35 @@ pub trait KittyOwnership {
 
     // storage - General
 
-    #[storage_get("geneScienceContractAddress")]
-    fn get_gene_science_contract_address(&self) -> ManagedAddress;
+    #[storage_mapper("geneScienceContractAddress")]
+    fn gene_science_contract_address(&self) -> SingleValueMapper<ManagedAddress>;
 
-    #[storage_set("geneScienceContractAddress")]
-    fn set_gene_science_contract_address(&self, address: &ManagedAddress);
-
-    #[storage_is_empty("geneScienceContractAddress")]
-    fn is_empty_gene_science_contract_address(&self) -> bool;
-
-    #[storage_get("kittyAuctionContractAddress")]
-    fn get_kitty_auction_contract_address(&self) -> ManagedAddress;
-
-    #[storage_set("kittyAuctionContractAddress")]
-    fn set_kitty_auction_contract_address(&self, address: &ManagedAddress);
-
-    #[storage_is_empty("kittyAuctionContractAddress")]
-    fn is_empty_kitty_auction_contract_address(&self) -> bool;
+    #[storage_mapper("kittyAuctionContractAddress")]
+    fn kitty_auction_contract_address(&self) -> SingleValueMapper<ManagedAddress>;
 
     #[view(birthFee)]
-    #[storage_get("birthFee")]
-    fn get_birth_fee(&self) -> BigUint;
-
-    #[storage_set("birthFee")]
-    fn set_birth_fee(&self, fee: BigUint);
+    #[storage_mapper("birthFee")]
+    fn birth_fee(&self) -> SingleValueMapper<BigUint>;
 
     // storage - Kitties
 
-    #[storage_get("totalKitties")]
-    fn get_total_kitties(&self) -> u32;
+    #[storage_mapper("totalKitties")]
+    fn total_kitties(&self) -> SingleValueMapper<u32>;
 
-    #[storage_set("totalKitties")]
-    fn set_total_kitties(&self, total_kitties: u32);
+    #[storage_mapper("kitty")]
+    fn kitty_by_id(&self, kitty_id: u32) -> SingleValueMapper<Kitty>;
 
-    #[storage_get("kitty")]
-    fn get_kitty_by_id(&self, kitty_id: u32) -> Kitty;
+    #[storage_mapper("owner")]
+    fn kitty_owner(&self, kitty_id: u32) -> SingleValueMapper<ManagedAddress>;
 
-    #[storage_set("kitty")]
-    fn set_kitty_at_id(&self, kitty_id: u32, kitty: &Kitty);
+    #[storage_mapper("nrOwnedKitties")]
+    fn nr_owned_kitties(&self, address: &ManagedAddress) -> SingleValueMapper<u32>;
 
-    #[storage_get("owner")]
-    fn get_kitty_owner(&self, kitty_id: u32) -> ManagedAddress;
+    #[storage_mapper("approvedAddress")]
+    fn approved_address(&self, kitty_id: u32) -> SingleValueMapper<ManagedAddress>;
 
-    #[storage_set("owner")]
-    fn set_kitty_owner(&self, kitty_id: u32, owner: &ManagedAddress);
-
-    #[storage_get("nrOwnedKitties")]
-    fn get_nr_owned_kitties(&self, address: &ManagedAddress) -> u32;
-
-    #[storage_set("nrOwnedKitties")]
-    fn set_nr_owned_kitties(&self, address: &ManagedAddress, nr_owned: u32);
-
-    #[storage_get("approvedAddress")]
-    fn get_approved_address(&self, kitty_id: u32) -> ManagedAddress;
-
-    #[storage_set("approvedAddress")]
-    fn set_approved_address(&self, kitty_id: u32, address: &ManagedAddress);
-
-    #[storage_clear("approvedAddress")]
-    fn clear_approved_address(&self, kitty_id: u32);
-
-    #[storage_is_empty("approvedAddress")]
-    fn is_empty_approved_address(&self, kitty_id: u32) -> bool;
-
-    #[storage_get("sireAllowedAddress")]
-    fn get_sire_allowed_address(&self, kitty_id: u32) -> ManagedAddress;
-
-    #[storage_set("sireAllowedAddress")]
-    fn set_sire_allowed_address(&self, kitty_id: u32, address: &ManagedAddress);
-
-    #[storage_clear("sireAllowedAddress")]
-    fn clear_sire_allowed_address(&self, kitty_id: u32);
-
-    #[storage_is_empty("sireAllowedAddress")]
-    fn is_empty_sire_allowed_address(&self, kitty_id: u32) -> bool;
+    #[storage_mapper("sireAllowedAddress")]
+    fn sire_allowed_address(&self, kitty_id: u32) -> SingleValueMapper<ManagedAddress>;
 
     // events
 

--- a/contracts/examples/digital-cash/src/digital_cash.rs
+++ b/contracts/examples/digital-cash/src/digital_cash.rs
@@ -18,13 +18,8 @@ pub trait DigitalCash {
 
     #[endpoint]
     #[payable("*")]
-    fn fund(
-        &self,
-        #[payment] payment: BigUint,
-        #[payment_token] token: TokenIdentifier,
-        address: ManagedAddress,
-        valability: u64,
-    ) -> SCResult<()> {
+    fn fund(&self, address: ManagedAddress, valability: u64) {
+        let (payment, token) = self.call_value().payment_token_pair();
         require!(payment > BigUint::zero(), "amount must be greater than 0");
         require!(self.deposit(&address).is_empty(), "key already used");
 
@@ -39,12 +34,10 @@ pub trait DigitalCash {
         };
 
         self.deposit(&address).set(deposit);
-
-        Ok(())
     }
 
     #[endpoint]
-    fn withdraw(&self, address: ManagedAddress) -> SCResult<()> {
+    fn withdraw(&self, address: ManagedAddress) {
         require!(!self.deposit(&address).is_empty(), "non-existent key");
 
         let deposit = self.deposit(&address).get();
@@ -61,12 +54,10 @@ pub trait DigitalCash {
             b"successful withdrawal",
         );
         self.deposit(&address).clear();
-
-        Ok(())
     }
 
     #[endpoint]
-    fn claim(&self, address: ManagedAddress, signature: ManagedBuffer) -> SCResult<()> {
+    fn claim(&self, address: ManagedAddress, signature: ManagedBuffer) {
         require!(!self.deposit(&address).is_empty(), "non-existent key");
 
         let deposit = self.deposit(&address).get();
@@ -93,19 +84,16 @@ pub trait DigitalCash {
             b"successful claim",
         );
         self.deposit(&address).clear();
-
-        Ok(())
     }
 
     //views
 
     #[view(amount)]
-    fn get_amount(&self, address: ManagedAddress) -> SCResult<BigUint> {
+    fn get_amount(&self, address: ManagedAddress) -> BigUint {
         require!(!self.deposit(&address).is_empty(), "non-existent key");
 
         let data = self.deposit(&address).get();
-
-        Ok(data.amount)
+        data.amount
     }
 
     //private functions

--- a/contracts/examples/egld-esdt-swap/mandos/unwrap_egld.scen.json
+++ b/contracts/examples/egld-esdt-swap/mandos/unwrap_egld.scen.json
@@ -1,5 +1,6 @@
 {
     "name": "unwrap egld",
+    "gasSchedule": "v4",
     "steps": [
         {
             "step": "externalSteps",
@@ -10,33 +11,20 @@
             "txId": "unwrap-egld",
             "tx": {
                 "from": "address:user",
-                "to": "sc:egld-esdt-swap",
-                "esdtValue": [
-                    {
-                        "tokenIdentifier": "str:WEGLD-abcdef",
-                        "value": "300"
-                    }
-                ],
+                "to": "sc:egld_esdt_swap",
+                "value": "0",
+                "esdt": {
+                    "tokenIdentifier": "str:EGLD-abcdef",
+                    "value": "300"
+                },
                 "function": "unwrapEgld",
                 "arguments": [],
-                "gasLimit": "100,000,000",
+                "gasLimit": "5,000,000",
                 "gasPrice": "0"
             },
             "expect": {
-                "out": [],
                 "status": "0",
                 "message": "",
-                "logs": [
-                    {
-                        "address": "sc:egld-esdt-swap",
-                        "endpoint": "str:unwrapEgld",
-                        "topics": [
-                            "str:unwrap-egld",
-                            "address:user"
-                        ],
-                        "data": "300"
-                    }
-                ],
                 "gas": "*",
                 "refund": "*"
             }
@@ -48,19 +36,24 @@
                     "nonce": "2",
                     "balance": "800",
                     "esdt": {
-                        "str:WEGLD-abcdef": "200"
+                        "str:EGLD-abcdef": "200"
                     },
                     "storage": {}
                 },
-                "sc:egld-esdt-swap": {
+                "sc:egld_esdt_swap": {
                     "nonce": "0",
                     "balance": "200",
                     "esdt": {
-                        "str:WEGLD-abcdef": "1800"
+                        "str:EGLD-abcdef": {
+                            "balance": "1",
+                            "roles": [
+                                "ESDTRoleLocalMint",
+                                "ESDTRoleLocalBurn"
+                            ]
+                        }
                     },
                     "storage": {
-                        "str:wrapped_egld_token_id": "str:WEGLD-abcdef",
-                        "str:unused_wrapped_egld": "1800"
+                        "str:wrappedEgldTokenId": "str:EGLD-abcdef"
                     },
                     "code": "file:../output/egld-esdt-swap.wasm"
                 }

--- a/contracts/examples/egld-esdt-swap/mandos/wrap_egld.scen.json
+++ b/contracts/examples/egld-esdt-swap/mandos/wrap_egld.scen.json
@@ -1,22 +1,29 @@
 {
     "name": "wrap egld",
+    "gasSchedule": "v4",
     "steps": [
         {
             "step": "setState",
             "accounts": {
                 "address:user": {
                     "nonce": "0",
-                    "balance": "1000"
+                    "balance": "1000",
+                    "storage": {}
                 },
-                "sc:egld-esdt-swap": {
+                "sc:egld_esdt_swap": {
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:WEGLD-abcdef": "2000"
+                        "str:EGLD-abcdef": {
+                            "balance": "1",
+                            "roles": [
+                                "ESDTRoleLocalMint",
+                                "ESDTRoleLocalBurn"
+                            ]
+                        }
                     },
                     "storage": {
-                        "str:wrapped_egld_token_id": "str:WEGLD-abcdef",
-                        "str:unused_wrapped_egld": "2000"
+                        "str:wrappedEgldTokenId": "str:EGLD-abcdef"
                     },
                     "code": "file:../output/egld-esdt-swap.wasm"
                 }
@@ -27,39 +34,16 @@
             "txId": "wrap-egld",
             "tx": {
                 "from": "address:user",
-                "to": "sc:egld-esdt-swap",
-                "egldValue": "500",
+                "to": "sc:egld_esdt_swap",
+                "value": "500",
                 "function": "wrapEgld",
                 "arguments": [],
-                "gasLimit": "100,000,000",
+                "gasLimit": "5,000,000",
                 "gasPrice": "0"
             },
             "expect": {
-                "out": [],
                 "status": "0",
                 "message": "",
-                "logs": [
-                    {
-                        "address": "sc:egld-esdt-swap",
-                        "endpoint": "str:ESDTTransfer",
-                        "topics": [
-                            "str:WEGLD-abcdef",
-                            "",
-                            "500",
-                            "address:user"
-                        ],
-                        "data": ""
-                    },
-                    {
-                        "address": "sc:egld-esdt-swap",
-                        "endpoint": "str:wrapEgld",
-                        "topics": [
-                            "str:wrap-egld",
-                            "address:user"
-                        ],
-                        "data": "500"
-                    }
-                ],
                 "gas": "*",
                 "refund": "*"
             }
@@ -71,19 +55,24 @@
                     "nonce": "1",
                     "balance": "500",
                     "esdt": {
-                        "str:WEGLD-abcdef": "500"
+                        "str:EGLD-abcdef": "500"
                     },
                     "storage": {}
                 },
-                "sc:egld-esdt-swap": {
+                "sc:egld_esdt_swap": {
                     "nonce": "0",
                     "balance": "500",
                     "esdt": {
-                        "str:WEGLD-abcdef": "1500"
+                        "str:EGLD-abcdef": {
+                            "balance": "1",
+                            "roles": [
+                                "ESDTRoleLocalMint",
+                                "ESDTRoleLocalBurn"
+                            ]
+                        }
                     },
                     "storage": {
-                        "str:wrapped_egld_token_id": "str:WEGLD-abcdef",
-                        "str:unused_wrapped_egld": "1500"
+                        "str:wrappedEgldTokenId": "str:EGLD-abcdef"
                     },
                     "code": "file:../output/egld-esdt-swap.wasm"
                 }

--- a/contracts/examples/egld-esdt-swap/src/swap.rs
+++ b/contracts/examples/egld-esdt-swap/src/swap.rs
@@ -22,15 +22,15 @@ pub trait EgldEsdtSwap {
         &self,
         token_display_name: ManagedBuffer,
         token_ticker: ManagedBuffer,
-        initial_supply: BigUint,
-        #[payment] issue_cost: BigUint,
     ) -> AsyncCall {
         require!(
             self.wrapped_egld_token_id().is_empty(),
             "wrapped egld was already issued"
         );
 
+        let issue_cost = self.call_value().egld_value();
         let caller = self.blockchain().get_caller();
+        let initial_supply = BigUint::zero();
 
         self.issue_started_event(&caller, &token_ticker, &initial_supply);
 
@@ -61,16 +61,15 @@ pub trait EgldEsdtSwap {
     fn esdt_issue_callback(
         &self,
         caller: &ManagedAddress,
-        #[payment_token] token_identifier: TokenIdentifier,
-        #[payment] returned_tokens: BigUint,
         #[call_result] result: ManagedAsyncCallResult<()>,
     ) {
+        let (returned_tokens, token_identifier) = self.call_value().payment_token_pair();
+
         // callback is called with ESDTTransfer of the newly issued token, with the amount requested,
         // so we can get the token identifier and amount from the call data
         match result {
             ManagedAsyncCallResult::Ok(()) => {
                 self.issue_success_event(caller, &token_identifier, &returned_tokens);
-                self.unused_wrapped_egld().set(returned_tokens.as_ref());
                 self.wrapped_egld_token_id().set(token_identifier.as_ref());
             },
             ManagedAsyncCallResult::Err(message) => {
@@ -86,112 +85,63 @@ pub trait EgldEsdtSwap {
     }
 
     #[only_owner]
-    #[endpoint(mintWrappedEgld)]
-    fn mint_wrapped_egld(&self, amount: BigUint) -> AsyncCall {
+    #[endpoint(setLocalRoles)]
+    fn set_local_roles(&self) -> AsyncCall {
         require!(
             !self.wrapped_egld_token_id().is_empty(),
-            "Wrapped EGLD was not issued yet"
+            "Must issue token first"
         );
-
-        let wrapped_egld_token_id = self.wrapped_egld_token_id().get();
-        let caller = self.blockchain().get_caller();
-        self.mint_started_event(&caller, &amount);
 
         self.send()
             .esdt_system_sc_proxy()
-            .mint(&wrapped_egld_token_id, &amount)
+            .set_special_roles(
+                &self.blockchain().get_sc_address(),
+                &self.wrapped_egld_token_id().get(),
+                [EsdtLocalRole::Mint, EsdtLocalRole::Burn][..]
+                    .iter()
+                    .cloned(),
+            )
             .async_call()
-            .with_callback(self.callbacks().esdt_mint_callback(&caller, &amount))
-    }
-
-    #[callback]
-    fn esdt_mint_callback(
-        &self,
-        caller: &ManagedAddress,
-        amount: &BigUint,
-        #[call_result] result: ManagedAsyncCallResult<()>,
-    ) {
-        match result {
-            ManagedAsyncCallResult::Ok(()) => {
-                self.mint_success_event(caller);
-                self.unused_wrapped_egld()
-                    .update(|unused_wrapped_egld| *unused_wrapped_egld += amount);
-            },
-            ManagedAsyncCallResult::Err(message) => {
-                self.mint_failure_event(caller, &message.err_msg);
-            },
-        }
     }
 
     // endpoints
 
     #[payable("EGLD")]
     #[endpoint(wrapEgld)]
-    fn wrap_egld(&self, #[payment] payment: BigUint) {
-        require!(payment > 0u32, "Payment must be more than 0");
-        require!(
-            !self.wrapped_egld_token_id().is_empty(),
-            "Wrapped EGLD was not issued yet"
-        );
+    fn wrap_egld(&self) {
+        let (payment_amount, payment_token) = self.call_value().payment_token_pair();
+        require!(payment_token.is_egld(), "Only EGLD accepted");
+        require!(payment_amount > 0u32, "Payment must be more than 0");
 
-        self.unused_wrapped_egld().update(|unused_wrapped_egld| {
-            require!(
-                *unused_wrapped_egld > payment,
-                "Contract does not have enough wrapped EGLD. Please try again once more is minted."
-            );
-
-            *unused_wrapped_egld -= &payment;
-        });
+        let wrapped_egld_token_id = self.wrapped_egld_token_id().get();
+        self.send()
+            .esdt_local_mint(&wrapped_egld_token_id, 0, &payment_amount);
 
         let caller = self.blockchain().get_caller();
-        self.send().direct(
-            &caller,
-            &self.wrapped_egld_token_id().get(),
-            0,
-            &payment,
-            b"wrapping",
-        );
-
-        self.wrap_egld_event(&caller, &payment);
+        self.send()
+            .direct(&caller, &wrapped_egld_token_id, 0, &payment_amount, &[]);
     }
 
     #[payable("*")]
     #[endpoint(unwrapEgld)]
-    fn unwrap_egld(
-        &self,
-        #[payment] wrapped_egld_payment: BigUint,
-        #[payment_token] token_identifier: TokenIdentifier,
-    ) {
-        require!(
-            !self.wrapped_egld_token_id().is_empty(),
-            "Wrapped EGLD was not issued yet"
-        );
+    fn unwrap_egld(&self) {
+        let (payment_amount, payment_token) = self.call_value().payment_token_pair();
+        let wrapped_egld_token_id = self.wrapped_egld_token_id().get();
 
-        let wrapped_egld_token_identifier = self.wrapped_egld_token_id().get();
-        require!(
-            token_identifier == wrapped_egld_token_identifier,
-            "Wrong esdt token"
-        );
-
-        require!(wrapped_egld_payment > 0u32, "Must pay more than 0 tokens!");
+        require!(payment_token == wrapped_egld_token_id, "Wrong esdt token");
+        require!(payment_amount > 0u32, "Must pay more than 0 tokens!");
         // this should never happen, but we'll check anyway
         require!(
-            wrapped_egld_payment
-                <= self
-                    .blockchain()
-                    .get_sc_balance(&TokenIdentifier::egld(), 0),
+            payment_amount <= self.get_locked_egld_balance(),
             "Contract does not have enough funds"
         );
 
-        self.unused_wrapped_egld()
-            .update(|unused_wrapped_egld| *unused_wrapped_egld += &wrapped_egld_payment);
-
-        // 1 wrapped EGLD = 1 EGLD, so we pay back the same amount
-        let caller = self.blockchain().get_caller();
         self.send()
-            .direct_egld(&caller, &wrapped_egld_payment, b"unwrapping");
+            .esdt_local_burn(&wrapped_egld_token_id, 0, &payment_amount);
 
-        self.unwrap_egld_event(&caller, &wrapped_egld_payment);
+        // 1 wrapped eGLD = 1 eGLD, so we pay back the same amount
+        let caller = self.blockchain().get_caller();
+        self.send().direct_egld(&caller, &payment_amount, &[]);
     }
 
     #[view(getLockedEgldBalance)]
@@ -203,12 +153,8 @@ pub trait EgldEsdtSwap {
     // storage
 
     #[view(getWrappedEgldTokenIdentifier)]
-    #[storage_mapper("wrapped_egld_token_id")]
+    #[storage_mapper("wrappedEgldTokenId")]
     fn wrapped_egld_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
-
-    #[view(getUnusedWrappedEgld)]
-    #[storage_mapper("unused_wrapped_egld")]
-    fn unused_wrapped_egld(&self) -> SingleValueMapper<BigUint>;
 
     // events
 
@@ -230,15 +176,6 @@ pub trait EgldEsdtSwap {
 
     #[event("issue-failure")]
     fn issue_failure_event(&self, #[indexed] caller: &ManagedAddress, message: &ManagedBuffer);
-
-    #[event("mint-started")]
-    fn mint_started_event(&self, #[indexed] caller: &ManagedAddress, amount: &BigUint);
-
-    #[event("mint-success")]
-    fn mint_success_event(&self, #[indexed] caller: &ManagedAddress);
-
-    #[event("mint-failure")]
-    fn mint_failure_event(&self, #[indexed] caller: &ManagedAddress, message: &ManagedBuffer);
 
     #[event("wrap-egld")]
     fn wrap_egld_event(&self, #[indexed] user: &ManagedAddress, amount: &BigUint);

--- a/contracts/examples/egld-esdt-swap/wasm/src/lib.rs
+++ b/contracts/examples/egld-esdt-swap/wasm/src/lib.rs
@@ -9,10 +9,9 @@ elrond_wasm_node::wasm_endpoints! {
     (
         callBack
         getLockedEgldBalance
-        getUnusedWrappedEgld
         getWrappedEgldTokenIdentifier
         issueWrappedEgld
-        mintWrappedEgld
+        setLocalRoles
         unwrapEgld
         wrapEgld
     )

--- a/contracts/examples/lottery-esdt/mandos/buy-all-tickets-different-accounts.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-all-tickets-different-accounts.scen.json
@@ -223,8 +223,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:1",
                             "5-prize_distribution": "u32:2|u8:75|u8:25",
-                            "6-whitelist": "u32:5|address:acc1|address:acc2|address:acc3|address:acc4|address:acc5",
-                            "7-prize_pool": "biguint:500"
+                            "6-prize_pool": "biguint:500"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "5",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",
@@ -236,7 +235,8 @@
                         "str:numberOfEntriesForUser|u32:12|str:lottery_name|address:acc2": "1",
                         "str:numberOfEntriesForUser|u32:12|str:lottery_name|address:acc3": "1",
                         "str:numberOfEntriesForUser|u32:12|str:lottery_name|address:acc4": "1",
-                        "str:numberOfEntriesForUser|u32:12|str:lottery_name|address:acc5": "1"
+                        "str:numberOfEntriesForUser|u32:12|str:lottery_name|address:acc5": "1",
+                        "+": ""
                     },
                     "code": "file:../output/lottery-esdt.wasm"
                 }

--- a/contracts/examples/lottery-esdt/mandos/buy-more-tickets-than-allowed.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-more-tickets-than-allowed.scen.json
@@ -80,12 +80,12 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:1",
                             "5-prize_distribution": "u32:2|u8:75|u8:25",
-                            "6-whitelist": "u32:3|address:my_address|address:acc1|address:acc2",
-                            "7-prize_pool": "biguint:100"
+                            "6-prize_pool": "biguint:100"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "1",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",
-                        "str:numberOfEntriesForUser|u32:12|str:lottery_name|address:acc1": "1"
+                        "str:numberOfEntriesForUser|u32:12|str:lottery_name|address:acc1": "1",
+                        "+": ""
                     },
                     "code": "file:../output/lottery-esdt.wasm"
                 }

--- a/contracts/examples/lottery-esdt/mandos/buy-ticket-after-deadline.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-ticket-after-deadline.scen.json
@@ -83,8 +83,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:100"
+                            "6-prize_pool": "biguint:100"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "1",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",

--- a/contracts/examples/lottery-esdt/mandos/buy-ticket-after-sold-out.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-ticket-after-sold-out.scen.json
@@ -80,8 +80,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:200"
+                            "6-prize_pool": "biguint:200"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "2",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",

--- a/contracts/examples/lottery-esdt/mandos/buy-ticket-all-options.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-ticket-all-options.scen.json
@@ -76,12 +76,12 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:1",
                             "5-prize_distribution": "u32:2|u8:75|u8:25",
-                            "6-whitelist": "u32:3|address:my_address|address:acc1|address:acc2",
-                            "7-prize_pool": "biguint:100"
+                            "6-prize_pool": "biguint:100"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "1",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",
-                        "str:numberOfEntriesForUser|u32:12|str:lottery_name|address:acc1": "1"
+                        "str:numberOfEntriesForUser|u32:12|str:lottery_name|address:acc1": "1",
+                        "+": ""
                     },
                     "code": "file:../output/lottery-esdt.wasm"
                 }

--- a/contracts/examples/lottery-esdt/mandos/buy-ticket-another-account.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-ticket-another-account.scen.json
@@ -76,8 +76,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:200"
+                            "6-prize_pool": "biguint:200"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "2",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",

--- a/contracts/examples/lottery-esdt/mandos/buy-ticket-not-on-whitelist.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-ticket-not-on-whitelist.scen.json
@@ -82,9 +82,9 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:1",
                             "5-prize_distribution": "u32:2|u8:75|u8:25",
-                            "6-whitelist": "u32:3|address:my_address|address:acc1|address:acc2",
-                            "7-prize_pool": "biguint:0"
-                        }
+                            "6-prize_pool": "biguint:0"
+                        },
+                        "+": ""
                     },
                     "code": "file:../output/lottery-esdt.wasm"
                 }

--- a/contracts/examples/lottery-esdt/mandos/buy-ticket-same-account.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-ticket-same-account.scen.json
@@ -76,8 +76,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:200"
+                            "6-prize_pool": "biguint:200"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "2",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",

--- a/contracts/examples/lottery-esdt/mandos/buy-ticket-second-lottery.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-ticket-second-lottery.scen.json
@@ -76,8 +76,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         },
                         "str:lotteryInfo|nested:str:lottery_$$$$": {
                             "0-token_identifier": "nested:str:LOTTO-123456",
@@ -86,8 +85,7 @@
                             "3-deadline": "u64:234,567",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:500"
+                            "6-prize_pool": "biguint:500"
                         },
                         "str:ticketHolder|nested:str:lottery_$$$$|str:.len": "1",
                         "str:ticketHolder|nested:str:lottery_$$$$|str:.item|u32:1": "address:acc1",

--- a/contracts/examples/lottery-esdt/mandos/buy-ticket-wrong-fee.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-ticket-wrong-fee.scen.json
@@ -77,8 +77,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         }
                     },
                     "code": "file:../output/lottery-esdt.wasm"

--- a/contracts/examples/lottery-esdt/mandos/buy-ticket.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/buy-ticket.scen.json
@@ -76,8 +76,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:100"
+                            "6-prize_pool": "biguint:100"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "1",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",

--- a/contracts/examples/lottery-esdt/mandos/complex-prize-distribution.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/complex-prize-distribution.scen.json
@@ -64,8 +64,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:1",
                             "5-prize_distribution": "u32:10|u8:50|u8:25|u8:10|u8:5|u8:5|u8:1|u8:1|u8:1|u8:1|u8:1",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:60700"
+                            "6-prize_pool": "biguint:60700"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "10",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",

--- a/contracts/examples/lottery-esdt/mandos/determine-winner-early.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/determine-winner-early.scen.json
@@ -87,8 +87,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:100"
+                            "6-prize_pool": "biguint:100"
                         },
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "1",
                         "str:ticketHolder|nested:str:lottery_name|str:.item|u32:1": "address:acc1",

--- a/contracts/examples/lottery-esdt/mandos/lottery-with-burn-percentage.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/lottery-with-burn-percentage.scen.json
@@ -112,8 +112,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         },
                         "str:burnPercentageForLottery|nested:str:lottery_name": "50"
                     },
@@ -211,8 +210,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:200"
+                            "6-prize_pool": "biguint:200"
                         },
                         "str:burnPercentageForLottery|nested:str:lottery_name": "50",
                         "str:ticketHolder|nested:str:lottery_name|str:.len": "2",

--- a/contracts/examples/lottery-esdt/mandos/start-after-announced-winner.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/start-after-announced-winner.scen.json
@@ -65,8 +65,7 @@
                             "3-deadline": "u64:12345678905",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         }
                     },
                     "code": "file:../output/lottery-esdt.wasm"

--- a/contracts/examples/lottery-esdt/mandos/start-all-options-bigger-whitelist.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/start-all-options-bigger-whitelist.scen.json
@@ -94,9 +94,9 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:1",
                             "5-prize_distribution": "u32:2|u8:75|u8:25",
-                            "6-whitelist": "u32:5|address:acc1|address:acc2|address:acc3|address:acc4|address:acc5",
-                            "7-prize_pool": "biguint:0"
-                        }
+                            "6-prize_pool": "biguint:0"
+                        },
+                        "+": ""
                     },
                     "code": "file:../output/lottery-esdt.wasm"
                 }

--- a/contracts/examples/lottery-esdt/mandos/start-alternative-function-name.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/start-alternative-function-name.scen.json
@@ -62,8 +62,7 @@
                             "3-deadline": "u64:2592000",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         }
                     },
                     "code": "file:../output/lottery-esdt.wasm"

--- a/contracts/examples/lottery-esdt/mandos/start-fixed-deadline.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/start-fixed-deadline.scen.json
@@ -62,8 +62,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         }
                     },
                     "code": "file:../output/lottery-esdt.wasm"

--- a/contracts/examples/lottery-esdt/mandos/start-limited-tickets-and-fixed-deadline.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/start-limited-tickets-and-fixed-deadline.scen.json
@@ -62,8 +62,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         }
                     },
                     "code": "file:../output/lottery-esdt.wasm"

--- a/contracts/examples/lottery-esdt/mandos/start-limited-tickets.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/start-limited-tickets.scen.json
@@ -62,8 +62,7 @@
                             "3-deadline": "u64:2592000",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         }
                     },
                     "code": "file:../output/lottery-esdt.wasm"

--- a/contracts/examples/lottery-esdt/mandos/start-second-lottery.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/start-second-lottery.scen.json
@@ -62,8 +62,7 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         },
                         "str:lotteryInfo|nested:str:lottery_$$$$": {
                             "0-token_identifier": "nested:str:LOTTO-123456",
@@ -72,8 +71,7 @@
                             "3-deadline": "u64:234,567",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         }
                     },
                     "code": "file:../output/lottery-esdt.wasm"

--- a/contracts/examples/lottery-esdt/mandos/start-with-all-options.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/start-with-all-options.scen.json
@@ -62,9 +62,9 @@
                             "3-deadline": "u64:123,456",
                             "4-max_entries_per_user": "u32:1",
                             "5-prize_distribution": "u32:2|u8:75|u8:25",
-                            "6-whitelist": "u32:3|address:my_address|address:acc1|address:acc2",
-                            "7-prize_pool": "biguint:0"
-                        }
+                            "6-prize_pool": "biguint:0"
+                        },
+                        "+": ""
                     },
                     "code": "file:../output/lottery-esdt.wasm"
                 }

--- a/contracts/examples/lottery-esdt/mandos/start-with-no-options.scen.json
+++ b/contracts/examples/lottery-esdt/mandos/start-with-no-options.scen.json
@@ -62,8 +62,7 @@
                             "3-deadline": "u64:2592000",
                             "4-max_entries_per_user": "u32:800",
                             "5-prize_distribution": "nested:u8:100",
-                            "6-whitelist": "nested:",
-                            "7-prize_pool": "biguint:0"
+                            "6-prize_pool": "biguint:0"
                         }
                     },
                     "code": "file:../output/lottery-esdt.wasm"

--- a/contracts/examples/lottery-esdt/src/lottery.rs
+++ b/contracts/examples/lottery-esdt/src/lottery.rs
@@ -20,16 +20,16 @@ pub trait Lottery {
     #[endpoint]
     fn start(
         &self,
-        lottery_name: BoxedBytes,
+        lottery_name: ManagedBuffer,
         token_identifier: TokenIdentifier,
         ticket_price: BigUint,
         opt_total_tickets: Option<u32>,
         opt_deadline: Option<u64>,
         opt_max_entries_per_user: Option<u32>,
-        opt_prize_distribution: Option<Vec<u8>>,
-        opt_whitelist: Option<Vec<ManagedAddress>>,
+        opt_prize_distribution: Option<ManagedVec<u8>>,
+        opt_whitelist: Option<ManagedVec<ManagedAddress>>,
         #[var_args] opt_burn_percentage: OptionalArg<BigUint>,
-    ) -> SCResult<()> {
+    ) {
         self.start_lottery(
             lottery_name,
             token_identifier,
@@ -40,22 +40,22 @@ pub trait Lottery {
             opt_prize_distribution,
             opt_whitelist,
             opt_burn_percentage,
-        )
+        );
     }
 
     #[endpoint(createLotteryPool)]
     fn create_lottery_pool(
         &self,
-        lottery_name: BoxedBytes,
+        lottery_name: ManagedBuffer,
         token_identifier: TokenIdentifier,
         ticket_price: BigUint,
         opt_total_tickets: Option<u32>,
         opt_deadline: Option<u64>,
         opt_max_entries_per_user: Option<u32>,
-        opt_prize_distribution: Option<Vec<u8>>,
-        opt_whitelist: Option<Vec<ManagedAddress>>,
+        opt_prize_distribution: Option<ManagedVec<u8>>,
+        opt_whitelist: Option<ManagedVec<ManagedAddress>>,
         #[var_args] opt_burn_percentage: OptionalArg<BigUint>,
-    ) -> SCResult<()> {
+    ) {
         self.start_lottery(
             lottery_name,
             token_identifier,
@@ -66,31 +66,30 @@ pub trait Lottery {
             opt_prize_distribution,
             opt_whitelist,
             opt_burn_percentage,
-        )
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
     fn start_lottery(
         &self,
-        lottery_name: BoxedBytes,
+        lottery_name: ManagedBuffer,
         token_identifier: TokenIdentifier,
         ticket_price: BigUint,
         opt_total_tickets: Option<u32>,
         opt_deadline: Option<u64>,
         opt_max_entries_per_user: Option<u32>,
-        opt_prize_distribution: Option<Vec<u8>>,
-        opt_whitelist: Option<Vec<ManagedAddress>>,
+        opt_prize_distribution: Option<ManagedVec<u8>>,
+        opt_whitelist: Option<ManagedVec<ManagedAddress>>,
         #[var_args] opt_burn_percentage: OptionalArg<BigUint>,
-    ) -> SCResult<()> {
+    ) {
         require!(!lottery_name.is_empty(), "Name can't be empty!");
 
         let timestamp = self.blockchain().get_block_timestamp();
         let total_tickets = opt_total_tickets.unwrap_or(MAX_TICKETS);
         let deadline = opt_deadline.unwrap_or(timestamp + THIRTY_DAYS_IN_SECONDS);
         let max_entries_per_user = opt_max_entries_per_user.unwrap_or(MAX_TICKETS);
-        let prize_distribution =
-            opt_prize_distribution.unwrap_or_else(|| [PERCENTAGE_TOTAL as u8].to_vec());
-        let whitelist = opt_whitelist.unwrap_or_default();
+        let prize_distribution = opt_prize_distribution
+            .unwrap_or_else(|| ManagedVec::from_single_item(PERCENTAGE_TOTAL as u8));
 
         require!(
             self.status(&lottery_name) == Status::Inactive,
@@ -144,6 +143,13 @@ pub trait Lottery {
             OptionalArg::None => {},
         }
 
+        if let Some(whitelist) = opt_whitelist {
+            let mut mapper = self.lottery_whitelist(&lottery_name);
+            for addr in &whitelist {
+                mapper.insert(addr);
+            }
+        }
+
         let info = LotteryInfo {
             token_identifier,
             ticket_price,
@@ -151,49 +157,42 @@ pub trait Lottery {
             deadline,
             max_entries_per_user,
             prize_distribution,
-            whitelist,
             prize_pool: BigUint::zero(),
         };
 
         self.lottery_info(&lottery_name).set(&info);
-
-        Ok(())
     }
 
     #[endpoint]
     #[payable("*")]
-    fn buy_ticket(
-        &self,
-        lottery_name: BoxedBytes,
-        #[payment_token] token_identifier: TokenIdentifier,
-        #[payment] payment: BigUint,
-    ) -> SCResult<()> {
+    fn buy_ticket(&self, lottery_name: ManagedBuffer) {
+        let (payment, token_identifier) = self.call_value().payment_token_pair();
+
         match self.status(&lottery_name) {
-            Status::Inactive => sc_error!("Lottery is currently inactive."),
+            Status::Inactive => sc_panic!("Lottery is currently inactive."),
             Status::Running => {
                 self.update_after_buy_ticket(&lottery_name, &token_identifier, &payment)
             },
             Status::Ended => {
-                sc_error!("Lottery entry period has ended! Awaiting winner announcement.")
+                sc_panic!("Lottery entry period has ended! Awaiting winner announcement.")
             },
-        }
+        };
     }
 
     #[endpoint]
-    fn determine_winner(&self, lottery_name: BoxedBytes) -> SCResult<()> {
+    fn determine_winner(&self, lottery_name: ManagedBuffer) {
         match self.status(&lottery_name) {
-            Status::Inactive => sc_error!("Lottery is inactive!"),
-            Status::Running => sc_error!("Lottery is still running!"),
+            Status::Inactive => sc_panic!("Lottery is inactive!"),
+            Status::Running => sc_panic!("Lottery is still running!"),
             Status::Ended => {
                 self.distribute_prizes(&lottery_name);
                 self.clear_storage(&lottery_name);
-                Ok(())
             },
-        }
+        };
     }
 
     #[view]
-    fn status(&self, lottery_name: &BoxedBytes) -> Status {
+    fn status(&self, lottery_name: &ManagedBuffer) -> Status {
         if self.lottery_info(lottery_name).is_empty() {
             return Status::Inactive;
         }
@@ -209,15 +208,16 @@ pub trait Lottery {
 
     fn update_after_buy_ticket(
         &self,
-        lottery_name: &BoxedBytes,
+        lottery_name: &ManagedBuffer,
         token_identifier: &TokenIdentifier,
         payment: &BigUint,
-    ) -> SCResult<()> {
+    ) {
         let mut info = self.lottery_info(lottery_name).get();
         let caller = self.blockchain().get_caller();
+        let whitelist = self.lottery_whitelist(lottery_name);
 
         require!(
-            info.whitelist.is_empty() || info.whitelist.contains(&caller),
+            whitelist.is_empty() || whitelist.contains(&caller),
             "You are not allowed to participate in this lottery!"
         );
         require!(
@@ -240,11 +240,9 @@ pub trait Lottery {
         self.number_of_entries_for_user(lottery_name, &caller)
             .set(&entries);
         self.lottery_info(lottery_name).set(&info);
-
-        Ok(())
     }
 
-    fn distribute_prizes(&self, lottery_name: &BoxedBytes) {
+    fn distribute_prizes(&self, lottery_name: &ManagedBuffer) {
         let mut info = self.lottery_info(lottery_name).get();
         let total_tickets = self.ticket_holders(lottery_name).len();
 
@@ -286,8 +284,10 @@ pub trait Lottery {
         for i in (1..total_winning_tickets).rev() {
             let winning_ticket_id = winning_tickets[i];
             let winner_address = self.ticket_holders(lottery_name).get(winning_ticket_id);
-            let prize = self
-                .calculate_percentage_of(&total_prize, &BigUint::from(info.prize_distribution[i]));
+            let prize = self.calculate_percentage_of(
+                &total_prize,
+                &BigUint::from(info.prize_distribution.get(i)),
+            );
 
             self.send().direct(
                 &winner_address,
@@ -310,7 +310,7 @@ pub trait Lottery {
         );
     }
 
-    fn clear_storage(&self, lottery_name: &BoxedBytes) {
+    fn clear_storage(&self, lottery_name: &ManagedBuffer) {
         let current_ticket_number = self.ticket_holders(lottery_name).len();
 
         for i in 1..=current_ticket_number {
@@ -320,19 +320,22 @@ pub trait Lottery {
 
         self.ticket_holders(lottery_name).clear();
         self.lottery_info(lottery_name).clear();
+        self.lottery_whitelist(lottery_name).clear();
         self.burn_percentage_for_lottery(lottery_name).clear();
     }
 
-    fn sum_array(&self, array: &[u8]) -> u32 {
+    fn sum_array(&self, array: &ManagedVec<u8>) -> u32 {
         let mut sum = 0;
 
-        for &item in array {
+        for item in array {
             sum += item as u32;
         }
 
         sum
     }
 
+    // Normally, we recommend managed types, like ManagedVec > Vec, ManagedBuffer > BoxedBytes, etc.
+    // But in this case, ManagedVec would need too many API calls for this algorithm
     /// does not check if max - min >= amount, that is the caller's job
     fn get_distinct_random(&self, min: usize, max: usize, amount: usize) -> Vec<usize> {
         let mut rand_numbers: Vec<usize> = (min..=max).collect();
@@ -355,18 +358,29 @@ pub trait Lottery {
 
     #[view(getLotteryInfo)]
     #[storage_mapper("lotteryInfo")]
-    fn lottery_info(&self, lottery_name: &BoxedBytes) -> SingleValueMapper<LotteryInfo<Self::Api>>;
+    fn lottery_info(
+        &self,
+        lottery_name: &ManagedBuffer,
+    ) -> SingleValueMapper<LotteryInfo<Self::Api>>;
+
+    #[view(getLotteryWhitelist)]
+    #[storage_mapper("lotteryWhitelist")]
+    fn lottery_whitelist(&self, lottery_name: &ManagedBuffer)
+        -> UnorderedSetMapper<ManagedAddress>;
 
     #[storage_mapper("ticketHolder")]
-    fn ticket_holders(&self, lottery_name: &BoxedBytes) -> VecMapper<ManagedAddress>;
+    fn ticket_holders(&self, lottery_name: &ManagedBuffer) -> VecMapper<ManagedAddress>;
 
     #[storage_mapper("numberOfEntriesForUser")]
     fn number_of_entries_for_user(
         &self,
-        lottery_name: &BoxedBytes,
+        lottery_name: &ManagedBuffer,
         user: &ManagedAddress,
     ) -> SingleValueMapper<u32>;
 
     #[storage_mapper("burnPercentageForLottery")]
-    fn burn_percentage_for_lottery(&self, lottery_name: &BoxedBytes) -> SingleValueMapper<BigUint>;
+    fn burn_percentage_for_lottery(
+        &self,
+        lottery_name: &ManagedBuffer,
+    ) -> SingleValueMapper<BigUint>;
 }

--- a/contracts/examples/lottery-esdt/src/lottery_info.rs
+++ b/contracts/examples/lottery-esdt/src/lottery_info.rs
@@ -1,6 +1,6 @@
 use elrond_wasm::{
     api::ManagedTypeApi,
-    types::{BigUint, ManagedAddress, TokenIdentifier, Vec},
+    types::{BigUint, ManagedVec, TokenIdentifier},
 };
 
 elrond_wasm::derive_imports!();
@@ -12,7 +12,6 @@ pub struct LotteryInfo<M: ManagedTypeApi> {
     pub tickets_left: u32,
     pub deadline: u64,
     pub max_entries_per_user: u32,
-    pub prize_distribution: Vec<u8>,
-    pub whitelist: Vec<ManagedAddress<M>>,
+    pub prize_distribution: ManagedVec<M, u8>,
     pub prize_pool: BigUint<M>,
 }

--- a/contracts/examples/lottery-esdt/wasm/src/lib.rs
+++ b/contracts/examples/lottery-esdt/wasm/src/lib.rs
@@ -11,6 +11,7 @@ elrond_wasm_node::wasm_endpoints! {
         createLotteryPool
         determine_winner
         getLotteryInfo
+        getLotteryWhitelist
         start
         status
     )

--- a/contracts/examples/multisig/src/multisig_propose.rs
+++ b/contracts/examples/multisig/src/multisig_propose.rs
@@ -5,7 +5,7 @@ elrond_wasm::imports!();
 /// Contains all events that can be emitted by the contract.
 #[elrond_wasm::module]
 pub trait MultisigProposeModule: crate::multisig_state::MultisigStateModule {
-    fn propose_action(&self, action: Action<Self::Api>) -> SCResult<usize> {
+    fn propose_action(&self, action: Action<Self::Api>) -> usize {
         let (caller_id, caller_role) = self.get_caller_id_and_role();
         require!(
             caller_role.can_propose(),
@@ -19,31 +19,31 @@ pub trait MultisigProposeModule: crate::multisig_state::MultisigStateModule {
             self.action_signer_ids(action_id).insert(caller_id);
         }
 
-        Ok(action_id)
+        action_id
     }
 
     /// Initiates board member addition process.
     /// Can also be used to promote a proposer to board member.
     #[endpoint(proposeAddBoardMember)]
-    fn propose_add_board_member(&self, board_member_address: ManagedAddress) -> SCResult<usize> {
+    fn propose_add_board_member(&self, board_member_address: ManagedAddress) -> usize {
         self.propose_action(Action::AddBoardMember(board_member_address))
     }
 
     /// Initiates proposer addition process..
     /// Can also be used to demote a board member to proposer.
     #[endpoint(proposeAddProposer)]
-    fn propose_add_proposer(&self, proposer_address: ManagedAddress) -> SCResult<usize> {
+    fn propose_add_proposer(&self, proposer_address: ManagedAddress) -> usize {
         self.propose_action(Action::AddProposer(proposer_address))
     }
 
     /// Removes user regardless of whether it is a board member or proposer.
     #[endpoint(proposeRemoveUser)]
-    fn propose_remove_user(&self, user_address: ManagedAddress) -> SCResult<usize> {
+    fn propose_remove_user(&self, user_address: ManagedAddress) -> usize {
         self.propose_action(Action::RemoveUser(user_address))
     }
 
     #[endpoint(proposeChangeQuorum)]
-    fn propose_change_quorum(&self, new_quorum: usize) -> SCResult<usize> {
+    fn propose_change_quorum(&self, new_quorum: usize) -> usize {
         self.propose_action(Action::ChangeQuorum(new_quorum))
     }
 
@@ -77,7 +77,7 @@ pub trait MultisigProposeModule: crate::multisig_state::MultisigStateModule {
         egld_amount: BigUint,
         #[var_args] opt_function: OptionalArg<ManagedBuffer>,
         #[var_args] arguments: ManagedVarArgs<ManagedBuffer>,
-    ) -> SCResult<usize> {
+    ) -> usize {
         let call_data = self.prepare_call_data(to, egld_amount, opt_function, arguments);
         self.propose_action(Action::SendTransferExecute(call_data))
     }
@@ -94,7 +94,7 @@ pub trait MultisigProposeModule: crate::multisig_state::MultisigStateModule {
         egld_amount: BigUint,
         #[var_args] opt_function: OptionalArg<ManagedBuffer>,
         #[var_args] arguments: ManagedVarArgs<ManagedBuffer>,
-    ) -> SCResult<usize> {
+    ) -> usize {
         let call_data = self.prepare_call_data(to, egld_amount, opt_function, arguments);
         self.propose_action(Action::SendAsyncCall(call_data))
     }
@@ -106,7 +106,7 @@ pub trait MultisigProposeModule: crate::multisig_state::MultisigStateModule {
         source: ManagedAddress,
         code_metadata: CodeMetadata,
         #[var_args] arguments: ManagedVarArgs<ManagedBuffer>,
-    ) -> SCResult<usize> {
+    ) -> usize {
         self.propose_action(Action::SCDeployFromSource {
             amount,
             source,
@@ -123,7 +123,7 @@ pub trait MultisigProposeModule: crate::multisig_state::MultisigStateModule {
         source: ManagedAddress,
         code_metadata: CodeMetadata,
         #[var_args] arguments: ManagedVarArgs<ManagedBuffer>,
-    ) -> SCResult<usize> {
+    ) -> usize {
         self.propose_action(Action::SCUpgradeFromSource {
             sc_address,
             amount,

--- a/contracts/examples/multisig/src/multisig_state.rs
+++ b/contracts/examples/multisig/src/multisig_state.rs
@@ -35,10 +35,7 @@ pub trait MultisigStateModule {
     #[storage_mapper("num_proposers")]
     fn num_proposers(&self) -> SingleValueMapper<usize>;
 
-    fn add_multiple_board_members(
-        &self,
-        new_board_members: ManagedVec<ManagedAddress>,
-    ) -> SCResult<usize> {
+    fn add_multiple_board_members(&self, new_board_members: ManagedVec<ManagedAddress>) -> usize {
         let mut duplicates = false;
         self.user_mapper().get_or_create_users(
             new_board_members.into_iter(),
@@ -54,7 +51,8 @@ pub trait MultisigStateModule {
         let num_board_members_mapper = self.num_board_members();
         let new_num_board_members = num_board_members_mapper.get() + new_board_members.len();
         num_board_members_mapper.set(new_num_board_members);
-        Ok(new_num_board_members)
+
+        new_num_board_members
     }
 
     #[storage_mapper("action_data")]

--- a/contracts/examples/nft-storage-prepay/src/nft_storage_prepay.rs
+++ b/contracts/examples/nft-storage-prepay/src/nft_storage_prepay.rs
@@ -48,14 +48,15 @@ pub trait NftStoragePrepay {
 
     #[payable("EGLD")]
     #[endpoint(depositPaymentForStorage)]
-    fn deposit_payment_for_storage(&self, #[payment] payment: BigUint) {
+    fn deposit_payment_for_storage(&self) {
+        let payment = self.call_value().egld_value();
         let caller = self.blockchain().get_caller();
         self.deposit(&caller).update(|deposit| *deposit += payment);
     }
 
     /// defaults to max amount
     #[endpoint(withdraw)]
-    fn withdraw(&self, #[var_args] opt_amount: OptionalArg<BigUint>) -> SCResult<()> {
+    fn withdraw(&self, #[var_args] opt_amount: OptionalArg<BigUint>) {
         let caller = self.blockchain().get_caller();
         let mut user_deposit = self.deposit(&caller).get();
         let amount = match opt_amount {
@@ -69,8 +70,6 @@ pub trait NftStoragePrepay {
         self.deposit(&caller).set(&user_deposit);
 
         self.send().direct_egld(&caller, &amount, &[]);
-
-        Ok(())
     }
 
     // views

--- a/contracts/examples/order-book/factory/src/lib.rs
+++ b/contracts/examples/order-book/factory/src/lib.rs
@@ -17,7 +17,7 @@ pub trait Factory {
     }
 
     #[endpoint(createPair)]
-    fn create_pair(&self, token_id_pair: TokenIdPair<Self::Api>) -> SCResult<ManagedAddress> {
+    fn create_pair(&self, token_id_pair: TokenIdPair<Self::Api>) -> ManagedAddress {
         require!(self.get_pair(&token_id_pair).is_none(), "Already has pair");
 
         let mut arguments = ManagedArgBuffer::new_empty();
@@ -31,22 +31,22 @@ pub trait Factory {
             CodeMetadata::DEFAULT,
             &arguments,
         );
-
         self.pairs().insert(token_id_pair, pair_address.clone());
-        Ok(pair_address)
+
+        pair_address
     }
 
     #[view(getPair)]
     fn get_pair(&self, token_id_pair: &TokenIdPair<Self::Api>) -> Option<ManagedAddress> {
-        let address = self.pairs().get(token_id_pair);
+        let opt_address = self.pairs().get(token_id_pair);
 
-        if address.is_none() {
+        if opt_address.is_none() {
             self.pairs().get(&TokenIdPair {
                 first_token_id: token_id_pair.second_token_id.clone(),
                 second_token_id: token_id_pair.first_token_id.clone(),
             })
         } else {
-            address
+            opt_address
         }
     }
 

--- a/contracts/examples/order-book/pair/mandos/steps/deploy.steps.json
+++ b/contracts/examples/order-book/pair/mandos/steps/deploy.steps.json
@@ -17,7 +17,7 @@
             "tx": {
                 "from": "address:owner",
                 "value": "0",
-                "contractCode": "file:../../output/pair.wasm",
+                "contractCode": "file:../../output/order-book-pair.wasm",
                 "arguments": [
                     "str:WEGLD-abcdef",
                     "str:BUSD-abcdef"

--- a/contracts/examples/order-book/pair/src/global.rs
+++ b/contracts/examples/order-book/pair/src/global.rs
@@ -5,34 +5,30 @@ elrond_wasm::derive_imports!();
 pub trait GlobalOperationModule {
     #[only_owner]
     #[endpoint(startGlobalOperation)]
-    fn global_op_start(&self) -> SCResult<()> {
-        self.require_global_op_not_ongoing()?;
+    fn global_op_start(&self) {
+        self.require_global_op_not_ongoing();
         self.global_op_is_ongoing().set(&true);
-        Ok(())
     }
 
     #[only_owner]
     #[endpoint(stopGlobalOperation)]
-    fn global_op_stop(&self) -> SCResult<()> {
-        self.require_global_op_ongoing()?;
+    fn global_op_stop(&self) {
+        self.require_global_op_ongoing();
         self.global_op_is_ongoing().set(&false);
-        Ok(())
     }
 
-    fn require_global_op_not_ongoing(&self) -> SCResult<()> {
+    fn require_global_op_not_ongoing(&self) {
         require!(
             !self.global_op_is_ongoing().get(),
             "Global operation ongoing"
         );
-        Ok(())
     }
 
-    fn require_global_op_ongoing(&self) -> SCResult<()> {
+    fn require_global_op_ongoing(&self) {
         require!(
             self.global_op_is_ongoing().get(),
             "Global operation not ongoing"
         );
-        Ok(())
     }
 
     #[storage_mapper("global_operation_ongoing")]

--- a/contracts/examples/order-book/pair/src/lib.rs
+++ b/contracts/examples/order-book/pair/src/lib.rs
@@ -27,52 +27,51 @@ pub trait Pair:
 
     #[payable("*")]
     #[endpoint(createBuyOrder)]
-    fn create_buy_order_endpoint(&self, params: OrderInputParams<Self::Api>) -> SCResult<()> {
-        self.require_global_op_not_ongoing()?;
-        self.require_valid_order_input_params(&params)?;
-        let payment = self.require_valid_buy_payment()?;
+    fn create_buy_order_endpoint(&self, params: OrderInputParams<Self::Api>) {
+        self.require_global_op_not_ongoing();
+        self.require_valid_order_input_params(&params);
+        let payment = self.require_valid_buy_payment();
 
-        self.create_order(payment, params, common::OrderType::Buy)
+        self.create_order(payment, params, common::OrderType::Buy);
     }
 
     #[payable("*")]
     #[endpoint(createSellOrder)]
-    fn create_sell_order_endpoint(&self, params: OrderInputParams<Self::Api>) -> SCResult<()> {
-        self.require_global_op_not_ongoing()?;
-        self.require_valid_order_input_params(&params)?;
-        let payment = self.require_valid_sell_payment()?;
+    fn create_sell_order_endpoint(&self, params: OrderInputParams<Self::Api>) {
+        self.require_global_op_not_ongoing();
+        self.require_valid_order_input_params(&params);
+        let payment = self.require_valid_sell_payment();
 
-        self.create_order(payment, params, common::OrderType::Sell)
+        self.create_order(payment, params, common::OrderType::Sell);
     }
 
     #[endpoint(matchOrders)]
-    fn match_orders_endpoint(&self, order_ids: Vec<u64>) -> SCResult<()> {
-        self.require_global_op_not_ongoing()?;
-        self.require_valid_match_input_order_ids(&order_ids)?;
+    fn match_orders_endpoint(&self, order_ids: Vec<u64>) {
+        self.require_global_op_not_ongoing();
+        self.require_valid_match_input_order_ids(&order_ids);
 
-        self.match_orders(order_ids)
+        self.match_orders(order_ids);
     }
 
     #[endpoint(cancelOrders)]
-    fn cancel_orders_endpoint(&self, order_ids: Vec<u64>) -> SCResult<()> {
-        self.require_global_op_not_ongoing()?;
-        self.require_order_ids_not_empty(&order_ids)?;
+    fn cancel_orders_endpoint(&self, order_ids: Vec<u64>) {
+        self.require_global_op_not_ongoing();
+        self.require_order_ids_not_empty(&order_ids);
 
-        self.cancel_orders(order_ids)
+        self.cancel_orders(order_ids);
     }
 
     #[endpoint(cancelAllOrders)]
-    fn cancel_all_orders_endpoint(&self) -> SCResult<()> {
-        self.require_global_op_not_ongoing()?;
-
-        self.cancel_all_orders()
+    fn cancel_all_orders_endpoint(&self) {
+        self.require_global_op_not_ongoing();
+        self.cancel_all_orders();
     }
 
     #[endpoint(freeOrders)]
-    fn free_orders_endpoint(&self, order_ids: Vec<u64>) -> SCResult<()> {
-        self.require_global_op_not_ongoing()?;
-        self.require_order_ids_not_empty(&order_ids)?;
+    fn free_orders_endpoint(&self, order_ids: Vec<u64>) {
+        self.require_global_op_not_ongoing();
+        self.require_order_ids_not_empty(&order_ids);
 
-        self.free_orders(order_ids)
+        self.free_orders(order_ids);
     }
 }

--- a/contracts/examples/order-book/pair/src/validation.rs
+++ b/contracts/examples/order-book/pair/src/validation.rs
@@ -13,10 +13,7 @@ use super::{
 
 #[elrond_wasm::module]
 pub trait ValidationModule: common::CommonModule {
-    fn require_valid_order_input_amount(
-        &self,
-        params: &OrderInputParams<Self::Api>,
-    ) -> SCResult<()> {
+    fn require_valid_order_input_amount(&self, params: &OrderInputParams<Self::Api>) {
         require!(params.amount != 0, "Amout cannot be zero");
         require!(
             self.calculate_fee_amount(
@@ -25,24 +22,16 @@ pub trait ValidationModule: common::CommonModule {
             ) != 0,
             "Penalty increase amount cannot be zero"
         );
-        Ok(())
     }
 
-    fn require_valid_order_input_match_provider(
-        &self,
-        params: &OrderInputParams<Self::Api>,
-    ) -> SCResult<()> {
+    fn require_valid_order_input_match_provider(&self, params: &OrderInputParams<Self::Api>) {
         require!(
             params.match_provider.is_none() || !params.match_provider.clone().unwrap().is_zero(),
             "Match address cannot be zero"
         );
-        Ok(())
     }
 
-    fn require_valid_order_input_fee_config(
-        &self,
-        params: &OrderInputParams<Self::Api>,
-    ) -> SCResult<()> {
+    fn require_valid_order_input_fee_config(&self, params: &OrderInputParams<Self::Api>) {
         match params.fee_config.clone() {
             FeeConfig::Fixed(amount) => {
                 require!(amount < params.amount, "Invalid fee config fixed amount");
@@ -57,33 +46,24 @@ pub trait ValidationModule: common::CommonModule {
 
         let amount_after_fee = self.calculate_amount_after_fee(&params.amount, &params.fee_config);
         require!(amount_after_fee != 0, "Amount after fee cannot be zero");
-        Ok(())
     }
 
-    fn require_valid_order_input_deal_config(
-        &self,
-        params: &OrderInputParams<Self::Api>,
-    ) -> SCResult<()> {
+    fn require_valid_order_input_deal_config(&self, params: &OrderInputParams<Self::Api>) {
         require!(
             params.deal_config.match_provider_percent < PERCENT_BASE_POINTS,
             "Bad deal config"
         );
-        Ok(())
     }
 
-    fn require_valid_order_input_params(
-        &self,
-        params: &OrderInputParams<Self::Api>,
-    ) -> SCResult<()> {
-        self.require_valid_order_input_amount(params)?;
-        self.require_valid_order_input_match_provider(params)?;
-        self.require_valid_order_input_fee_config(params)?;
-        self.require_valid_order_input_deal_config(params)?;
-        Ok(())
+    fn require_valid_order_input_params(&self, params: &OrderInputParams<Self::Api>) {
+        self.require_valid_order_input_amount(params);
+        self.require_valid_order_input_match_provider(params);
+        self.require_valid_order_input_fee_config(params);
+        self.require_valid_order_input_deal_config(params);
     }
 
-    fn require_valid_buy_payment(&self) -> SCResult<Payment<Self::Api>> {
-        self.require_fungible_input()?;
+    fn require_valid_buy_payment(&self) -> Payment<Self::Api> {
+        self.require_fungible_input();
         let second_token_id = self.second_token_id().get();
         let (amount, token_id) = self.call_value().payment_token_pair();
         require!(
@@ -91,11 +71,12 @@ pub trait ValidationModule: common::CommonModule {
             "Token in and second token id should be the same"
         );
         require!(amount != 0, "Input amount should not be zero");
-        Ok(Payment { token_id, amount })
+
+        Payment { token_id, amount }
     }
 
-    fn require_valid_sell_payment(&self) -> SCResult<Payment<Self::Api>> {
-        self.require_fungible_input()?;
+    fn require_valid_sell_payment(&self) -> Payment<Self::Api> {
+        self.require_fungible_input();
         let first_token_id = self.first_token_id().get();
         let (amount, token_id) = self.call_value().payment_token_pair();
         require!(
@@ -103,36 +84,33 @@ pub trait ValidationModule: common::CommonModule {
             "Token in and first token id should be the same"
         );
         require!(amount != 0, "Input amount should not be zero");
-        Ok(Payment { token_id, amount })
+
+        Payment { token_id, amount }
     }
 
-    fn require_valid_match_input_order_ids(&self, order_ids: &[u64]) -> SCResult<()> {
+    fn require_valid_match_input_order_ids(&self, order_ids: &[u64]) {
         require!(order_ids.len() >= 2, "Should be at least two order ids");
-        Ok(())
     }
 
-    fn require_fungible_input(&self) -> SCResult<()> {
+    fn require_fungible_input(&self) {
         require!(
             self.call_value().esdt_token_nonce() == 0,
             "Nonce is not zero"
         );
-        Ok(())
     }
 
-    fn require_not_max_size(&self, address_order_ids: &[u64]) -> SCResult<()> {
+    fn require_not_max_size(&self, address_order_ids: &[u64]) {
         require!(
             address_order_ids.len() < MAX_ORDERS_PER_USER,
             "Cannot place more orders"
         );
-        Ok(())
     }
 
-    fn require_order_ids_not_empty(&self, order_ids: &[u64]) -> SCResult<()> {
+    fn require_order_ids_not_empty(&self, order_ids: &[u64]) {
         require!(!order_ids.is_empty(), "Order ids vec is empty");
-        Ok(())
     }
 
-    fn require_match_provider_empty_or_caller(&self, orders: &[Order<Self::Api>]) -> SCResult<()> {
+    fn require_match_provider_empty_or_caller(&self, orders: &[Order<Self::Api>]) {
         let caller = &self.blockchain().get_caller();
 
         for order in orders.iter() {
@@ -143,20 +121,17 @@ pub trait ValidationModule: common::CommonModule {
                 None => {},
             }
         }
-        Ok(())
     }
 
-    fn require_contains_all(&self, vec_base: &[u64], items: &[u64]) -> SCResult<()> {
+    fn require_contains_all(&self, vec_base: &[u64], items: &[u64]) {
         for item in items.iter() {
             require!(vec_base.contains(item), "Base vec do not contain item");
         }
-        Ok(())
     }
 
-    fn require_contains_none(&self, vec_base: &[u64], items: &[u64]) -> SCResult<()> {
+    fn require_contains_none(&self, vec_base: &[u64], items: &[u64]) {
         for item in items.iter() {
             require!(!vec_base.contains(item), "Base vec contains item");
         }
-        Ok(())
     }
 }

--- a/contracts/examples/ping-pong-egld/src/ping_pong.rs
+++ b/contracts/examples/ping-pong-egld/src/ping_pong.rs
@@ -50,11 +50,9 @@ pub trait PingPong {
     /// Optional `_data` argument is ignored.
     #[payable("EGLD")]
     #[endpoint]
-    fn ping(
-        &self,
-        #[payment] payment: BigUint,
-        #[var_args] _data: OptionalArg<BoxedBytes>,
-    ) -> SCResult<()> {
+    fn ping(&self, #[var_args] _data: OptionalArg<ManagedBuffer>) {
+        let payment = self.call_value().egld_value();
+
         require!(
             payment == self.ping_amount().get(),
             "the payment must match the fixed sum"
@@ -88,35 +86,33 @@ pub trait PingPong {
         match user_status {
             UserStatus::New => {
                 self.user_status(user_id).set(UserStatus::Registered);
-                Ok(())
             },
             UserStatus::Registered => {
-                sc_error!("can only ping once")
+                sc_panic!("can only ping once")
             },
             UserStatus::Withdrawn => {
-                sc_error!("already withdrawn")
+                sc_panic!("already withdrawn")
             },
         }
     }
 
-    fn pong_by_user_id(&self, user_id: usize) -> SCResult<()> {
+    fn pong_by_user_id(&self, user_id: usize) {
         let user_status = self.user_status(user_id).get();
         match user_status {
             UserStatus::New => {
-                sc_error!("can't pong, never pinged")
+                sc_panic!("can't pong, never pinged")
             },
             UserStatus::Registered => {
                 self.user_status(user_id).set(UserStatus::Withdrawn);
                 if let Some(user_address) = self.user_mapper().get_user_address(user_id) {
                     self.send()
                         .direct_egld(&user_address, &self.ping_amount().get(), b"pong");
-                    Ok(())
                 } else {
-                    sc_error!("unknown user")
+                    sc_panic!("unknown user")
                 }
             },
             UserStatus::Withdrawn => {
-                sc_error!("already withdrawn")
+                sc_panic!("already withdrawn")
             },
         }
     }
@@ -124,7 +120,7 @@ pub trait PingPong {
     /// User can take back funds from the contract.
     /// Can only be called after expiration.
     #[endpoint]
-    fn pong(&self) -> SCResult<()> {
+    fn pong(&self) {
         require!(
             self.blockchain().get_block_timestamp() >= self.deadline().get(),
             "can't withdraw before deadline"
@@ -132,7 +128,7 @@ pub trait PingPong {
 
         let caller = self.blockchain().get_caller();
         let user_id = self.user_mapper().get_user_id(&caller);
-        self.pong_by_user_id(user_id)
+        self.pong_by_user_id(user_id);
     }
 
     /// Send back funds to all users who pinged.
@@ -141,7 +137,7 @@ pub trait PingPong {
     /// - `interrupted` if run out of gas midway.
     /// Can only be called after expiration.
     #[endpoint(pongAll)]
-    fn pong_all(&self) -> SCResult<OperationCompletionStatus> {
+    fn pong_all(&self) -> OperationCompletionStatus {
         require!(
             self.blockchain().get_block_timestamp() >= self.deadline().get(),
             "can't withdraw before deadline"
@@ -154,12 +150,12 @@ pub trait PingPong {
                 // clear field and reset to 0
                 pong_all_last_user = 0;
                 self.pong_all_last_user().set(pong_all_last_user);
-                return Ok(OperationCompletionStatus::Completed);
+                return OperationCompletionStatus::Completed;
             }
 
             if self.blockchain().get_gas_left() < PONG_ALL_LOW_GAS_LIMIT {
                 self.pong_all_last_user().set(pong_all_last_user);
-                return Ok(OperationCompletionStatus::InterruptedBeforeOutOfGas);
+                return OperationCompletionStatus::InterruptedBeforeOutOfGas;
             }
 
             pong_all_last_user += 1;

--- a/contracts/examples/proxy-pause/src/proxy_pause.rs
+++ b/contracts/examples/proxy-pause/src/proxy_pause.rs
@@ -23,34 +23,27 @@ pub trait PauseProxy {
     }
 
     #[endpoint(addContracts)]
-    fn add_contracts(&self, #[var_args] contracts: ManagedVarArgs<ManagedAddress>) -> SCResult<()> {
-        self.require_owner()?;
+    fn add_contracts(&self, #[var_args] contracts: ManagedVarArgs<ManagedAddress>) {
+        self.require_owner();
         self.contracts().extend(contracts);
-        Ok(())
     }
 
     #[endpoint(removeContracts)]
-    fn remove_contracts(
-        &self,
-        #[var_args] contracts: ManagedVarArgs<ManagedAddress>,
-    ) -> SCResult<()> {
-        self.require_owner()?;
+    fn remove_contracts(&self, #[var_args] contracts: ManagedVarArgs<ManagedAddress>) {
+        self.require_owner();
         self.contracts().remove_all(contracts);
-        Ok(())
     }
 
     #[endpoint(addOwners)]
-    fn add_owners(&self, #[var_args] owners: ManagedVarArgs<ManagedAddress>) -> SCResult<()> {
-        self.require_owner()?;
+    fn add_owners(&self, #[var_args] owners: ManagedVarArgs<ManagedAddress>) {
+        self.require_owner();
         self.owners().extend(owners);
-        Ok(())
     }
 
     #[endpoint(removeOwners)]
-    fn remove_owners(&self, #[var_args] owners: ManagedVarArgs<ManagedAddress>) -> SCResult<()> {
-        self.require_owner()?;
+    fn remove_owners(&self, #[var_args] owners: ManagedVarArgs<ManagedAddress>) {
+        self.require_owner();
         self.owners().remove_all(owners);
-        Ok(())
     }
 
     fn for_each_contract<F>(&self, f: F)
@@ -63,25 +56,22 @@ pub trait PauseProxy {
     }
 
     #[endpoint]
-    fn pause(&self) -> SCResult<()> {
-        self.require_owner()?;
+    fn pause(&self) {
+        self.require_owner();
         self.for_each_contract(|contract| contract.pause().execute_on_dest_context());
-        Ok(())
     }
 
     #[endpoint]
-    fn unpause(&self) -> SCResult<()> {
-        self.require_owner()?;
+    fn unpause(&self) {
+        self.require_owner();
         self.for_each_contract(|contract| contract.unpause().execute_on_dest_context());
-        Ok(())
     }
 
-    fn require_owner(&self) -> SCResult<()> {
+    fn require_owner(&self) {
         require!(
             self.owners().contains(&self.blockchain().get_caller()),
             "caller is not an owner"
         );
-        Ok(())
     }
 
     #[view]

--- a/contracts/examples/token-release/src/token_release.rs
+++ b/contracts/examples/token-release/src/token_release.rs
@@ -14,14 +14,13 @@ pub trait TokenRelease {
     // The SC initializes with the setup period started. After the initial setup, the SC offers a function that ends the setup period.
     // There is no function to start the setup period back on, so once the setup period is ended, it cannot be changed.
     #[init]
-    fn init(&self, token_identifier: TokenIdentifier) -> SCResult<()> {
+    fn init(&self, token_identifier: TokenIdentifier) {
         require!(
             token_identifier.is_valid_esdt_identifier(),
             "Invalid token provided"
         );
         self.token_identifier().set(&token_identifier);
         self.setup_period_status().set(&true);
-        Ok(())
     }
 
     // endpoints
@@ -37,8 +36,8 @@ pub trait TokenRelease {
         period_unlock_amount: BigUint,
         release_period: u64,
         release_ticks: u64,
-    ) -> SCResult<()> {
-        self.require_setup_period_live()?;
+    ) {
+        self.require_setup_period_live();
         require!(
             self.group_schedule(&group_identifier).is_empty(),
             "The group already exists"
@@ -68,8 +67,6 @@ pub trait TokenRelease {
             unlock_type,
         };
         self.group_schedule(&group_identifier).set(&new_schedule);
-
-        Ok(())
     }
 
     #[only_owner]
@@ -81,8 +78,8 @@ pub trait TokenRelease {
         period_unlock_percentage: u8,
         release_period: u64,
         release_ticks: u64,
-    ) -> SCResult<()> {
-        self.require_setup_period_live()?;
+    ) {
+        self.require_setup_period_live();
         require!(
             self.group_schedule(&group_identifier).is_empty(),
             "The group already exists"
@@ -112,14 +109,12 @@ pub trait TokenRelease {
             unlock_type,
         };
         self.group_schedule(&group_identifier).set(&new_schedule);
-
-        Ok(())
     }
 
     #[only_owner]
     #[endpoint(removeGroup)]
-    fn remove_group(&self, group_identifier: ManagedBuffer) -> SCResult<()> {
-        self.require_setup_period_live()?;
+    fn remove_group(&self, group_identifier: ManagedBuffer) {
+        self.require_setup_period_live();
         require!(
             !self.group_schedule(&group_identifier).is_empty(),
             "The group does not exist"
@@ -130,17 +125,12 @@ pub trait TokenRelease {
             .update(|total| *total -= &schedule.group_total_amount);
         self.group_schedule(&group_identifier).clear();
         self.users_in_group(&group_identifier).clear();
-        Ok(())
     }
 
     #[only_owner]
     #[endpoint(addUserGroup)]
-    fn add_user_group(
-        &self,
-        address: ManagedAddress,
-        group_identifier: ManagedBuffer,
-    ) -> SCResult<()> {
-        self.require_setup_period_live()?;
+    fn add_user_group(&self, address: ManagedAddress, group_identifier: ManagedBuffer) {
+        self.require_setup_period_live();
         require!(
             !self.group_schedule(&group_identifier).is_empty(),
             "The group does not exist"
@@ -153,14 +143,12 @@ pub trait TokenRelease {
                 groups.push(group_identifier);
             }
         });
-
-        Ok(())
     }
 
     #[only_owner]
     #[endpoint(removeUser)]
-    fn remove_user(&self, address: ManagedAddress) -> SCResult<()> {
-        self.require_setup_period_live()?;
+    fn remove_user(&self, address: ManagedAddress) {
+        self.require_setup_period_live();
         require!(
             !self.user_groups(&address).is_empty(),
             "The address is not defined"
@@ -172,22 +160,20 @@ pub trait TokenRelease {
         }
         self.user_groups(&address).clear();
         self.claimed_balance(&address).clear();
-        Ok(())
     }
 
     //To change a receiving address, the user registers a request, which is afterwards accepted or not by the owner
     #[endpoint(requestAddressChange)]
-    fn request_address_change(&self, new_address: ManagedAddress) -> SCResult<()> {
-        self.require_setup_period_ended()?;
+    fn request_address_change(&self, new_address: ManagedAddress) {
+        self.require_setup_period_ended();
         let user_address = self.blockchain().get_caller();
         self.address_change_request(&user_address).set(&new_address);
-        Ok(())
     }
 
     #[only_owner]
     #[endpoint(approveAddressChange)]
-    fn approve_address_change(&self, user_address: ManagedAddress) -> SCResult<()> {
-        self.require_setup_period_ended()?;
+    fn approve_address_change(&self, user_address: ManagedAddress) {
+        self.require_setup_period_ended();
         require!(
             !self.address_change_request(&user_address).is_empty(),
             "The address does not have a change request"
@@ -209,25 +195,22 @@ pub trait TokenRelease {
 
         // Delete the change request
         self.address_change_request(&user_address).clear();
-
-        Ok(())
     }
 
     #[only_owner]
     #[endpoint(endSetupPeriod)]
-    fn end_setup_period(&self) -> SCResult<()> {
+    fn end_setup_period(&self) {
         let token_identifier = self.token_identifier().get();
         let total_mint_tokens = self.token_total_supply().get();
         self.mint_all_tokens(&token_identifier, &total_mint_tokens);
         let activation_timestamp = self.blockchain().get_block_timestamp();
         self.activation_timestamp().set(&activation_timestamp);
         self.setup_period_status().set(false);
-        Ok(())
     }
 
     #[endpoint(claimTokens)]
-    fn claim_tokens(&self) -> SCResult<BigUint> {
-        self.require_setup_period_ended()?;
+    fn claim_tokens(&self) -> BigUint {
+        self.require_setup_period_ended();
         let token_identifier = self.token_identifier().get();
         let caller = self.blockchain().get_caller();
         let current_claimable_amount = self.get_claimable_tokens(&caller);
@@ -240,7 +223,7 @@ pub trait TokenRelease {
         self.claimed_balance(&caller)
             .update(|current_balance| *current_balance += &current_claimable_amount);
 
-        Ok(current_claimable_amount)
+        current_claimable_amount
     }
 
     // views
@@ -330,17 +313,15 @@ pub trait TokenRelease {
         self.send().esdt_local_mint(token_identifier, 0, amount);
     }
 
-    fn require_setup_period_live(&self) -> SCResult<()> {
+    fn require_setup_period_live(&self) {
         require!(self.setup_period_status().get(), "Setup period has ended");
-        Ok(())
     }
 
-    fn require_setup_period_ended(&self) -> SCResult<()> {
+    fn require_setup_period_ended(&self) {
         require!(
             !(self.setup_period_status().get()),
             "Setup period is still active"
         );
-        Ok(())
     }
 
     // storage

--- a/contracts/feature-tests/rust-testing-framework-tester/tests/rust_testing_framework-test.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/tests/rust_testing_framework-test.rs
@@ -3,7 +3,7 @@ use forwarder::call_sync::*;
 use num_traits::ToPrimitive;
 
 use elrond_wasm::types::{
-    Address, BigInt, EsdtLocalRole, EsdtTokenPayment, EsdtTokenType, ManagedBuffer, ManagedVec,
+    Address, BigUint, EsdtLocalRole, EsdtTokenPayment, EsdtTokenType, ManagedBuffer, ManagedVec,
 };
 use elrond_wasm_debug::{
     assert_values_eq, managed_address, managed_biguint, managed_buffer, managed_token_id,
@@ -1079,7 +1079,7 @@ fn test_async_call() {
     wrapper
         .execute_query(&adder_wrapper, |sc| {
             let current_sum = sc.sum().get();
-            let expected_sum = BigInt::from(10);
+            let expected_sum = BigUint::from(10u32);
             assert_eq!(current_sum, expected_sum);
         })
         .assert_ok();


### PR DESCRIPTION
- remove SCResult from example contracts
- remove #[payment] annotations, as they just create confusion for newbies. Use the API functions instead.
- use SingleValueMapper instead of storage_get/set/clear/is_empty
- general upgrades for performance, like using managed types where possible