### PR TITLE
Add view for MapMapper

### DIFF
--- a/contracts/feature-tests/basic-features/mandos/storage_mapper_map.scen.json
+++ b/contracts/feature-tests/basic-features/mandos/storage_mapper_map.scen.json
@@ -220,6 +220,24 @@
             }
         },
         {
+            "step": "scQuery",
+            "txId": "check-map-key-value-pairs",
+            "tx": {
+                "to": "sc:basic-features",
+                "function": "map_mapper",
+                "arguments": []
+            },
+            "expect": {
+                "out": [
+                    "123",
+                    "456",
+                    "111",
+                    "222"
+                ],
+                "status": ""
+            }
+        },
+        {
             "step": "scCall",
             "txId": "check-contains-after-second-insert",
             "tx": {

--- a/contracts/feature-tests/basic-features/src/storage_mapper_map.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_map.rs
@@ -3,6 +3,7 @@ elrond_wasm::imports!();
 /// Storage mapper test.
 #[elrond_wasm::module]
 pub trait MapMapperFeatures {
+    #[view]
     #[storage_mapper("map_mapper")]
     fn map_mapper(&self) -> MapMapper<u32, u32>;
 


### PR DESCRIPTION
Add `#[view]` capabilities for `MapMapper<K, V>` which outputs it as a `MultiResultVec<MultiValue<K, V>>`.