### PR TITLE
Add `sc_format!` macro

### DIFF
--- a/contracts/feature-tests/formatted-message-features/mandos/managed_error_message.scen.json
+++ b/contracts/feature-tests/formatted-message-features/mandos/managed_error_message.scen.json
@@ -110,6 +110,26 @@
                 "gas": "*",
                 "refund": "*"
             }
+        },
+        {
+            "step": "scCall",
+            "txId": "4",
+            "tx": {
+                "from": "address:an_account",
+                "to": "sc:msg-features",
+                "function": "decode_error_message",
+                "arguments": [],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "4",
+                "message": "str:unsupported operation",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
         }
     ]
 }

--- a/contracts/feature-tests/formatted-message-features/mandos/sc_format.scen.json
+++ b/contracts/feature-tests/formatted-message-features/mandos/sc_format.scen.json
@@ -1,0 +1,64 @@
+{
+    "steps": [
+        {
+            "step": "setState",
+            "accounts": {
+                "sc:msg-features": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "code": "file:../output/formatted-message-features.wasm"
+                },
+                "address:an_account": {
+                    "nonce": "0",
+                    "balance": "0"
+                }
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "format_message_one_argument",
+            "tx": {
+                "from": "address:an_account",
+                "to": "sc:msg-features",
+                "function": "format_message_one_argument",
+                "arguments": [],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [
+                    "str:Test"
+                ],
+                "status": "0",
+                "message": "",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "format_message_multiple_arguments",
+            "tx": {
+                "from": "address:an_account",
+                "to": "sc:msg-features",
+                "function": "format_message_multiple_arguments",
+                "arguments": [
+                    "123456789"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [
+                    "str:Hello 123456789 world"
+                ],
+                "status": "0",
+                "message": "",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        }
+    ]
+}

--- a/contracts/feature-tests/formatted-message-features/src/formatted_message_features.rs
+++ b/contracts/feature-tests/formatted-message-features/src/formatted_message_features.rs
@@ -59,4 +59,16 @@ pub trait FormattedMessageFeatures {
     fn print_message(&self, x: i32) {
         sc_print!("Printing x: {}", x,);
     }
+
+    #[endpoint]
+    fn format_message_one_argument(&self) -> ManagedBuffer {
+        let message = sc_format!("Test");
+        message
+    }
+
+    #[endpoint]
+    fn format_message_multiple_arguments(&self, x: i32) -> ManagedBuffer {
+        let message = sc_format!("Hello {} world", x);
+        message
+    }
 }

--- a/contracts/feature-tests/formatted-message-features/tests/msg_mandos_go_test.rs
+++ b/contracts/feature-tests/formatted-message-features/tests/msg_mandos_go_test.rs
@@ -2,3 +2,8 @@
 fn msg_go() {
     elrond_wasm_debug::mandos_go("mandos/managed_error_message.scen.json");
 }
+
+#[test]
+fn sc_format_go() {
+    elrond_wasm_debug::mandos_go("mandos/sc_format.scen.json");
+}

--- a/contracts/feature-tests/formatted-message-features/tests/msg_mandos_rs_test.rs
+++ b/contracts/feature-tests/formatted-message-features/tests/msg_mandos_rs_test.rs
@@ -16,3 +16,8 @@ fn world() -> BlockchainMock {
 fn msg_rs() {
     elrond_wasm_debug::mandos_rs("mandos/managed_error_message.scen.json", world());
 }
+
+#[test]
+fn sc_format_rs() {
+    elrond_wasm_debug::mandos_rs("mandos/sc_format.scen.json", world());
+}

--- a/contracts/feature-tests/formatted-message-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/formatted-message-features/wasm/src/lib.rs
@@ -11,6 +11,8 @@ elrond_wasm_node::wasm_endpoints! {
         dynamic_message
         dynamic_message_ascii
         dynamic_message_multiple
+        format_message_multiple_arguments
+        format_message_one_argument
         print_message
         static_message
     )

--- a/elrond-wasm/src/macros.rs
+++ b/elrond-wasm/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! imports {
             io::*,
             non_zero_usize,
             non_zero_util::*,
-            require, require_old, sc_error, sc_panic, sc_print,
+            require, require_old, sc_error, sc_format, sc_panic, sc_print,
             storage::mappers::*,
             types::{
                 SCResult::{Err, Ok},
@@ -140,6 +140,19 @@ macro_rules! sc_print {
             &<Self::Api as elrond_wasm::api::PrintApi>::print_api_impl(),
             ___buffer___,
         );
+    }};
+}
+
+#[macro_export]
+macro_rules! sc_format {
+    ($msg:tt, $($arg:expr),+ $(,)?) => {{
+        let mut ___buffer___ =
+            elrond_wasm::types::ManagedBufferCachedBuilder::<Self::Api>::new_from_slice(&[]);
+        elrond_wasm::derive::format_receiver_args!(___buffer___, $msg, $($arg),+);
+        ___buffer___.into_managed_buffer()
+    }};
+    ($msg:expr $(,)?) => {{
+        elrond_wasm::types::ManagedBuffer::new_from_bytes($msg.as_bytes())
     }};
 }
 


### PR DESCRIPTION
- add `sc_format!` macro which formats the messages into a `ManagedBuffer`
- tested the functionality with mandos-rs and mandos-go
- add an unrelated missing test for `decode_error_message`