### PR TITLE
Mandos step refactor #2

### DIFF
--- a/contracts/examples/adder/tests/adder_mandos_constructed_test.rs
+++ b/contracts/examples/adder/tests/adder_mandos_constructed_test.rs
@@ -1,0 +1,49 @@
+use elrond_wasm_debug::{mandos::model::*, *};
+
+fn world() -> BlockchainMock {
+    let mut blockchain = BlockchainMock::new();
+    blockchain.set_current_dir_from_workspace("contracts/examples/adder");
+
+    blockchain.register_contract_builder("file:output/adder.wasm", adder::ContractBuilder);
+    blockchain
+}
+
+#[test]
+fn adder_mandos_constructed() {
+    let _ = world()
+        .mandos_set_state(
+            SetStateStep::new()
+                .put_account("address:owner", Account::new().nonce(1))
+                .new_address("address:owner", 1, "sc:adder"),
+        )
+        .mandos_sc_deploy(
+            ScDeployStep::new()
+                .from("address:owner")
+                .contract_code("file:output/adder.wasm")
+                .argument("5")
+                .gas_limit("5,000,000")
+                .expect(TxExpect::ok().no_result()),
+        )
+        .mandos_sc_query(
+            ScQueryStep::new()
+                .to("sc:adder")
+                .function("getSum")
+                .expect(TxExpect::ok().result("5")),
+        )
+        .mandos_sc_call(
+            ScCallStep::new()
+                .from("address:owner")
+                .to("sc:adder")
+                .function("add")
+                .argument("3")
+                .expect(TxExpect::ok().no_result()),
+        )
+        .mandos_check_state(
+            CheckStateStep::new()
+                .put_account("address:owner", CheckAccount::new())
+                .put_account(
+                    "sc:adder",
+                    CheckAccount::new().check_storage("str:sum", "8"),
+                ),
+        );
+}

--- a/contracts/examples/adder/tests/adder_mandos_constructed_test.rs
+++ b/contracts/examples/adder/tests/adder_mandos_constructed_test.rs
@@ -2,8 +2,6 @@ use elrond_wasm_debug::{mandos::model::*, *};
 
 fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/adder");
-
     blockchain.register_contract_builder("file:output/adder.wasm", adder::ContractBuilder);
     blockchain
 }

--- a/contracts/examples/adder/tests/adder_mandos_constructed_test.rs
+++ b/contracts/examples/adder/tests/adder_mandos_constructed_test.rs
@@ -2,13 +2,17 @@ use elrond_wasm_debug::{mandos::model::*, *};
 
 fn world() -> BlockchainMock {
     let mut blockchain = BlockchainMock::new();
+    blockchain.set_current_dir_from_workspace("contracts/examples/adder");
+
     blockchain.register_contract_builder("file:output/adder.wasm", adder::ContractBuilder);
     blockchain
 }
 
 #[test]
 fn adder_mandos_constructed() {
-    let _ = world()
+    let world = world();
+    let intp_context = world.interpreter_context();
+    let _ = world
         .mandos_set_state(
             SetStateStep::new()
                 .put_account("address:owner", Account::new().nonce(1))
@@ -17,7 +21,7 @@ fn adder_mandos_constructed() {
         .mandos_sc_deploy(
             ScDeployStep::new()
                 .from("address:owner")
-                .contract_code("file:output/adder.wasm")
+                .contract_code("file:output/adder.wasm", &intp_context)
                 .argument("5")
                 .gas_limit("5,000,000")
                 .expect(TxExpect::ok().no_result()),

--- a/elrond-wasm-debug/src/lib.rs
+++ b/elrond-wasm-debug/src/lib.rs
@@ -25,6 +25,9 @@ pub use mandos_rs_runner::mandos_rs;
 pub use tx_mock::DebugApi;
 pub use world_mock::BlockchainMock;
 
+// Re-exporting the whole mandos crate for easier use in tests.
+pub use mandos;
+
 #[macro_use]
 extern crate alloc;
 pub use alloc::{boxed::Box, vec::Vec};

--- a/elrond-wasm-debug/src/mandos_rs_runner.rs
+++ b/elrond-wasm-debug/src/mandos_rs_runner.rs
@@ -20,53 +20,37 @@ fn parse_execute_mandos_steps(steps_path: &Path, state: &mut Rc<BlockchainMock>)
 
     for step in scenario.steps.iter() {
         match step {
-            Step::ExternalSteps { path } => {
+            Step::ExternalSteps(external_steps_step) => {
                 let parent_path = steps_path.parent().unwrap();
-                let new_path = parent_path.join(path);
+                let new_path = parent_path.join(&external_steps_step.path);
                 parse_execute_mandos_steps(new_path.as_path(), state);
             },
-            Step::SetState {
-                comment,
-                accounts,
-                new_addresses,
-                block_hashes,
-                previous_block_info,
-                current_block_info,
-            } => mandos_step::set_state::execute(
-                Rc::get_mut(state).unwrap(),
-                accounts,
-                new_addresses,
-                previous_block_info,
-                current_block_info,
-            ),
-            Step::ScCall {
-                tx_id,
-                comment,
-                tx,
-                expect,
-            } => mandos_step::sc_call::execute(state, tx_id, tx, expect),
-            Step::ScQuery {
-                tx_id,
-                comment,
-                tx,
-                expect,
-            } => mandos_step::sc_query::execute(state.clone(), tx_id, tx, expect),
-            Step::ScDeploy {
-                tx_id,
-                comment,
-                tx,
-                expect,
-            } => mandos_step::sc_deploy::execute(state, tx_id, tx, expect),
-            Step::Transfer { tx_id, comment, tx } => mandos_step::transfer::execute(state, tx),
-            Step::ValidatorReward { tx_id, comment, tx } => {
-                Rc::get_mut(state)
-                    .unwrap()
-                    .increase_validator_reward(&tx.to.value.into(), &tx.egld_value.value);
+            Step::SetState(set_state_step) => {
+                mandos_step::set_state::execute(Rc::get_mut(state).unwrap(), set_state_step)
             },
-            Step::CheckState { comment, accounts } => {
-                mandos_step::check_state::execute(accounts, Rc::get_mut(state).unwrap());
+            Step::ScCall(sc_call_step) => mandos_step::sc_call::execute(state, sc_call_step),
+            Step::ScQuery(sc_query_step) => {
+                mandos_step::sc_query::execute(state.clone(), sc_query_step)
             },
-            Step::DumpState { .. } => {
+            Step::ScDeploy(sc_deploy_step) => {
+                mandos_step::sc_deploy::execute(state, sc_deploy_step)
+            },
+            Step::Transfer(transfer_step) => {
+                mandos_step::transfer::execute(state, &transfer_step.tx)
+            },
+            Step::ValidatorReward(validator_reward) => {
+                Rc::get_mut(state).unwrap().increase_validator_reward(
+                    &validator_reward.tx.to.value.into(),
+                    &validator_reward.tx.egld_value.value,
+                );
+            },
+            Step::CheckState(check_state_step) => {
+                mandos_step::check_state::execute(
+                    &check_state_step.accounts,
+                    Rc::get_mut(state).unwrap(),
+                );
+            },
+            Step::DumpState(_) => {
                 state.print_accounts();
             },
         }

--- a/elrond-wasm-debug/src/mandos_rs_runner.rs
+++ b/elrond-wasm-debug/src/mandos_rs_runner.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)] // for now
 
-use crate::{mandos_step, world_mock::BlockchainMock};
+use crate::world_mock::BlockchainMock;
 
 use mandos::model::Step;
 use std::path::Path;
@@ -17,40 +17,23 @@ pub fn mandos_rs<P: AsRef<Path>>(relative_path: P, world: BlockchainMock) {
 fn parse_execute_mandos_steps(steps_path: &Path, mut state: BlockchainMock) -> BlockchainMock {
     let scenario = mandos::parse_scenario(steps_path);
 
-    for step in scenario.steps.iter() {
+    for step in scenario.steps.into_iter() {
         state = match step {
             Step::ExternalSteps(external_steps_step) => {
                 let parent_path = steps_path.parent().unwrap();
                 let new_path = parent_path.join(&external_steps_step.path);
                 parse_execute_mandos_steps(new_path.as_path(), state)
             },
-            Step::SetState(set_state_step) => {
-                mandos_step::set_state::execute(&mut state, set_state_step);
-                state
+            Step::SetState(set_state_step) => state.mandos_set_state(set_state_step),
+            Step::ScCall(sc_call_step) => state.mandos_sc_call(sc_call_step),
+            Step::ScQuery(sc_query_step) => state.mandos_sc_query(sc_query_step),
+            Step::ScDeploy(sc_deploy_step) => state.mandos_sc_deploy(sc_deploy_step),
+            Step::Transfer(transfer_step) => state.mandos_transfer(transfer_step),
+            Step::ValidatorReward(validator_reward_step) => {
+                state.mandos_validator_reward(validator_reward_step)
             },
-            Step::ScCall(sc_call_step) => mandos_step::sc_call::execute(state, sc_call_step),
-            Step::ScQuery(sc_query_step) => mandos_step::sc_query::execute(state, sc_query_step),
-            Step::ScDeploy(sc_deploy_step) => {
-                mandos_step::sc_deploy::execute(state, sc_deploy_step)
-            },
-            Step::Transfer(transfer_step) => {
-                mandos_step::transfer::execute(state, &transfer_step.tx)
-            },
-            Step::ValidatorReward(validator_reward) => {
-                state.increase_validator_reward(
-                    &validator_reward.tx.to.value.into(),
-                    &validator_reward.tx.egld_value.value,
-                );
-                state
-            },
-            Step::CheckState(check_state_step) => {
-                mandos_step::check_state::execute(&check_state_step.accounts, &mut state);
-                state
-            },
-            Step::DumpState(_) => {
-                state.print_accounts();
-                state
-            },
+            Step::CheckState(check_state_step) => state.mandos_check_state(check_state_step),
+            Step::DumpState(_) => state.mandos_dump_state(),
         };
     }
 

--- a/elrond-wasm-debug/src/mandos_rs_runner.rs
+++ b/elrond-wasm-debug/src/mandos_rs_runner.rs
@@ -3,7 +3,7 @@
 use crate::{mandos_step, world_mock::BlockchainMock};
 
 use mandos::model::Step;
-use std::{path::Path, rc::Rc};
+use std::path::Path;
 
 /// Runs mandos test using the Rust infrastructure and the debug mode.
 /// Uses a contract map to replace the references to the wasm bytecode
@@ -11,27 +11,25 @@ use std::{path::Path, rc::Rc};
 pub fn mandos_rs<P: AsRef<Path>>(relative_path: P, world: BlockchainMock) {
     let mut absolute_path = world.current_dir.clone();
     absolute_path.push(relative_path);
-    let mut state = Rc::new(world);
-    parse_execute_mandos_steps(absolute_path.as_ref(), &mut state);
+    let _ = parse_execute_mandos_steps(absolute_path.as_ref(), world);
 }
 
-fn parse_execute_mandos_steps(steps_path: &Path, state: &mut Rc<BlockchainMock>) {
+fn parse_execute_mandos_steps(steps_path: &Path, mut state: BlockchainMock) -> BlockchainMock {
     let scenario = mandos::parse_scenario(steps_path);
 
     for step in scenario.steps.iter() {
-        match step {
+        state = match step {
             Step::ExternalSteps(external_steps_step) => {
                 let parent_path = steps_path.parent().unwrap();
                 let new_path = parent_path.join(&external_steps_step.path);
-                parse_execute_mandos_steps(new_path.as_path(), state);
+                parse_execute_mandos_steps(new_path.as_path(), state)
             },
             Step::SetState(set_state_step) => {
-                mandos_step::set_state::execute(Rc::get_mut(state).unwrap(), set_state_step)
+                mandos_step::set_state::execute(&mut state, set_state_step);
+                state
             },
             Step::ScCall(sc_call_step) => mandos_step::sc_call::execute(state, sc_call_step),
-            Step::ScQuery(sc_query_step) => {
-                mandos_step::sc_query::execute(state.clone(), sc_query_step)
-            },
+            Step::ScQuery(sc_query_step) => mandos_step::sc_query::execute(state, sc_query_step),
             Step::ScDeploy(sc_deploy_step) => {
                 mandos_step::sc_deploy::execute(state, sc_deploy_step)
             },
@@ -39,20 +37,22 @@ fn parse_execute_mandos_steps(steps_path: &Path, state: &mut Rc<BlockchainMock>)
                 mandos_step::transfer::execute(state, &transfer_step.tx)
             },
             Step::ValidatorReward(validator_reward) => {
-                Rc::get_mut(state).unwrap().increase_validator_reward(
+                state.increase_validator_reward(
                     &validator_reward.tx.to.value.into(),
                     &validator_reward.tx.egld_value.value,
                 );
+                state
             },
             Step::CheckState(check_state_step) => {
-                mandos_step::check_state::execute(
-                    &check_state_step.accounts,
-                    Rc::get_mut(state).unwrap(),
-                );
+                mandos_step::check_state::execute(&check_state_step.accounts, &mut state);
+                state
             },
             Step::DumpState(_) => {
                 state.print_accounts();
+                state
             },
-        }
+        };
     }
+
+    state
 }

--- a/elrond-wasm-debug/src/mandos_step/check_state.rs
+++ b/elrond-wasm-debug/src/mandos_step/check_state.rs
@@ -1,6 +1,6 @@
 use mandos::model::{
     AddressKey, BytesValue, CheckEsdt, CheckEsdtData, CheckEsdtInstance, CheckEsdtInstances,
-    CheckEsdtMap, CheckStorage, CheckValue, Checkable,
+    CheckEsdtMap, CheckStateStep, CheckStorage, CheckValue, Checkable,
 };
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -10,7 +10,19 @@ use crate::{
     world_mock::{AccountEsdt, BlockchainMock, EsdtData, EsdtInstance, EsdtInstances},
 };
 
-pub fn execute(accounts: &mandos::model::CheckAccounts, state: &mut BlockchainMock) {
+impl BlockchainMock {
+    pub fn mandos_check_state(mut self, check_state_step: CheckStateStep) -> BlockchainMock {
+        execute(&mut self, &check_state_step.accounts);
+        self
+    }
+
+    pub fn mandos_dump_state(self) -> BlockchainMock {
+        self.print_accounts();
+        self
+    }
+}
+
+fn execute(state: &mut BlockchainMock, accounts: &mandos::model::CheckAccounts) {
     for (expected_address, expected_account) in accounts.accounts.iter() {
         if let Some(account) = state.accounts.get(&expected_address.value.into()) {
             assert!(

--- a/elrond-wasm-debug/src/mandos_step/sc_call.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_call.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use mandos::model::{ScCallStep, TxESDT};
+use mandos::model::{ScCallStep, Step, TxESDT};
 
 use crate::{
     tx_execution::sc_call_with_async_and_callback,
@@ -10,10 +10,14 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(state: BlockchainMock, sc_call_step: &ScCallStep) -> BlockchainMock {
-    let mut state_rc = Rc::new(state);
-    execute_rc(&mut state_rc, sc_call_step);
-    Rc::try_unwrap(state_rc).unwrap()
+impl BlockchainMock {
+    pub fn mandos_sc_call(mut self, sc_call_step: ScCallStep) -> BlockchainMock {
+        let mut state_rc = Rc::new(self);
+        execute_rc(&mut state_rc, &sc_call_step);
+        self = Rc::try_unwrap(state_rc).unwrap();
+        self.mandos_trace.steps.push(Step::ScCall(sc_call_step));
+        self
+    }
 }
 
 fn execute_rc(state: &mut Rc<BlockchainMock>, sc_call_step: &ScCallStep) {

--- a/elrond-wasm-debug/src/mandos_step/sc_call.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_call.rs
@@ -10,7 +10,13 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(state: &mut Rc<BlockchainMock>, sc_call_step: &ScCallStep) {
+pub fn execute(state: BlockchainMock, sc_call_step: &ScCallStep) -> BlockchainMock {
+    let mut state_rc = Rc::new(state);
+    execute_rc(&mut state_rc, sc_call_step);
+    Rc::try_unwrap(state_rc).unwrap()
+}
+
+fn execute_rc(state: &mut Rc<BlockchainMock>, sc_call_step: &ScCallStep) {
     let tx = &sc_call_step.tx;
     let tx_input = TxInput {
         from: tx.from.value.into(),

--- a/elrond-wasm-debug/src/mandos_step/sc_call.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_call.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use mandos::model::{TxCall, TxESDT, TxExpect};
+use mandos::model::{ScCallStep, TxESDT};
 
 use crate::{
     tx_execution::sc_call_with_async_and_callback,
@@ -10,12 +10,8 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(
-    state: &mut Rc<BlockchainMock>,
-    tx_id: &str,
-    tx: &TxCall,
-    expect: &Option<TxExpect>,
-) {
+pub fn execute(state: &mut Rc<BlockchainMock>, sc_call_step: &ScCallStep) {
+    let tx = &sc_call_step.tx;
     let tx_input = TxInput {
         from: tx.from.value.into(),
         to: tx.to.value.into(),
@@ -29,11 +25,11 @@ pub fn execute(
             .collect(),
         gas_limit: tx.gas_limit.value,
         gas_price: tx.gas_price.value,
-        tx_hash: generate_tx_hash_dummy(tx_id),
+        tx_hash: generate_tx_hash_dummy(&sc_call_step.tx_id),
     };
     let tx_result = sc_call_with_async_and_callback(tx_input, state, true);
-    if let Some(tx_expect) = expect {
-        check_tx_output(tx_id, tx_expect, &tx_result);
+    if let Some(tx_expect) = &sc_call_step.expect {
+        check_tx_output(&sc_call_step.tx_id, tx_expect, &tx_result);
     }
 }
 

--- a/elrond-wasm-debug/src/mandos_step/sc_deploy.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_deploy.rs
@@ -11,7 +11,13 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(state: &mut Rc<BlockchainMock>, sc_deploy_step: &ScDeployStep) {
+pub fn execute(state: BlockchainMock, sc_deploy_step: &ScDeployStep) -> BlockchainMock {
+    let mut state_rc = Rc::new(state);
+    execute_rc(&mut state_rc, sc_deploy_step);
+    Rc::try_unwrap(state_rc).unwrap()
+}
+
+fn execute_rc(state: &mut Rc<BlockchainMock>, sc_deploy_step: &ScDeployStep) {
     let tx = &sc_deploy_step.tx;
     let tx_input = TxInput {
         from: tx.from.value.into(),

--- a/elrond-wasm-debug/src/mandos_step/sc_deploy.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_deploy.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use elrond_wasm::types::heap::Address;
-use mandos::model::{TxDeploy, TxExpect};
+use mandos::model::ScDeployStep;
 
 use crate::{
     tx_execution::sc_create,
@@ -11,12 +11,8 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(
-    state: &mut Rc<BlockchainMock>,
-    tx_id: &str,
-    tx: &TxDeploy,
-    expect: &Option<TxExpect>,
-) {
+pub fn execute(state: &mut Rc<BlockchainMock>, sc_deploy_step: &ScDeployStep) {
+    let tx = &sc_deploy_step.tx;
     let tx_input = TxInput {
         from: tx.from.value.into(),
         to: Address::zero(),
@@ -30,10 +26,10 @@ pub fn execute(
             .collect(),
         gas_limit: tx.gas_limit.value,
         gas_price: tx.gas_price.value,
-        tx_hash: generate_tx_hash_dummy(tx_id),
+        tx_hash: generate_tx_hash_dummy(&sc_deploy_step.tx_id),
     };
     let tx_result = sc_create(tx_input, &tx.contract_code.value, state);
-    if let Some(tx_expect) = expect {
-        check_tx_output(tx_id, tx_expect, &tx_result);
+    if let Some(tx_expect) = &sc_deploy_step.expect {
+        check_tx_output(&sc_deploy_step.tx_id, tx_expect, &tx_result);
     }
 }

--- a/elrond-wasm-debug/src/mandos_step/sc_deploy.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_deploy.rs
@@ -11,10 +11,12 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(state: BlockchainMock, sc_deploy_step: &ScDeployStep) -> BlockchainMock {
-    let mut state_rc = Rc::new(state);
-    execute_rc(&mut state_rc, sc_deploy_step);
-    Rc::try_unwrap(state_rc).unwrap()
+impl BlockchainMock {
+    pub fn mandos_sc_deploy(self, sc_deploy_step: ScDeployStep) -> BlockchainMock {
+        let mut state_rc = Rc::new(self);
+        execute_rc(&mut state_rc, &sc_deploy_step);
+        Rc::try_unwrap(state_rc).unwrap()
+    }
 }
 
 fn execute_rc(state: &mut Rc<BlockchainMock>, sc_deploy_step: &ScDeployStep) {

--- a/elrond-wasm-debug/src/mandos_step/sc_query.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_query.rs
@@ -11,7 +11,13 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(state: Rc<BlockchainMock>, sc_query_step: &ScQueryStep) {
+pub fn execute(state: BlockchainMock, sc_query_step: &ScQueryStep) -> BlockchainMock {
+    let state_rc = Rc::new(state);
+    execute_rc(state_rc.clone(), sc_query_step);
+    Rc::try_unwrap(state_rc).unwrap()
+}
+
+fn execute_rc(state: Rc<BlockchainMock>, sc_query_step: &ScQueryStep) {
     let tx_input = TxInput {
         from: sc_query_step.tx.to.value.into(),
         to: sc_query_step.tx.to.value.into(),

--- a/elrond-wasm-debug/src/mandos_step/sc_query.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_query.rs
@@ -11,10 +11,12 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(state: BlockchainMock, sc_query_step: &ScQueryStep) -> BlockchainMock {
-    let state_rc = Rc::new(state);
-    execute_rc(state_rc.clone(), sc_query_step);
-    Rc::try_unwrap(state_rc).unwrap()
+impl BlockchainMock {
+    pub fn mandos_sc_query(self, sc_query_step: ScQueryStep) -> BlockchainMock {
+        let state_rc = Rc::new(self);
+        execute_rc(state_rc.clone(), &sc_query_step);
+        Rc::try_unwrap(state_rc).unwrap()
+    }
 }
 
 fn execute_rc(state: Rc<BlockchainMock>, sc_query_step: &ScQueryStep) {

--- a/elrond-wasm-debug/src/mandos_step/sc_query.rs
+++ b/elrond-wasm-debug/src/mandos_step/sc_query.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use mandos::model::{TxExpect, TxQuery};
+use mandos::model::ScQueryStep;
 use num_bigint::BigUint;
 
 use crate::{
@@ -11,21 +11,22 @@ use crate::{
 
 use super::check_tx_output;
 
-pub fn execute(state: Rc<BlockchainMock>, tx_id: &str, tx: &TxQuery, expect: &Option<TxExpect>) {
+pub fn execute(state: Rc<BlockchainMock>, sc_query_step: &ScQueryStep) {
     let tx_input = TxInput {
-        from: tx.to.value.into(),
-        to: tx.to.value.into(),
+        from: sc_query_step.tx.to.value.into(),
+        to: sc_query_step.tx.to.value.into(),
         egld_value: BigUint::from(0u32),
         esdt_values: Vec::new(),
-        func_name: tx.function.as_bytes().to_vec(),
-        args: tx
+        func_name: sc_query_step.tx.function.as_bytes().to_vec(),
+        args: sc_query_step
+            .tx
             .arguments
             .iter()
             .map(|scen_arg| scen_arg.value.clone())
             .collect(),
         gas_limit: u64::MAX,
         gas_price: 0u64,
-        tx_hash: generate_tx_hash_dummy(tx_id),
+        tx_hash: generate_tx_hash_dummy(&sc_query_step.tx_id),
     };
 
     let tx_result = sc_query(tx_input, state);
@@ -33,7 +34,7 @@ pub fn execute(state: Rc<BlockchainMock>, tx_id: &str, tx: &TxQuery, expect: &Op
         tx_result.result_status != 0 || tx_result.result_calls.is_empty(),
         "Can't query a view function that performs an async call"
     );
-    if let Some(tx_expect) = expect {
-        check_tx_output(tx_id, tx_expect, &tx_result);
+    if let Some(tx_expect) = &sc_query_step.expect {
+        check_tx_output(&sc_query_step.tx_id, tx_expect, &tx_result);
     }
 }

--- a/elrond-wasm-debug/src/mandos_step/set_state.rs
+++ b/elrond-wasm-debug/src/mandos_step/set_state.rs
@@ -122,7 +122,7 @@ fn convert_mandos_esdt_to_world_mock(
                 full_esdt
                     .roles
                     .iter()
-                    .map(|role| role.value.clone())
+                    .map(|role| role.as_bytes().to_vec())
                     .collect(),
             ),
             frozen: if let Some(u64_value) = &full_esdt.frozen {

--- a/elrond-wasm-debug/src/mandos_step/set_state.rs
+++ b/elrond-wasm-debug/src/mandos_step/set_state.rs
@@ -1,7 +1,5 @@
-use std::collections::BTreeMap;
-
 use elrond_wasm::types::heap::Address;
-use mandos::model::{Account, AddressKey, BlockInfo, NewAddress};
+use mandos::model::SetStateStep;
 use num_bigint::BigUint;
 
 use crate::world_mock::{
@@ -9,14 +7,8 @@ use crate::world_mock::{
     BlockchainMock, EsdtData, EsdtInstance, EsdtInstanceMetadata, EsdtInstances, EsdtRoles,
 };
 
-pub fn execute(
-    state: &mut BlockchainMock,
-    accounts: &BTreeMap<AddressKey, Account>,
-    new_addresses: &[NewAddress],
-    previous_block_info: &Option<BlockInfo>,
-    current_block_info: &Option<BlockInfo>,
-) {
-    for (address, account) in accounts.iter() {
+pub fn execute(state: &mut BlockchainMock, set_state_step: &SetStateStep) {
+    for (address, account) in set_state_step.accounts.iter() {
         let storage = account
             .storage
             .iter()
@@ -64,7 +56,7 @@ pub fn execute(
                 .map(|address_value| address_value.value.into()),
         });
     }
-    for new_address in new_addresses.iter() {
+    for new_address in set_state_step.new_addresses.iter() {
         assert!(
             is_smart_contract_address(&new_address.new_address.value.into()),
             "field should have SC format"
@@ -75,10 +67,10 @@ pub fn execute(
             new_address.new_address.value.into(),
         )
     }
-    if let Some(block_info_obj) = &*previous_block_info {
+    if let Some(block_info_obj) = &*set_state_step.previous_block_info {
         update_block_info(&mut state.previous_block_info, block_info_obj);
     }
-    if let Some(block_info_obj) = &*current_block_info {
+    if let Some(block_info_obj) = &*set_state_step.current_block_info {
         update_block_info(&mut state.current_block_info, block_info_obj);
     }
 }

--- a/elrond-wasm-debug/src/mandos_step/set_state.rs
+++ b/elrond-wasm-debug/src/mandos_step/set_state.rs
@@ -7,7 +7,14 @@ use crate::world_mock::{
     BlockchainMock, EsdtData, EsdtInstance, EsdtInstanceMetadata, EsdtInstances, EsdtRoles,
 };
 
-pub fn execute(state: &mut BlockchainMock, set_state_step: &SetStateStep) {
+impl BlockchainMock {
+    pub fn mandos_set_state(mut self, set_state_step: SetStateStep) -> BlockchainMock {
+        execute(&mut self, &set_state_step);
+        self
+    }
+}
+
+fn execute(state: &mut BlockchainMock, set_state_step: &SetStateStep) {
     for (address, account) in set_state_step.accounts.iter() {
         let storage = account
             .storage

--- a/elrond-wasm-debug/src/mandos_step/transfer.rs
+++ b/elrond-wasm-debug/src/mandos_step/transfer.rs
@@ -8,7 +8,13 @@ use crate::{
     world_mock::BlockchainMock,
 };
 
-pub fn execute(state: &mut Rc<BlockchainMock>, tx_transfer: &TxTransfer) {
+pub fn execute(state: BlockchainMock, tx_transfer: &TxTransfer) -> BlockchainMock {
+    let mut state_rc = Rc::new(state);
+    execute_rc(&mut state_rc, tx_transfer);
+    Rc::try_unwrap(state_rc).unwrap()
+}
+
+pub fn execute_rc(state: &mut Rc<BlockchainMock>, tx_transfer: &TxTransfer) {
     let tx_input = TxInput {
         from: tx_transfer.from.value.into(),
         to: tx_transfer.to.value.into(),

--- a/elrond-wasm-debug/src/mandos_step/transfer.rs
+++ b/elrond-wasm-debug/src/mandos_step/transfer.rs
@@ -1,17 +1,30 @@
 use std::rc::Rc;
 
 use elrond_wasm::types::heap::H256;
-use mandos::model::TxTransfer;
+use mandos::model::{TransferStep, TxTransfer, ValidatorRewardStep};
 
 use crate::{
     sc_call::tx_esdt_transfers_from_mandos, tx_execution::sc_call, tx_mock::TxInput,
     world_mock::BlockchainMock,
 };
 
-pub fn execute(state: BlockchainMock, tx_transfer: &TxTransfer) -> BlockchainMock {
-    let mut state_rc = Rc::new(state);
-    execute_rc(&mut state_rc, tx_transfer);
-    Rc::try_unwrap(state_rc).unwrap()
+impl BlockchainMock {
+    pub fn mandos_transfer(self, transfer_step: TransferStep) -> BlockchainMock {
+        let mut state_rc = Rc::new(self);
+        execute_rc(&mut state_rc, &transfer_step.tx);
+        Rc::try_unwrap(state_rc).unwrap()
+    }
+
+    pub fn mandos_validator_reward(
+        mut self,
+        validator_rewards_step: ValidatorRewardStep,
+    ) -> BlockchainMock {
+        self.increase_validator_reward(
+            &validator_rewards_step.tx.to.value.into(),
+            &validator_rewards_step.tx.egld_value.value,
+        );
+        self
+    }
 }
 
 pub fn execute_rc(state: &mut Rc<BlockchainMock>, tx_transfer: &TxTransfer) {

--- a/elrond-wasm-debug/src/world_mock/blockchain_mock.rs
+++ b/elrond-wasm-debug/src/world_mock/blockchain_mock.rs
@@ -1,5 +1,7 @@
 use elrond_wasm::types::heap::Address;
-use mandos::{interpret_trait::InterpreterContext, value_interpreter::interpret_string};
+use mandos::{
+    interpret_trait::InterpreterContext, model::Scenario, value_interpreter::interpret_string,
+};
 use num_bigint::BigUint;
 use num_traits::Zero;
 use std::{collections::HashMap, path::PathBuf, rc::Rc};
@@ -21,6 +23,7 @@ pub struct BlockchainMock {
     pub current_block_info: BlockInfo,
     pub contract_map: ContractMap,
     pub current_dir: PathBuf,
+    pub mandos_trace: Scenario, // can be printed later - TODO: write the actual print
 }
 
 impl BlockchainMock {
@@ -32,6 +35,7 @@ impl BlockchainMock {
             current_block_info: BlockInfo::new(),
             contract_map: ContractMap::default(),
             current_dir: std::env::current_dir().unwrap(),
+            mandos_trace: Scenario::default(),
         }
     }
 }

--- a/elrond-wasm-debug/src/world_mock/blockchain_mock_init.rs
+++ b/elrond-wasm-debug/src/world_mock/blockchain_mock_init.rs
@@ -24,6 +24,10 @@ pub fn find_workspace() -> PathBuf {
 }
 
 impl BlockchainMock {
+    pub fn interpreter_context(&self) -> InterpreterContext {
+        InterpreterContext::new(self.current_dir.clone())
+    }
+
     /// Tells the tests where the crate lies relative to the workspace.
     /// This ensures that the paths are set correctly, including in debug mode.
     pub fn set_current_dir_from_workspace(&mut self, relative_path: &str) {
@@ -37,10 +41,8 @@ impl BlockchainMock {
         expression: &str,
         new_contract_obj: Box<dyn CallableContract>,
     ) {
-        let contract_bytes = interpret_string(
-            expression,
-            &InterpreterContext::new(self.current_dir.clone()),
-        );
+        let contract_bytes = interpret_string(expression, &self.interpreter_context());
+        // panic!("{}", String::from_utf8(contract_bytes).unwrap());
         self.contract_map
             .register_contract(contract_bytes, new_contract_obj);
     }

--- a/mandos/src/model/account_data/account.rs
+++ b/mandos/src/model/account_data/account.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use std::collections::BTreeMap;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Account {
     pub comment: Option<String>,
     pub nonce: Option<U64Value>,
@@ -16,6 +16,34 @@ pub struct Account {
     pub storage: BTreeMap<BytesKey, BytesValue>,
     pub code: Option<BytesValue>,
     pub owner: Option<AddressValue>,
+}
+
+impl Account {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn nonce<V>(mut self, nonce: V) -> Self
+    where
+        U64Value: InterpretableFrom<V>,
+    {
+        self.nonce = Some(U64Value::interpret_from(
+            nonce,
+            &InterpreterContext::default(),
+        ));
+        self
+    }
+
+    pub fn balance<V>(mut self, balance_expr: V) -> Self
+    where
+        BigUintValue: InterpretableFrom<V>,
+    {
+        self.balance = Some(BigUintValue::interpret_from(
+            balance_expr,
+            &InterpreterContext::default(),
+        ));
+        self
+    }
 }
 
 impl InterpretableFrom<AccountRaw> for Account {

--- a/mandos/src/model/account_data/accounts_check.rs
+++ b/mandos/src/model/account_data/accounts_check.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::CheckAccount;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CheckAccounts {
     pub other_accounts_allowed: bool,
     pub accounts: BTreeMap<AddressKey, CheckAccount>,

--- a/mandos/src/model/esdt_data/esdt.rs
+++ b/mandos/src/model/esdt_data/esdt.rs
@@ -30,11 +30,7 @@ impl InterpretableFrom<EsdtRaw> for Esdt {
                 last_nonce: full_esdt
                     .last_nonce
                     .map(|b| U64Value::interpret_from(b, context)),
-                roles: full_esdt
-                    .roles
-                    .into_iter()
-                    .map(|role| BytesValue::interpret_from(role, context))
-                    .collect(),
+                roles: full_esdt.roles,
                 frozen: full_esdt
                     .frozen
                     .map(|b| U64Value::interpret_from(b, context)),

--- a/mandos/src/model/esdt_data/esdt_map_check.rs
+++ b/mandos/src/model/esdt_data/esdt_map_check.rs
@@ -12,6 +12,12 @@ pub enum CheckEsdtMap {
     Equal(CheckEsdtMapContents),
 }
 
+impl Default for CheckEsdtMap {
+    fn default() -> Self {
+        CheckEsdtMap::Unspecified
+    }
+}
+
 impl InterpretableFrom<CheckEsdtMapRaw> for CheckEsdtMap {
     fn interpret_from(from: CheckEsdtMapRaw, context: &InterpreterContext) -> Self {
         match from {

--- a/mandos/src/model/esdt_data/esdt_object.rs
+++ b/mandos/src/model/esdt_data/esdt_object.rs
@@ -7,6 +7,6 @@ pub struct EsdtObject {
     pub token_identifier: Option<BytesValue>,
     pub instances: Vec<EsdtInstance>,
     pub last_nonce: Option<U64Value>,
-    pub roles: Vec<BytesValue>,
+    pub roles: Vec<String>,
     pub frozen: Option<U64Value>,
 }

--- a/mandos/src/model/mod.rs
+++ b/mandos/src/model/mod.rs
@@ -4,6 +4,7 @@ mod esdt_data;
 mod new_address;
 mod scenario;
 mod step;
+mod step_sugar;
 mod storage_check;
 mod storage_details_check;
 mod transaction;

--- a/mandos/src/model/scenario.rs
+++ b/mandos/src/model/scenario.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::Step;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Scenario {
     pub name: Option<String>,
     pub comment: Option<String>,

--- a/mandos/src/model/step.rs
+++ b/mandos/src/model/step.rs
@@ -15,7 +15,7 @@ pub struct ExternalStepsStep {
     pub path: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SetStateStep {
     pub comment: Option<String>,
     pub accounts: BTreeMap<AddressKey, Account>,
@@ -25,7 +25,7 @@ pub struct SetStateStep {
     pub current_block_info: Box<Option<BlockInfo>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ScCallStep {
     pub tx_id: String,
     pub comment: Option<String>,
@@ -33,7 +33,7 @@ pub struct ScCallStep {
     pub expect: Option<TxExpect>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ScQueryStep {
     pub tx_id: String,
     pub comment: Option<String>,
@@ -41,7 +41,7 @@ pub struct ScQueryStep {
     pub expect: Option<TxExpect>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ScDeployStep {
     pub tx_id: String,
     pub comment: Option<String>,
@@ -63,13 +63,13 @@ pub struct ValidatorRewardStep {
     pub tx: Box<TxValidatorReward>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CheckStateStep {
     pub comment: Option<String>,
     pub accounts: CheckAccounts,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct DumpStateStep {
     pub comment: Option<String>,
 }

--- a/mandos/src/model/step.rs
+++ b/mandos/src/model/step.rs
@@ -11,59 +11,88 @@ use super::{
 };
 
 #[derive(Debug)]
+pub struct ExternalStepsStep {
+    pub path: String,
+}
+
+#[derive(Debug)]
+pub struct SetStateStep {
+    pub comment: Option<String>,
+    pub accounts: BTreeMap<AddressKey, Account>,
+    pub new_addresses: Vec<NewAddress>,
+    pub block_hashes: Vec<BytesValue>,
+    pub previous_block_info: Box<Option<BlockInfo>>,
+    pub current_block_info: Box<Option<BlockInfo>>,
+}
+
+#[derive(Debug)]
+pub struct ScCallStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxCall>,
+    pub expect: Option<TxExpect>,
+}
+
+#[derive(Debug)]
+pub struct ScQueryStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxQuery>,
+    pub expect: Option<TxExpect>,
+}
+
+#[derive(Debug)]
+pub struct ScDeployStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxDeploy>,
+    pub expect: Option<TxExpect>,
+}
+
+#[derive(Debug)]
+pub struct TransferStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxTransfer>,
+}
+
+#[derive(Debug)]
+pub struct ValidatorRewardStep {
+    pub tx_id: String,
+    pub comment: Option<String>,
+    pub tx: Box<TxValidatorReward>,
+}
+
+#[derive(Debug)]
+pub struct CheckStateStep {
+    pub comment: Option<String>,
+    pub accounts: CheckAccounts,
+}
+
+#[derive(Debug)]
+pub struct DumpStateStep {
+    pub comment: Option<String>,
+}
+
+#[derive(Debug)]
 pub enum Step {
-    ExternalSteps {
-        path: String,
-    },
-    SetState {
-        comment: Option<String>,
-        accounts: BTreeMap<AddressKey, Account>,
-        new_addresses: Vec<NewAddress>,
-        block_hashes: Vec<BytesValue>,
-        previous_block_info: Box<Option<BlockInfo>>,
-        current_block_info: Box<Option<BlockInfo>>,
-    },
-    ScCall {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxCall>,
-        expect: Option<TxExpect>,
-    },
-    ScQuery {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxQuery>,
-        expect: Option<TxExpect>,
-    },
-    ScDeploy {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxDeploy>,
-        expect: Option<TxExpect>,
-    },
-    Transfer {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxTransfer>,
-    },
-    ValidatorReward {
-        tx_id: String,
-        comment: Option<String>,
-        tx: Box<TxValidatorReward>,
-    },
-    CheckState {
-        comment: Option<String>,
-        accounts: CheckAccounts,
-    },
-    DumpState {
-        comment: Option<String>,
-    },
+    ExternalSteps(ExternalStepsStep),
+    SetState(SetStateStep),
+    ScCall(ScCallStep),
+    ScQuery(ScQueryStep),
+    ScDeploy(ScDeployStep),
+    Transfer(TransferStep),
+    ValidatorReward(ValidatorRewardStep),
+    CheckState(CheckStateStep),
+    DumpState(DumpStateStep),
 }
 
 impl InterpretableFrom<StepRaw> for Step {
     fn interpret_from(from: StepRaw, context: &InterpreterContext) -> Self {
         match from {
-            StepRaw::ExternalSteps { comment: _, path } => Step::ExternalSteps { path },
+            StepRaw::ExternalSteps { comment: _, path } => {
+                Step::ExternalSteps(ExternalStepsStep { path })
+            },
             StepRaw::SetState {
                 comment,
                 accounts,
@@ -71,7 +100,7 @@ impl InterpretableFrom<StepRaw> for Step {
                 block_hashes,
                 previous_block_info,
                 current_block_info,
-            } => Step::SetState {
+            } => Step::SetState(SetStateStep {
                 comment,
                 accounts: accounts
                     .into_iter()
@@ -96,58 +125,60 @@ impl InterpretableFrom<StepRaw> for Step {
                 current_block_info: Box::new(
                     current_block_info.map(|v| BlockInfo::interpret_from(v, context)),
                 ),
-            },
+            }),
             StepRaw::ScCall {
                 tx_id,
                 comment,
                 display_logs: _,
                 tx,
                 expect,
-            } => Step::ScCall {
+            } => Step::ScCall(ScCallStep {
                 tx_id,
                 comment,
                 tx: Box::new(TxCall::interpret_from(tx, context)),
                 expect: expect.map(|v| TxExpect::interpret_from(v, context)),
-            },
+            }),
             StepRaw::ScQuery {
                 tx_id,
                 comment,
                 display_logs: _,
                 tx,
                 expect,
-            } => Step::ScQuery {
+            } => Step::ScQuery(ScQueryStep {
                 tx_id,
                 comment,
                 tx: Box::new(TxQuery::interpret_from(tx, context)),
                 expect: expect.map(|v| TxExpect::interpret_from(v, context)),
-            },
+            }),
             StepRaw::ScDeploy {
                 tx_id,
                 comment,
                 display_logs: _,
                 tx,
                 expect,
-            } => Step::ScDeploy {
+            } => Step::ScDeploy(ScDeployStep {
                 tx_id,
                 comment,
                 tx: Box::new(TxDeploy::interpret_from(tx, context)),
                 expect: expect.map(|v| TxExpect::interpret_from(v, context)),
-            },
-            StepRaw::Transfer { tx_id, comment, tx } => Step::Transfer {
+            }),
+            StepRaw::Transfer { tx_id, comment, tx } => Step::Transfer(TransferStep {
                 tx_id,
                 comment,
                 tx: Box::new(TxTransfer::interpret_from(tx, context)),
+            }),
+            StepRaw::ValidatorReward { tx_id, comment, tx } => {
+                Step::ValidatorReward(ValidatorRewardStep {
+                    tx_id,
+                    comment,
+                    tx: Box::new(TxValidatorReward::interpret_from(tx, context)),
+                })
             },
-            StepRaw::ValidatorReward { tx_id, comment, tx } => Step::ValidatorReward {
-                tx_id,
-                comment,
-                tx: Box::new(TxValidatorReward::interpret_from(tx, context)),
-            },
-            StepRaw::CheckState { comment, accounts } => Step::CheckState {
+            StepRaw::CheckState { comment, accounts } => Step::CheckState(CheckStateStep {
                 comment,
                 accounts: CheckAccounts::interpret_from(accounts, context),
-            },
-            StepRaw::DumpState { comment } => Step::DumpState { comment },
+            }),
+            StepRaw::DumpState { comment } => Step::DumpState(DumpStateStep { comment }),
         }
     }
 }

--- a/mandos/src/model/step_sugar.rs
+++ b/mandos/src/model/step_sugar.rs
@@ -1,0 +1,171 @@
+use crate::interpret_trait::{InterpretableFrom, InterpreterContext};
+
+use super::{
+    Account, AddressKey, AddressValue, BigUintValue, BytesValue, CheckAccount, CheckStateStep,
+    NewAddress, ScCallStep, ScDeployStep, ScQueryStep, SetStateStep, TxExpect, U64Value,
+};
+
+impl SetStateStep {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn put_account(mut self, address_expr: &str, account: Account) -> Self {
+        let address_key =
+            AddressKey::interpret_from(address_expr.to_string(), &InterpreterContext::default());
+        self.accounts.insert(address_key, account);
+        self
+    }
+
+    pub fn new_address(
+        mut self,
+        creator_address_expr: &str,
+        creator_nonce_expr: u64,
+        new_address_expr: &str,
+    ) -> Self {
+        self.new_addresses.push(NewAddress {
+            creator_address: AddressValue::interpret_from(
+                creator_address_expr,
+                &InterpreterContext::default(),
+            ),
+            creator_nonce: U64Value::interpret_from(
+                creator_nonce_expr,
+                &InterpreterContext::default(),
+            ),
+            new_address: AddressValue::interpret_from(
+                new_address_expr,
+                &InterpreterContext::default(),
+            ),
+        });
+        self
+    }
+}
+
+impl ScDeployStep {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from(mut self, expr: &str) -> Self {
+        self.tx.from = AddressValue::interpret_from(expr, &InterpreterContext::default());
+        self
+    }
+
+    pub fn egld_value<V>(mut self, expr: V) -> Self
+    where
+        BigUintValue: InterpretableFrom<V>,
+    {
+        self.tx.egld_value = BigUintValue::interpret_from(expr, &InterpreterContext::default());
+        self
+    }
+
+    pub fn contract_code(mut self, expr: &str) -> Self {
+        self.tx.contract_code = BytesValue::interpret_from(expr, &InterpreterContext::default());
+        self
+    }
+
+    pub fn argument(mut self, expr: &str) -> Self {
+        self.tx.arguments.push(BytesValue::interpret_from(
+            expr,
+            &InterpreterContext::default(),
+        ));
+        self
+    }
+
+    pub fn gas_limit<V>(mut self, value: V) -> Self
+    where
+        U64Value: InterpretableFrom<V>,
+    {
+        self.tx.gas_limit = U64Value::interpret_from(value, &InterpreterContext::default());
+        self
+    }
+
+    pub fn expect(mut self, expect: TxExpect) -> Self {
+        self.expect = Some(expect);
+        self
+    }
+}
+
+impl ScQueryStep {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn to(mut self, expr: &str) -> Self {
+        self.tx.to = AddressValue::interpret_from(expr, &InterpreterContext::default());
+        self
+    }
+
+    pub fn function(mut self, expr: &str) -> Self {
+        self.tx.function = expr.to_string();
+        self
+    }
+
+    pub fn argument(mut self, expr: &str) -> Self {
+        self.tx.arguments.push(BytesValue::interpret_from(
+            expr,
+            &InterpreterContext::default(),
+        ));
+        self
+    }
+
+    pub fn expect(mut self, expect: TxExpect) -> Self {
+        self.expect = Some(expect);
+        self
+    }
+}
+
+impl ScCallStep {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from(mut self, expr: &str) -> Self {
+        self.tx.from = AddressValue::interpret_from(expr, &InterpreterContext::default());
+        self
+    }
+
+    pub fn to(mut self, expr: &str) -> Self {
+        self.tx.to = AddressValue::interpret_from(expr, &InterpreterContext::default());
+        self
+    }
+
+    pub fn function(mut self, expr: &str) -> Self {
+        self.tx.function = expr.to_string();
+        self
+    }
+
+    pub fn argument(mut self, expr: &str) -> Self {
+        self.tx.arguments.push(BytesValue::interpret_from(
+            expr,
+            &InterpreterContext::default(),
+        ));
+        self
+    }
+
+    pub fn gas_limit<V>(mut self, value: V) -> Self
+    where
+        U64Value: InterpretableFrom<V>,
+    {
+        self.tx.gas_limit = U64Value::interpret_from(value, &InterpreterContext::default());
+        self
+    }
+
+    pub fn expect(mut self, expect: TxExpect) -> Self {
+        self.expect = Some(expect);
+        self
+    }
+}
+
+impl CheckStateStep {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn put_account(mut self, address_expr: &str, account: CheckAccount) -> Self {
+        let address_key =
+            AddressKey::interpret_from(address_expr.to_string(), &InterpreterContext::default());
+        self.accounts.accounts.insert(address_key, account);
+        self
+    }
+}

--- a/mandos/src/model/step_sugar.rs
+++ b/mandos/src/model/step_sugar.rs
@@ -59,8 +59,8 @@ impl ScDeployStep {
         self
     }
 
-    pub fn contract_code(mut self, expr: &str) -> Self {
-        self.tx.contract_code = BytesValue::interpret_from(expr, &InterpreterContext::default());
+    pub fn contract_code(mut self, expr: &str, context: &InterpreterContext) -> Self {
+        self.tx.contract_code = BytesValue::interpret_from(expr, context);
         self
     }
 

--- a/mandos/src/model/storage_check.rs
+++ b/mandos/src/model/storage_check.rs
@@ -11,6 +11,12 @@ pub enum CheckStorage {
     Equal(CheckStorageDetails),
 }
 
+impl Default for CheckStorage {
+    fn default() -> Self {
+        CheckStorage::Star
+    }
+}
+
 impl CheckStorage {
     pub fn is_star(&self) -> bool {
         matches!(self, CheckStorage::Star)

--- a/mandos/src/model/storage_details_check.rs
+++ b/mandos/src/model/storage_details_check.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 
 use super::BytesKey;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CheckStorageDetails {
     pub storages: BTreeMap<BytesKey, CheckValue<BytesValue>>,
     pub other_storages_allowed: bool,

--- a/mandos/src/model/transaction/tx_call.rs
+++ b/mandos/src/model/transaction/tx_call.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::{tx_interpret_util::interpret_egld_value, TxESDT};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TxCall {
     pub from: AddressValue,
     pub to: AddressValue,

--- a/mandos/src/model/transaction/tx_deploy.rs
+++ b/mandos/src/model/transaction/tx_deploy.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::tx_interpret_util::interpret_egld_value;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TxDeploy {
     pub from: AddressValue,
     pub egld_value: BigUintValue,

--- a/mandos/src/model/transaction/tx_expect.rs
+++ b/mandos/src/model/transaction/tx_expect.rs
@@ -14,6 +14,37 @@ pub struct TxExpect {
     pub refund: CheckValue<U64Value>,
 }
 
+impl TxExpect {
+    pub fn ok() -> Self {
+        TxExpect {
+            out: CheckValue::Star,
+            status: CheckValue::Equal(U64Value::zero()),
+            message: CheckValue::Star,
+            logs: CheckLogs::Star,
+            gas: None,
+            refund: CheckValue::Star,
+        }
+    }
+
+    pub fn no_result(mut self) -> Self {
+        self.out = CheckValue::Equal(Vec::new());
+        self
+    }
+
+    pub fn result(mut self, value: &str) -> Self {
+        let mut check_results = match self.out {
+            CheckValue::Star => Vec::new(),
+            CheckValue::Equal(check_results) => check_results,
+        };
+        check_results.push(CheckValue::Equal(BytesValue::interpret_from(
+            value,
+            &InterpreterContext::default(),
+        )));
+        self.out = CheckValue::Equal(check_results);
+        self
+    }
+}
+
 impl InterpretableFrom<TxExpectRaw> for TxExpect {
     fn interpret_from(from: TxExpectRaw, context: &InterpreterContext) -> Self {
         TxExpect {

--- a/mandos/src/model/transaction/tx_query.rs
+++ b/mandos/src/model/transaction/tx_query.rs
@@ -4,7 +4,7 @@ use crate::{
     serde_raw::TxQueryRaw,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TxQuery {
     pub to: AddressValue,
     pub function: String,

--- a/mandos/src/model/value/address_value.rs
+++ b/mandos/src/model/value/address_value.rs
@@ -40,7 +40,7 @@ impl InterpretableFrom<ValueSubTree> for AddressValue {
 
 impl InterpretableFrom<&str> for AddressValue {
     fn interpret_from(from: &str, context: &InterpreterContext) -> Self {
-        let bytes = interpret_string(&from, context);
+        let bytes = interpret_string(from, context);
         AddressValue {
             value: value_from_slice(bytes.as_slice()),
             original: ValueSubTree::Str(from.to_string()),

--- a/mandos/src/model/value/address_value.rs
+++ b/mandos/src/model/value/address_value.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use crate::{
     interpret_trait::{InterpretableFrom, InterpreterContext},
     serde_raw::ValueSubTree,
-    value_interpreter::interpret_subtree,
+    value_interpreter::{interpret_string, interpret_subtree},
 };
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Default)]
 pub struct AddressValue {
     pub value: [u8; 32],
     pub original: ValueSubTree,
@@ -18,18 +18,32 @@ impl fmt::Display for AddressValue {
     }
 }
 
+fn value_from_slice(slice: &[u8]) -> [u8; 32] {
+    let mut value = [0u8; 32];
+    if slice.len() == 32 {
+        value.copy_from_slice(slice);
+    } else {
+        panic!("account address is not 32 bytes in length");
+    }
+    value
+}
+
 impl InterpretableFrom<ValueSubTree> for AddressValue {
     fn interpret_from(from: ValueSubTree, context: &InterpreterContext) -> Self {
         let bytes = interpret_subtree(&from, context);
-        let mut value = [0u8; 32];
-        if bytes.len() == 32 {
-            value.copy_from_slice(&bytes[..]);
-        } else {
-            panic!("account address is not 32 bytes in length");
-        }
         AddressValue {
-            value,
+            value: value_from_slice(bytes.as_slice()),
             original: from,
+        }
+    }
+}
+
+impl InterpretableFrom<&str> for AddressValue {
+    fn interpret_from(from: &str, context: &InterpreterContext) -> Self {
+        let bytes = interpret_string(&from, context);
+        AddressValue {
+            value: value_from_slice(bytes.as_slice()),
+            original: ValueSubTree::Str(from.to_string()),
         }
     }
 }

--- a/mandos/src/model/value/value_key_bytes.rs
+++ b/mandos/src/model/value/value_key_bytes.rs
@@ -43,6 +43,16 @@ impl Ord for BytesKey {
     }
 }
 
+impl InterpretableFrom<&str> for BytesKey {
+    fn interpret_from(from: &str, context: &InterpreterContext) -> Self {
+        let bytes = interpret_string(from, context);
+        BytesKey {
+            value: bytes,
+            original: from.to_string(),
+        }
+    }
+}
+
 impl InterpretableFrom<String> for BytesKey {
     fn interpret_from(from: String, context: &InterpreterContext) -> Self {
         let bytes = interpret_string(&from, context);

--- a/mandos/src/model/value/value_set_big_uint.rs
+++ b/mandos/src/model/value/value_set_big_uint.rs
@@ -25,7 +25,7 @@ impl InterpretableFrom<ValueSubTree> for BigUintValue {
 
 impl InterpretableFrom<&str> for BigUintValue {
     fn interpret_from(from: &str, context: &InterpreterContext) -> Self {
-        let bytes = interpret_string(&from, context);
+        let bytes = interpret_string(from, context);
         BigUintValue {
             value: BigUint::from_bytes_be(&bytes),
             original: ValueSubTree::Str(from.to_string()),

--- a/mandos/src/model/value/value_set_big_uint.rs
+++ b/mandos/src/model/value/value_set_big_uint.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpret_trait::{InterpretableFrom, InterpreterContext},
     serde_raw::ValueSubTree,
-    value_interpreter::interpret_subtree,
+    value_interpreter::{interpret_string, interpret_subtree},
 };
 
 use num_bigint::BigUint;
@@ -19,6 +19,16 @@ impl InterpretableFrom<ValueSubTree> for BigUintValue {
         BigUintValue {
             value: BigUint::from_bytes_be(&bytes),
             original: from,
+        }
+    }
+}
+
+impl InterpretableFrom<&str> for BigUintValue {
+    fn interpret_from(from: &str, context: &InterpreterContext) -> Self {
+        let bytes = interpret_string(&from, context);
+        BigUintValue {
+            value: BigUint::from_bytes_be(&bytes),
+            original: ValueSubTree::Str(from.to_string()),
         }
     }
 }

--- a/mandos/src/model/value/value_set_bytes.rs
+++ b/mandos/src/model/value/value_set_bytes.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpret_trait::{InterpretableFrom, InterpreterContext},
     serde_raw::ValueSubTree,
-    value_interpreter::interpret_subtree,
+    value_interpreter::{interpret_string, interpret_subtree},
 };
 
 use std::fmt;
@@ -39,10 +39,19 @@ impl InterpretableFrom<ValueSubTree> for BytesValue {
     }
 }
 
-impl InterpretableFrom<String> for BytesValue {
-    fn interpret_from(from: String, _context: &InterpreterContext) -> Self {
+impl InterpretableFrom<&str> for BytesValue {
+    fn interpret_from(from: &str, context: &InterpreterContext) -> Self {
         BytesValue {
-            value: from.clone().into_bytes(),
+            value: interpret_string(from, context),
+            original: ValueSubTree::Str(from.to_string()),
+        }
+    }
+}
+
+impl InterpretableFrom<String> for BytesValue {
+    fn interpret_from(from: String, context: &InterpreterContext) -> Self {
+        BytesValue {
+            value: interpret_string(from.as_str(), context),
             original: ValueSubTree::Str(from),
         }
     }

--- a/mandos/src/model/value/value_set_u64.rs
+++ b/mandos/src/model/value/value_set_u64.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpret_trait::{InterpretableFrom, InterpreterContext},
     serde_raw::ValueSubTree,
-    value_interpreter::interpret_subtree,
+    value_interpreter::{interpret_string, interpret_subtree},
 };
 
 use num_bigint::BigUint;
@@ -21,6 +21,13 @@ impl U64Value {
             original: ValueSubTree::Str(String::default()),
         }
     }
+
+    pub fn zero() -> Self {
+        U64Value {
+            value: 0,
+            original: ValueSubTree::Str("0".to_string()),
+        }
+    }
 }
 
 impl Default for U64Value {
@@ -36,6 +43,26 @@ impl InterpretableFrom<ValueSubTree> for U64Value {
         U64Value {
             value: bu.to_u64().unwrap(),
             original: from,
+        }
+    }
+}
+
+impl InterpretableFrom<&str> for U64Value {
+    fn interpret_from(from: &str, context: &InterpreterContext) -> Self {
+        let bytes = interpret_string(&from, context);
+        let bu = BigUint::from_bytes_be(&bytes);
+        U64Value {
+            value: bu.to_u64().unwrap(),
+            original: ValueSubTree::Str(from.to_string()),
+        }
+    }
+}
+
+impl InterpretableFrom<u64> for U64Value {
+    fn interpret_from(from: u64, _context: &InterpreterContext) -> Self {
+        U64Value {
+            value: from,
+            original: ValueSubTree::Str(from.to_string()),
         }
     }
 }

--- a/mandos/src/model/value/value_set_u64.rs
+++ b/mandos/src/model/value/value_set_u64.rs
@@ -49,7 +49,7 @@ impl InterpretableFrom<ValueSubTree> for U64Value {
 
 impl InterpretableFrom<&str> for U64Value {
     fn interpret_from(from: &str, context: &InterpreterContext) -> Self {
-        let bytes = interpret_string(&from, context);
+        let bytes = interpret_string(from, context);
         let bu = BigUint::from_bytes_be(&bytes);
         U64Value {
             value: bu.to_u64().unwrap(),


### PR DESCRIPTION
Here, the mandos step functions become methods of `BlockchainMock`. This hides the `Rc` part, cleans up lifetimes and helps composability.

With the help of this, it is possible to construct a mandos test fully programatically, by invoking these methods of `BlockchainMock`. It is also possible to log all these mandos steps and export them as json (json export not yet implemented).