### PR TITLE
mandos step refactoring #1

### DIFF
--- a/elrond-wasm-debug/src/mandos_rs_runner.rs
+++ b/elrond-wasm-debug/src/mandos_rs_runner.rs
@@ -20,53 +20,37 @@ fn parse_execute_mandos_steps(steps_path: &Path, state: &mut Rc<BlockchainMock>)
 
     for step in scenario.steps.iter() {
         match step {
-            Step::ExternalSteps { path } => {
+            Step::ExternalSteps(external_steps_step) => {
                 let parent_path = steps_path.parent().unwrap();
-                let new_path = parent_path.join(path);
+                let new_path = parent_path.join(&external_steps_step.path);
                 parse_execute_mandos_steps(new_path.as_path(), state);
             },
-            Step::SetState {
-                comment,
-                accounts,
-                new_addresses,
-                block_hashes,
-                previous_block_info,
-                current_block_info,
-            } => mandos_step::set_state::execute(
-                Rc::get_mut(state).unwrap(),
-                accounts,
-                new_addresses,
-                previous_block_info,
-                current_block_info,
-            ),
-            Step::ScCall {
-                tx_id,
-                comment,
-                tx,
-                expect,
-            } => mandos_step::sc_call::execute(state, tx_id, tx, expect),
-            Step::ScQuery {
-                tx_id,
-                comment,
-                tx,
-                expect,
-            } => mandos_step::sc_query::execute(state.clone(), tx_id, tx, expect),
-            Step::ScDeploy {
-                tx_id,
-                comment,
-                tx,
-                expect,
-            } => mandos_step::sc_deploy::execute(state, tx_id, tx, expect),
-            Step::Transfer { tx_id, comment, tx } => mandos_step::transfer::execute(state, tx),
-            Step::ValidatorReward { tx_id, comment, tx } => {
-                Rc::get_mut(state)
-                    .unwrap()
-                    .increase_validator_reward(&tx.to.value.into(), &tx.egld_value.value);
+            Step::SetState(set_state_step) => {
+                mandos_step::set_state::execute(Rc::get_mut(state).unwrap(), set_state_step)
             },
-            Step::CheckState { comment, accounts } => {
-                mandos_step::check_state::execute(accounts, Rc::get_mut(state).unwrap());
+            Step::ScCall(sc_call_step) => mandos_step::sc_call::execute(state, sc_call_step),
+            Step::ScQuery(sc_query_step) => {
+                mandos_step::sc_query::execute(state.clone(), sc_query_step)
             },
-            Step::DumpState { .. } => {
+            Step::ScDeploy(sc_deploy_step) => {
+                mandos_step::sc_deploy::execute(state, sc_deploy_step)
+            },
+            Step::Transfer(transfer_step) => {
+                mandos_step::transfer::execute(state, &transfer_step.tx)
+            },
+            Step::ValidatorReward(validator_reward) => {
+                Rc::get_mut(state).unwrap().increase_validator_reward(
+                    &validator_reward.tx.to.value.into(),
+                    &validator_reward.tx.egld_value.value,
+                );
+            },
+            Step::CheckState(check_state_step) => {
+                mandos_step::check_state::execute(
+                    &check_state_step.accounts,
+                    Rc::get_mut(state).unwrap(),
+                );
+            },
+            Step::DumpState(_) => {
                 state.print_accounts();
             },
         }

--- a/elrond-wasm-debug/src/mandos_step/sc_call.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_call.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use mandos::model::{TxCall, TxESDT, TxExpect};
+use mandos::model::{ScCallStep, TxESDT};
 
 use crate::{
     tx_execution::sc_call_with_async_and_callback,
@@ -10,12 +10,8 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(
-    state: &mut Rc<BlockchainMock>,
-    tx_id: &str,
-    tx: &TxCall,
-    expect: &Option<TxExpect>,
-) {
+pub fn execute(state: &mut Rc<BlockchainMock>, sc_call_step: &ScCallStep) {
+    let tx = &sc_call_step.tx;
     let tx_input = TxInput {
         from: tx.from.value.into(),
         to: tx.to.value.into(),
@@ -29,11 +25,11 @@ pub fn execute(
             .collect(),
         gas_limit: tx.gas_limit.value,
         gas_price: tx.gas_price.value,
-        tx_hash: generate_tx_hash_dummy(tx_id),
+        tx_hash: generate_tx_hash_dummy(&sc_call_step.tx_id),
     };
     let tx_result = sc_call_with_async_and_callback(tx_input, state, true);
-    if let Some(tx_expect) = expect {
-        check_tx_output(tx_id, tx_expect, &tx_result);
+    if let Some(tx_expect) = &sc_call_step.expect {
+        check_tx_output(&sc_call_step.tx_id, tx_expect, &tx_result);
     }
 }
 

--- a/elrond-wasm-debug/src/mandos_step/sc_deploy.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_deploy.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use elrond_wasm::types::heap::Address;
-use mandos::model::{TxDeploy, TxExpect};
+use mandos::model::ScDeployStep;
 
 use crate::{
     tx_execution::sc_create,
@@ -11,12 +11,8 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(
-    state: &mut Rc<BlockchainMock>,
-    tx_id: &str,
-    tx: &TxDeploy,
-    expect: &Option<TxExpect>,
-) {
+pub fn execute(state: &mut Rc<BlockchainMock>, sc_deploy_step: &ScDeployStep) {
+    let tx = &sc_deploy_step.tx;
     let tx_input = TxInput {
         from: tx.from.value.into(),
         to: Address::zero(),
@@ -30,10 +26,10 @@ pub fn execute(
             .collect(),
         gas_limit: tx.gas_limit.value,
         gas_price: tx.gas_price.value,
-        tx_hash: generate_tx_hash_dummy(tx_id),
+        tx_hash: generate_tx_hash_dummy(&sc_deploy_step.tx_id),
     };
     let tx_result = sc_create(tx_input, &tx.contract_code.value, state);
-    if let Some(tx_expect) = expect {
-        check_tx_output(tx_id, tx_expect, &tx_result);
+    if let Some(tx_expect) = &sc_deploy_step.expect {
+        check_tx_output(&sc_deploy_step.tx_id, tx_expect, &tx_result);
     }
 }

--- a/elrond-wasm-debug/src/mandos_step/sc_query.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_query.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use mandos::model::{TxExpect, TxQuery};
+use mandos::model::ScQueryStep;
 use num_bigint::BigUint;
 
 use crate::{
@@ -11,21 +11,22 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(state: Rc<BlockchainMock>, tx_id: &str, tx: &TxQuery, expect: &Option<TxExpect>) {
+pub fn execute(state: Rc<BlockchainMock>, sc_query_step: &ScQueryStep) {
     let tx_input = TxInput {
-        from: tx.to.value.into(),
-        to: tx.to.value.into(),
+        from: sc_query_step.tx.to.value.into(),
+        to: sc_query_step.tx.to.value.into(),
         egld_value: BigUint::from(0u32),
         esdt_values: Vec::new(),
-        func_name: tx.function.as_bytes().to_vec(),
-        args: tx
+        func_name: sc_query_step.tx.function.as_bytes().to_vec(),
+        args: sc_query_step
+            .tx
             .arguments
             .iter()
             .map(|scen_arg| scen_arg.value.clone())
             .collect(),
         gas_limit: u64::MAX,
         gas_price: 0u64,
-        tx_hash: generate_tx_hash_dummy(tx_id),
+        tx_hash: generate_tx_hash_dummy(&sc_query_step.tx_id),
     };
 
     let tx_result = sc_query(tx_input, state);
@@ -33,7 +34,7 @@ pub fn execute(state: Rc<BlockchainMock>, tx_id: &str, tx: &TxQuery, expect: &Op
         tx_result.result_status != 0 || tx_result.result_calls.is_empty(),
         "Can't query a view function that performs an async call"
     );
-    if let Some(tx_expect) = expect {
-        check_tx_output(tx_id, tx_expect, &tx_result);
+    if let Some(tx_expect) = &sc_query_step.expect {
+        check_tx_output(&sc_query_step.tx_id, tx_expect, &tx_result);
     }
 }

--- a/elrond-wasm-debug/src/mandos_step/set_state.rs
+++ b/elrond-wasm-debug/src/mandos_step/set_state.rs
@@ -1,7 +1,5 @@
-use std::collections::BTreeMap;
-
 use elrond_wasm::types::heap::Address;
-use mandos::model::{Account, AddressKey, BlockInfo, NewAddress};
+use mandos::model::SetStateStep;
 use num_bigint::BigUint;
 
 use crate::world_mock::{
@@ -9,14 +7,8 @@ use crate::world_mock::{
     BlockchainMock, EsdtData, EsdtInstance, EsdtInstanceMetadata, EsdtInstances, EsdtRoles,
 };
 
-pub fn execute(
-    state: &mut BlockchainMock,
-    accounts: &BTreeMap<AddressKey, Account>,
-    new_addresses: &[NewAddress],
-    previous_block_info: &Option<BlockInfo>,
-    current_block_info: &Option<BlockInfo>,
-) {
-    for (address, account) in accounts.iter() {
+pub fn execute(state: &mut BlockchainMock, set_state_step: &SetStateStep) {
+    for (address, account) in set_state_step.accounts.iter() {
         let storage = account
             .storage
             .iter()
@@ -64,7 +56,7 @@ pub fn execute(
                 .map(|address_value| address_value.value.into()),
         });
     }
-    for new_address in new_addresses.iter() {
+    for new_address in set_state_step.new_addresses.iter() {
         assert!(
             is_smart_contract_address(&new_address.new_address.value.into()),
             "field should have SC format"
@@ -75,10 +67,10 @@ pub fn execute(
             new_address.new_address.value.into(),
         )
     }
-    if let Some(block_info_obj) = &*previous_block_info {
+    if let Some(block_info_obj) = &*set_state_step.previous_block_info {
         update_block_info(&mut state.previous_block_info, block_info_obj);
     }
-    if let Some(block_info_obj) = &*current_block_info {
+    if let Some(block_info_obj) = &*set_state_step.current_block_info {
         update_block_info(&mut state.current_block_info, block_info_obj);
     }
 }

--- a/mandos/src/model/step.rs
+++ b/mandos/src/model/step.rs
@@ -11,59 +11,88 @@ use super::{
 };
 
 #[derive(Debug)]
+pub struct ExternalStepsStep {
+    pub path: String,
+}
+
+#[derive(Debug)]
+pub struct SetStateStep {
+    pub comment: Option<String>,
+    pub accounts: BTreeMap<AddressKey, Account>,
+    pub new_addresses: Vec<NewAddress>,
+    pub block_hashes: Vec<BytesValue>,
+    pub previous_block_info: Box<Option<BlockInfo>>,
+    pub current_block_info: Box<Option<BlockInfo>>,
+}
+
+#[derive(Debug)]
+pub struct ScCallStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxCall>,
+    pub expect: Option<TxExpect>,
+}
+
+#[derive(Debug)]
+pub struct ScQueryStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxQuery>,
+    pub expect: Option<TxExpect>,
+}
+
+#[derive(Debug)]
+pub struct ScDeployStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxDeploy>,
+    pub expect: Option<TxExpect>,
+}
+
+#[derive(Debug)]
+pub struct TransferStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxTransfer>,
+}
+
+#[derive(Debug)]
+pub struct ValidatorRewardStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxValidatorReward>,
+}
+
+#[derive(Debug)]
+pub struct CheckStateStep {
+    pub comment: Option<String>,
+    pub accounts: CheckAccounts,
+}
+
+#[derive(Debug)]
+pub struct DumpStateStep {
+    pub comment: Option<String>,
+}
+
+#[derive(Debug)]
 pub enum Step {
-    ExternalSteps {
-        path: String,
-    },
-    SetState {
-        comment: Option<String>,
-        accounts: BTreeMap<AddressKey, Account>,
-        new_addresses: Vec<NewAddress>,
-        block_hashes: Vec<BytesValue>,
-        previous_block_info: Box<Option<BlockInfo>>,
-        current_block_info: Box<Option<BlockInfo>>,
-    },
-    ScCall {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxCall>,
-        expect: Option<TxExpect>,
-    },
-    ScQuery {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxQuery>,
-        expect: Option<TxExpect>,
-    },
-    ScDeploy {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxDeploy>,
-        expect: Option<TxExpect>,
-    },
-    Transfer {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxTransfer>,
-    },
-    ValidatorReward {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxValidatorReward>,
-    },
-    CheckState {
-        comment: Option<String>,
-        accounts: CheckAccounts,
-    },
-    DumpState {
-        comment: Option<String>,
-    },
+    ExternalSteps(ExternalStepsStep),
+    SetState(SetStateStep),
+    ScCall(ScCallStep),
+    ScQuery(ScQueryStep),
+    ScDeploy(ScDeployStep),
+    Transfer(TransferStep),
+    ValidatorReward(ValidatorRewardStep),
+    CheckState(CheckStateStep),
+    DumpState(DumpStateStep),
 }
 
 impl InterpretableFrom<StepRaw> for Step {
     fn interpret_from(from: StepRaw, context: &InterpreterContext) -> Self {
         match from {
-            StepRaw::ExternalSteps { comment: _, path } => Step::ExternalSteps { path },
+            StepRaw::ExternalSteps { comment: _, path } => {
+                Step::ExternalSteps(ExternalStepsStep { path })
+            },
             StepRaw::SetState {
                 comment,
                 accounts,
@@ -71,7 +100,7 @@ impl InterpretableFrom<StepRaw> for Step {
                 block_hashes,
                 previous_block_info,
                 current_block_info,
-            } => Step::SetState {
+            } => Step::SetState(SetStateStep {
                 comment,
                 accounts: accounts
                     .into_iter()
@@ -96,58 +125,60 @@ impl InterpretableFrom<StepRaw> for Step {
                 current_block_info: Box::new(
                     current_block_info.map(|v| BlockInfo::interpret_from(v, context)),
                 ),
-            },
+            }),
             StepRaw::ScCall {
                 tx_id,
                 comment,
                 display_logs: _,
                 tx,
                 expect,
-            } => Step::ScCall {
+            } => Step::ScCall(ScCallStep {
                 tx_id,
                 comment,
                 tx: Box::new(TxCall::interpret_from(tx, context)),
                 expect: expect.map(|v| TxExpect::interpret_from(v, context)),
-            },
+            }),
             StepRaw::ScQuery {
                 tx_id,
                 comment,
                 display_logs: _,
                 tx,
                 expect,
-            } => Step::ScQuery {
+            } => Step::ScQuery(ScQueryStep {
                 tx_id,
                 comment,
                 tx: Box::new(TxQuery::interpret_from(tx, context)),
                 expect: expect.map(|v| TxExpect::interpret_from(v, context)),
-            },
+            }),
             StepRaw::ScDeploy {
                 tx_id,
                 comment,
                 display_logs: _,
                 tx,
                 expect,
-            } => Step::ScDeploy {
+            } => Step::ScDeploy(ScDeployStep {
                 tx_id,
                 comment,
                 tx: Box::new(TxDeploy::interpret_from(tx, context)),
                 expect: expect.map(|v| TxExpect::interpret_from(v, context)),
-            },
-            StepRaw::Transfer { tx_id, comment, tx } => Step::Transfer {
+            }),
+            StepRaw::Transfer { tx_id, comment, tx } => Step::Transfer(TransferStep {
                 tx_id,
                 comment,
                 tx: Box::new(TxTransfer::interpret_from(tx, context)),
+            }),
+            StepRaw::ValidatorReward { tx_id, comment, tx } => {
+                Step::ValidatorReward(ValidatorRewardStep {
+                    tx_id,
+                    comment,
+                    tx: Box::new(TxValidatorReward::interpret_from(tx, context)),
+                })
             },
-            StepRaw::ValidatorReward { tx_id, comment, tx } => Step::ValidatorReward {
-                tx_id,
-                comment,
-                tx: Box::new(TxValidatorReward::interpret_from(tx, context)),
-            },
-            StepRaw::CheckState { comment, accounts } => Step::CheckState {
+            StepRaw::CheckState { comment, accounts } => Step::CheckState(CheckStateStep {
                 comment,
                 accounts: CheckAccounts::interpret_from(accounts, context),
-            },
-            StepRaw::DumpState { comment } => Step::DumpState { comment },
+            }),
+            StepRaw::DumpState { comment } => Step::DumpState(DumpStateStep { comment }),
         }
     }
 }


### PR DESCRIPTION
Simple first step: changed the mandos `Step` enum to a more canonical form.