### PR TITLE
better token id macro

### DIFF
--- a/elrond-wasm-debug/src/testing_framework/helper_macros.rs
+++ b/elrond-wasm-debug/src/testing_framework/helper_macros.rs
@@ -29,7 +29,11 @@ macro_rules! managed_address {
 #[macro_export]
 macro_rules! managed_token_id {
     ($bytes:expr) => {{
-        elrond_wasm::types::TokenIdentifier::from_esdt_bytes($bytes)
+        if $bytes == &elrond_wasm::types::TokenIdentifier::<elrond_wasm_debug::DebugApi>::EGLD_REPRESENTATION[..] {
+            elrond_wasm::types::TokenIdentifier::egld()
+        } else {
+            elrond_wasm::types::TokenIdentifier::from_esdt_bytes($bytes)
+        }
     }};
 }
 

--- a/elrond-wasm-debug/tests/managed_token_identifier_test.rs
+++ b/elrond-wasm-debug/tests/managed_token_identifier_test.rs
@@ -1,5 +1,7 @@
 use elrond_wasm::types::{BoxedBytes, TokenIdentifier};
-use elrond_wasm_debug::{check_managed_top_decode, check_managed_top_encode_decode, DebugApi};
+use elrond_wasm_debug::{
+    check_managed_top_decode, check_managed_top_encode_decode, managed_token_id, DebugApi,
+};
 
 #[test]
 fn test_egld() {
@@ -71,4 +73,17 @@ fn test_is_valid_esdt_identifier() {
 
     // ticker too long
     assert!(!TokenIdentifier::<DebugApi>::from_esdt_bytes(&b"ALCCCCCCCCC-6258d2"[..]).is_valid_esdt_identifier());
+}
+
+#[test]
+fn test_managed_token_id_macro() {
+    let _ = DebugApi::dummy();
+    assert_eq!(
+        managed_token_id!(b"EGLD"),
+        TokenIdentifier::<DebugApi>::egld()
+    );
+    assert_eq!(
+        managed_token_id!(b"ALC-6258d2"),
+        TokenIdentifier::<DebugApi>::from_esdt_bytes(&b"ALC-6258d2"[..])
+    );
 }


### PR DESCRIPTION
- account for the "EGLD" string