### PR TITLE
Add possibility to set vote weight for board members

### DIFF
--- a/contracts/examples/multisig/src/action.rs
+++ b/contracts/examples/multisig/src/action.rs
@@ -35,6 +35,10 @@ pub enum Action<M: ManagedTypeApi> {
         code_metadata: CodeMetadata,
         arguments: ManagedVec<M, ManagedBuffer<M>>,
     },
+    AddWeightToBoardMember {
+        board_member_address: ManagedAddress<M>,
+        weight: usize,
+    },
 }
 
 impl<M: ManagedTypeApi> Action<M> {

--- a/contracts/examples/multisig/src/action.rs
+++ b/contracts/examples/multisig/src/action.rs
@@ -35,9 +35,9 @@ pub enum Action<M: ManagedTypeApi> {
         code_metadata: CodeMetadata,
         arguments: ManagedVec<M, ManagedBuffer<M>>,
     },
-    AddWeightToBoardMember {
+    ChangeWeightForBoardMember {
         board_member_address: ManagedAddress<M>,
-        weight: usize,
+        new_weight: usize,
     },
 }
 

--- a/contracts/examples/multisig/src/multisig.rs
+++ b/contracts/examples/multisig/src/multisig.rs
@@ -25,9 +25,8 @@ pub trait Multisig:
         let board_vec = board.to_vec();
         let new_num_board_members = self.add_multiple_board_members(board_vec);
 
-        let num_proposers = self.num_proposers().get();
         require!(
-            new_num_board_members + num_proposers > 0,
+            new_num_board_members > 0,
             "board cannot be empty on init, no-one would be able to propose"
         );
 

--- a/contracts/examples/multisig/src/multisig.rs
+++ b/contracts/examples/multisig/src/multisig.rs
@@ -158,7 +158,7 @@ pub trait Multisig:
             "only board members and proposers can discard actions"
         );
         require!(
-            self.get_action_valid_signer_count(action_id) == 0,
+            self.get_action_valid_signer_weight(action_id) == 0,
             "cannot discard action with valid signatures"
         );
 

--- a/contracts/examples/multisig/src/multisig_perform.rs
+++ b/contracts/examples/multisig/src/multisig_perform.rs
@@ -187,6 +187,14 @@ pub trait MultisigPerformModule: crate::multisig_state::MultisigStateModule {
                 );
                 OptionalValue::None
             },
+            Action::AddWeightToBoardMember {
+                board_member_address,
+                weight,
+            } => {
+                let user_id = self.user_mapper().get_user_id(&board_member_address);
+                self.user_id_to_weight(user_id).set_if_empty(&weight);
+                OptionalValue::None
+            },
         }
     }
 }

--- a/contracts/examples/multisig/src/multisig_perform.rs
+++ b/contracts/examples/multisig/src/multisig_perform.rs
@@ -62,7 +62,7 @@ pub trait MultisigPerformModule: crate::multisig_state::MultisigStateModule {
     #[view(quorumReached)]
     fn quorum_reached(&self, action_id: usize) -> bool {
         let quorum = self.quorum().get();
-        let valid_signers_count = self.get_action_valid_signer_count(action_id);
+        let valid_signers_count = self.get_action_valid_signer_weight(action_id);
         valid_signers_count >= quorum
     }
 

--- a/contracts/examples/multisig/src/multisig_perform.rs
+++ b/contracts/examples/multisig/src/multisig_perform.rs
@@ -192,6 +192,7 @@ pub trait MultisigPerformModule: crate::multisig_state::MultisigStateModule {
                 new_weight,
             } => {
                 let user_id = self.user_mapper().get_user_id(&board_member_address);
+                require!(user_id != 0, "user does not exist");
                 require!(
                     self.user_id_to_role(user_id).get() == UserRole::BoardMember,
                     "user is not a board member"

--- a/contracts/examples/multisig/src/multisig_perform.rs
+++ b/contracts/examples/multisig/src/multisig_perform.rs
@@ -187,12 +187,12 @@ pub trait MultisigPerformModule: crate::multisig_state::MultisigStateModule {
                 );
                 OptionalValue::None
             },
-            Action::AddWeightToBoardMember {
+            Action::ChangeWeightForBoardMember {
                 board_member_address,
-                weight,
+                new_weight,
             } => {
                 let user_id = self.user_mapper().get_user_id(&board_member_address);
-                self.user_id_to_weight(user_id).set_if_empty(&weight);
+                self.user_id_to_weight(user_id).set(&new_weight);
                 OptionalValue::None
             },
         }

--- a/contracts/examples/multisig/src/multisig_perform.rs
+++ b/contracts/examples/multisig/src/multisig_perform.rs
@@ -192,6 +192,10 @@ pub trait MultisigPerformModule: crate::multisig_state::MultisigStateModule {
                 new_weight,
             } => {
                 let user_id = self.user_mapper().get_user_id(&board_member_address);
+                require!(
+                    self.user_id_to_role(user_id).get() == UserRole::BoardMember,
+                    "user is not a board member"
+                );
                 self.user_id_to_weight(user_id).set(&new_weight);
                 OptionalValue::None
             },

--- a/contracts/examples/multisig/src/multisig_state.rs
+++ b/contracts/examples/multisig/src/multisig_state.rs
@@ -124,8 +124,10 @@ pub trait MultisigStateModule {
             let signer_role = self.user_id_to_role(signer_id).get();
             if signer_role.can_sign() {
                 if self.user_id_to_weight(signer_id).is_empty() {
+                    // it means that the user has regular voting power
                     total_weight += 1;
                 } else {
+                    // it means that the user has weighted voting power
                     total_weight += self.user_id_to_weight(signer_id).get();
                 }
             }

--- a/contracts/examples/multisig/src/multisig_state.rs
+++ b/contracts/examples/multisig/src/multisig_state.rs
@@ -123,7 +123,11 @@ pub trait MultisigStateModule {
         for signer_id in signer_ids.iter() {
             let signer_role = self.user_id_to_role(signer_id).get();
             if signer_role.can_sign() {
-                total_weight += self.user_id_to_weight(signer_id).get();
+                if self.user_id_to_weight(signer_id).is_empty() {
+                    total_weight += 1;
+                } else {
+                    total_weight += self.user_id_to_weight(signer_id).get();
+                }
             }
         }
         total_weight

--- a/contracts/examples/multisig/src/multisig_state.rs
+++ b/contracts/examples/multisig/src/multisig_state.rs
@@ -16,6 +16,9 @@ pub trait MultisigStateModule {
     #[storage_mapper("user_role")]
     fn user_id_to_role(&self, user_id: usize) -> SingleValueMapper<UserRole>;
 
+    #[storage_mapper("user_weight")]
+    fn user_id_to_weight(&self, user_id: usize) -> SingleValueMapper<u8>;
+
     fn get_caller_id_and_role(&self) -> (usize, UserRole) {
         let caller_address = self.blockchain().get_caller();
         let caller_id = self.user_mapper().get_user_id(&caller_address);

--- a/contracts/examples/multisig/wasm-view/src/lib.rs
+++ b/contracts/examples/multisig/wasm-view/src/lib.rs
@@ -11,6 +11,7 @@ elrond_wasm_node::external_view_wasm_endpoints! {
         getActionSignerCount
         getActionSigners
         getActionValidSignerCount
+        getActionValidSignerWeight
         getAllBoardMembers
         getAllProposers
         getPendingActionFullInfo


### PR DESCRIPTION
**Before this PR:**
All the board members have equal voting rights.

**After this PR:**
People might argue that a new employee should not have the same voting power as the CEO. To solve this issue, this PR introduces a new way of configuring the board, so that each board member can have different voting power.

**Nice to know:**
- by default, all members have a voting power of 1
- board members can add/edit the voting power of a member by proposing a `ChangeWeightForBoardMember` action
- in case of removal, the user and his voting power are not taken into consideration anymore
- the voting power doesn't have any cap, so the board is fully responsible for setting up the quorum and the weights properly for each member

**Regular flow:**
1. User creates a `multisig` SC, sets the quorum to 1 and only adds himself as a member in the board.
2. User adds all the other members in the board.
3. User sets voting power for each member.
4. User sets the quorum accordingly. (ex: if the board has 5 members and the voting power is 100, a recommended quorum would be 51)

**This change is backward compatible.**

**Left TODOs:**
- add `mandos` tests if this PR gets approval from Elrond community