### PR TITLE
staking module

### DIFF
--- a/contracts/feature-tests/use-module/src/use_module.rs
+++ b/contracts/feature-tests/use-module/src/use_module.rs
@@ -31,6 +31,7 @@ pub trait UseModule:
     + elrond_wasm_modules::governance::GovernanceModule
     + elrond_wasm_modules::governance::governance_configurable::GovernanceConfigurablePropertiesModule
     + elrond_wasm_modules::pause::PauseModule
+    + elrond_wasm_modules::staking::StakingModule
     + elrond_wasm_modules::default_issue_callbacks::DefaultIssueCallbacksModule
 {
     /// Validates that the "featureName" feature is on.

--- a/contracts/feature-tests/use-module/tests/staking_module_test.rs
+++ b/contracts/feature-tests/use-module/tests/staking_module_test.rs
@@ -1,0 +1,264 @@
+use elrond_wasm::types::ManagedVec;
+use elrond_wasm_debug::{
+    managed_address, managed_biguint, managed_token_id, rust_biguint,
+    testing_framework::BlockchainStateWrapper,
+};
+use elrond_wasm_modules::staking::StakingModule;
+
+static STAKING_TOKEN_ID: &[u8] = b"STAKE-123456";
+const INITIAL_BALANCE: u64 = 2_000_000;
+const REQUIRED_STAKE_AMOUNT: u64 = 1_000_000;
+const SLASH_AMOUNT: u64 = 600_000;
+const QUORUM: usize = 2;
+
+#[test]
+fn staking_module_test() {
+    // setup accounts
+    let rust_zero = rust_biguint!(0);
+    let mut b_mock = BlockchainStateWrapper::new();
+    let owner = b_mock.create_user_account(&rust_zero);
+    let alice = b_mock.create_user_account(&rust_zero);
+    let bob = b_mock.create_user_account(&rust_zero);
+    let carol = b_mock.create_user_account(&rust_zero);
+    let eve = b_mock.create_user_account(&rust_zero);
+    let staking_sc = b_mock.create_sc_account(
+        &rust_zero,
+        Some(&owner),
+        use_module::contract_obj,
+        "wasm path",
+    );
+
+    b_mock.set_esdt_balance(&alice, STAKING_TOKEN_ID, &rust_biguint!(INITIAL_BALANCE));
+    b_mock.set_esdt_balance(&bob, STAKING_TOKEN_ID, &rust_biguint!(INITIAL_BALANCE));
+    b_mock.set_esdt_balance(&carol, STAKING_TOKEN_ID, &rust_biguint!(INITIAL_BALANCE));
+    b_mock.set_esdt_balance(&eve, STAKING_TOKEN_ID, &rust_biguint!(INITIAL_BALANCE));
+
+    // init module
+    b_mock
+        .execute_tx(&owner, &staking_sc, &rust_zero, |sc| {
+            let mut whitelist = ManagedVec::new();
+            whitelist.push(managed_address!(&alice));
+            whitelist.push(managed_address!(&bob));
+            whitelist.push(managed_address!(&carol));
+
+            sc.init_staking_module(
+                &managed_token_id!(STAKING_TOKEN_ID),
+                &managed_biguint!(REQUIRED_STAKE_AMOUNT),
+                &managed_biguint!(SLASH_AMOUNT),
+                QUORUM,
+                &whitelist,
+            );
+        })
+        .assert_ok();
+
+    // try stake - not a board member
+    b_mock
+        .execute_esdt_transfer(
+            &eve,
+            &staking_sc,
+            STAKING_TOKEN_ID,
+            0,
+            &rust_biguint!(REQUIRED_STAKE_AMOUNT),
+            |sc| {
+                sc.stake();
+            },
+        )
+        .assert_user_error("Only whitelisted members can stake");
+
+    // stake half and try unstake
+    b_mock
+        .execute_esdt_transfer(
+            &alice,
+            &staking_sc,
+            STAKING_TOKEN_ID,
+            0,
+            &rust_biguint!(REQUIRED_STAKE_AMOUNT / 2),
+            |sc| {
+                sc.stake();
+            },
+        )
+        .assert_ok();
+    b_mock
+        .execute_tx(&alice, &staking_sc, &rust_zero, |sc| {
+            sc.unstake(managed_biguint!(REQUIRED_STAKE_AMOUNT / 4));
+        })
+        .assert_user_error("Not enough stake");
+
+    // bob and carol stake
+    b_mock
+        .execute_esdt_transfer(
+            &bob,
+            &staking_sc,
+            STAKING_TOKEN_ID,
+            0,
+            &rust_biguint!(REQUIRED_STAKE_AMOUNT),
+            |sc| {
+                sc.stake();
+            },
+        )
+        .assert_ok();
+    b_mock
+        .execute_esdt_transfer(
+            &carol,
+            &staking_sc,
+            STAKING_TOKEN_ID,
+            0,
+            &rust_biguint!(REQUIRED_STAKE_AMOUNT),
+            |sc| {
+                sc.stake();
+            },
+        )
+        .assert_ok();
+
+    // try vote slash, not enough stake
+    b_mock
+        .execute_tx(&alice, &staking_sc, &rust_zero, |sc| {
+            sc.vote_slash_member(managed_address!(&bob));
+        })
+        .assert_user_error("Not enough stake");
+
+    // try vote slash, slashed address not a board member
+    b_mock
+        .execute_tx(&bob, &staking_sc, &rust_zero, |sc| {
+            sc.vote_slash_member(managed_address!(&eve));
+        })
+        .assert_user_error("Voted user is not a staked board member");
+
+    // alice stake over max amount and withdraw surplus
+    b_mock
+        .execute_esdt_transfer(
+            &alice,
+            &staking_sc,
+            STAKING_TOKEN_ID,
+            0,
+            &rust_biguint!(REQUIRED_STAKE_AMOUNT),
+            |sc| {
+                sc.stake();
+
+                let alice_staked_amount = sc.staked_amount(&managed_address!(&alice)).get();
+                assert_eq!(alice_staked_amount, managed_biguint!(1_500_000));
+            },
+        )
+        .assert_ok();
+    b_mock
+        .execute_tx(&alice, &staking_sc, &rust_zero, |sc| {
+            sc.unstake(managed_biguint!(500_000));
+
+            let alice_staked_amount = sc.staked_amount(&managed_address!(&alice)).get();
+            assert_eq!(alice_staked_amount, managed_biguint!(1_000_000));
+        })
+        .assert_ok();
+    b_mock.check_esdt_balance(&alice, STAKING_TOKEN_ID, &rust_biguint!(1_000_000));
+
+    // alice vote to slash bob
+    b_mock
+        .execute_tx(&alice, &staking_sc, &rust_zero, |sc| {
+            sc.vote_slash_member(managed_address!(&bob));
+
+            assert_eq!(
+                sc.slashing_proposal_voters(&managed_address!(&bob)).len(),
+                1
+            );
+            assert!(sc
+                .slashing_proposal_voters(&managed_address!(&bob))
+                .contains(&managed_address!(&alice)));
+        })
+        .assert_ok();
+
+    // bob vote to slash alice
+    b_mock
+        .execute_tx(&bob, &staking_sc, &rust_zero, |sc| {
+            sc.vote_slash_member(managed_address!(&alice));
+        })
+        .assert_ok();
+
+    // try slash before quorum reached
+    b_mock
+        .execute_tx(&bob, &staking_sc, &rust_zero, |sc| {
+            sc.slash_member(managed_address!(&alice));
+        })
+        .assert_user_error("Quorum not reached");
+
+    // carol vote
+    b_mock
+        .execute_tx(&carol, &staking_sc, &rust_zero, |sc| {
+            sc.vote_slash_member(managed_address!(&alice));
+
+            assert_eq!(
+                sc.slashing_proposal_voters(&managed_address!(&alice)).len(),
+                2
+            );
+            assert!(sc
+                .slashing_proposal_voters(&managed_address!(&alice))
+                .contains(&managed_address!(&bob)));
+            assert!(sc
+                .slashing_proposal_voters(&managed_address!(&alice))
+                .contains(&managed_address!(&carol)));
+        })
+        .assert_ok();
+
+    // slash alice
+    b_mock
+        .execute_tx(&bob, &staking_sc, &rust_zero, |sc| {
+            sc.slash_member(managed_address!(&alice));
+
+            assert_eq!(
+                sc.staked_amount(&managed_address!(&alice)).get(),
+                managed_biguint!(REQUIRED_STAKE_AMOUNT - SLASH_AMOUNT)
+            );
+            assert_eq!(
+                sc.total_slashed_amount().get(),
+                managed_biguint!(SLASH_AMOUNT)
+            );
+            assert!(sc
+                .slashing_proposal_voters(&managed_address!(&alice))
+                .is_empty());
+        })
+        .assert_ok();
+
+    // alice try vote after slash
+    b_mock
+        .execute_tx(&alice, &staking_sc, &rust_zero, |sc| {
+            sc.vote_slash_member(managed_address!(&bob));
+        })
+        .assert_user_error("Not enough stake");
+
+    // alice try unstake the remaining tokens
+    b_mock
+        .execute_tx(&alice, &staking_sc, &rust_zero, |sc| {
+            sc.unstake(managed_biguint!(400_000));
+        })
+        .assert_user_error("Not enough stake");
+
+    // alice remove from board members
+    b_mock
+        .execute_tx(&owner, &staking_sc, &rust_zero, |sc| {
+            // check alice's votes before slash
+            assert!(sc
+                .slashing_proposal_voters(&managed_address!(&bob))
+                .contains(&managed_address!(&alice)));
+
+            sc.remove_board_member(&managed_address!(&alice));
+
+            assert_eq!(sc.user_whitelist().len(), 2);
+            assert!(!sc.user_whitelist().contains(&managed_address!(&alice)));
+
+            // alice's vote gets removed
+            assert!(sc
+                .slashing_proposal_voters(&managed_address!(&bob))
+                .is_empty());
+        })
+        .assert_ok();
+
+    // alice unstake ok
+    b_mock
+        .execute_tx(&alice, &staking_sc, &rust_zero, |sc| {
+            sc.unstake(managed_biguint!(400_000));
+        })
+        .assert_ok();
+    b_mock.check_esdt_balance(
+        &alice,
+        STAKING_TOKEN_ID,
+        &rust_biguint!(INITIAL_BALANCE - SLASH_AMOUNT),
+    );
+}

--- a/contracts/feature-tests/use-module/use_module_expected_main.abi.json
+++ b/contracts/feature-tests/use-module/use_module_expected_main.abi.json
@@ -527,6 +527,48 @@
             "mutability": "mutable",
             "inputs": [],
             "outputs": []
+        },
+        {
+            "name": "stake",
+            "mutability": "mutable",
+            "payableInTokens": [
+                "*"
+            ],
+            "inputs": [],
+            "outputs": []
+        },
+        {
+            "name": "unstake",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "unstake_amount",
+                    "type": "BigUint"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "voteSlashMember",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "member_to_slash",
+                    "type": "Address"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "slashMember",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "member_to_slash",
+                    "type": "Address"
+                }
+            ],
+            "outputs": []
         }
     ],
     "hasCallback": true,

--- a/contracts/feature-tests/use-module/wasm/src/lib.rs
+++ b/contracts/feature-tests/use-module/wasm/src/lib.rs
@@ -44,8 +44,12 @@ elrond_wasm_node::wasm_endpoints! {
         propose
         queue
         setFeatureFlag
+        slashMember
+        stake
         unpause
+        unstake
         vote
+        voteSlashMember
         withdrawGovernanceTokens
     )
 }

--- a/elrond-wasm-modules/src/lib.rs
+++ b/elrond-wasm-modules/src/lib.rs
@@ -5,6 +5,7 @@ pub mod dns;
 pub mod esdt;
 pub mod features;
 pub mod pause;
+pub mod staking;
 
 // TODO: remove alloc feature from the following, after they have been cleaned
 

--- a/elrond-wasm-modules/src/staking.rs
+++ b/elrond-wasm-modules/src/staking.rs
@@ -132,11 +132,11 @@ pub trait StakingModule {
 
     fn remove_board_member(&self, user: &ManagedAddress) {
         let mut whitelist_mapper = self.user_whitelist();
-        if !whitelist_mapper.contains(user) {
+
+        let was_whitelisted = whitelist_mapper.swap_remove(user);
+        if !was_whitelisted {
             return;
         }
-
-        let _ = whitelist_mapper.swap_remove(user);
 
         // remove user's votes as well
         for board_member in whitelist_mapper.iter() {

--- a/elrond-wasm-modules/src/staking.rs
+++ b/elrond-wasm-modules/src/staking.rs
@@ -1,0 +1,173 @@
+elrond_wasm::imports!();
+elrond_wasm::derive_imports!();
+
+#[derive(TopEncode, TopDecode)]
+pub struct TokenAmountPair<M: ManagedTypeApi> {
+    pub token_id: TokenIdentifier<M>,
+    pub amount: BigUint<M>,
+}
+
+static NOT_ENOUGH_STAKE_ERR_MSG: &[u8] = b"Not enough stake";
+
+#[elrond_wasm::module]
+pub trait StakingModule {
+    fn init_staking_module(
+        &self,
+        staking_token: TokenIdentifier,
+        staking_amount: BigUint,
+        slash_amount: BigUint,
+        slash_quorum: usize,
+        user_whitelist: &ManagedVec<ManagedAddress>,
+    ) {
+        let nr_board_members = user_whitelist.len();
+        require!(nr_board_members > 0, "No board members");
+        require!(
+            slash_quorum <= nr_board_members,
+            "Quorum higher than total possible board members"
+        );
+        require!(
+            staking_amount > 0 && slash_amount > 0,
+            "Staking and slash amount cannot be 0"
+        );
+        require!(
+            slash_amount <= staking_amount,
+            "Slash amount cannot be higher than required stake"
+        );
+
+        self.staking_token().set(&staking_token);
+        self.required_stake_amount().set(&staking_amount);
+        self.slash_amount().set(&slash_amount);
+        self.slash_quorum().set(slash_quorum);
+
+        for user in user_whitelist {
+            let _ = self.user_whitelist().insert(user);
+        }
+    }
+
+    #[payable("*")]
+    #[endpoint]
+    fn stake(&self) {
+        let (payment_amount, payment_token): (BigUint, TokenIdentifier) =
+            self.call_value().payment_token_pair();
+        let staking_token = self.staking_token().get();
+        require!(payment_token == staking_token, "Invalid payment token");
+
+        let caller = self.blockchain().get_caller();
+        require!(
+            self.user_whitelist().contains(&caller),
+            "Only whitelisted members can stake"
+        );
+
+        self.staked_amount(&caller)
+            .update(|amt| *amt += payment_amount);
+    }
+
+    #[endpoint]
+    fn unstake(&self, unstake_amount: BigUint) {
+        let caller = self.blockchain().get_caller();
+        let staked_amount_mapper = self.staked_amount(&caller);
+        let staked_amount = staked_amount_mapper.get();
+        require!(unstake_amount <= staked_amount, NOT_ENOUGH_STAKE_ERR_MSG);
+
+        let leftover_amount = &staked_amount - &unstake_amount;
+        let required_stake_amount = self.required_stake_amount().get();
+        if self.user_whitelist().contains(&caller) {
+            require!(
+                leftover_amount >= required_stake_amount,
+                NOT_ENOUGH_STAKE_ERR_MSG
+            );
+        }
+
+        let staking_token = self.staking_token().get();
+        self.send()
+            .direct(&caller, &staking_token, 0, &unstake_amount, &[]);
+    }
+
+    #[endpoint(voteSlashMember)]
+    fn vote_slash_member(&self, member_to_slash: ManagedAddress) {
+        require!(
+            self.is_staked_board_member(&member_to_slash),
+            "Voted user is not a staked board member"
+        );
+
+        let caller = self.blockchain().get_caller();
+        require!(
+            self.is_staked_board_member(&caller),
+            "Only staked board members can vote"
+        );
+
+        let _ = self
+            .slashing_proposal_voters(&member_to_slash)
+            .insert(caller);
+    }
+
+    #[endpoint(slashMember)]
+    fn slash_member(&self, member_to_slash: ManagedAddress) {
+        let quorum = self.slash_quorum().get();
+        let mut slashing_voters_mapper = self.slashing_proposal_voters(&member_to_slash);
+        require!(slashing_voters_mapper.len() >= quorum, "Quorum not reached");
+
+        let slash_amount = self.slash_amount().get();
+        self.staked_amount(&member_to_slash)
+            .update(|amt| *amt -= &slash_amount);
+        self.total_slashed_amount()
+            .update(|total| *total += slash_amount);
+
+        slashing_voters_mapper.clear();
+    }
+
+    fn is_staked_board_member(&self, user: &ManagedAddress) -> bool {
+        let required_stake = self.required_stake_amount().get();
+        let user_stake = self.staked_amount(user).get();
+
+        self.user_whitelist().contains(user) && user_stake >= required_stake
+    }
+
+    #[inline]
+    fn add_board_member(&self, user: ManagedAddress) {
+        let _ = self.user_whitelist().insert(user);
+    }
+
+    fn remove_board_member(&self, user: &ManagedAddress) {
+        let mut whitelist_mapper = self.user_whitelist();
+        if !whitelist_mapper.contains(user) {
+            return;
+        }
+
+        let _ = whitelist_mapper.swap_remove(user);
+
+        // remove user's votes as well
+        for board_member in whitelist_mapper.iter() {
+            let _ = self
+                .slashing_proposal_voters(&board_member)
+                .swap_remove(user);
+        }
+    }
+
+    #[storage_mapper("staking_module:stakingToken")]
+    fn staking_token(&self) -> SingleValueMapper<TokenIdentifier>;
+
+    #[storage_mapper("staking_module:requiredStakeAmount")]
+    fn required_stake_amount(&self) -> SingleValueMapper<BigUint>;
+
+    #[storage_mapper("staking_module:userWhitelist")]
+    fn user_whitelist(&self) -> UnorderedSetMapper<ManagedAddress>;
+
+    #[storage_mapper("staking_module:stakedAmount")]
+    fn staked_amount(&self, user: &ManagedAddress) -> SingleValueMapper<BigUint>;
+
+    #[storage_mapper("staking_module:slashingProposalVoters")]
+    fn slashing_proposal_voters(
+        &self,
+        slash_address: &ManagedAddress,
+    ) -> UnorderedSetMapper<ManagedAddress>;
+
+    #[storage_mapper("staking_module:slashQuorum")]
+    fn slash_quorum(&self) -> SingleValueMapper<usize>;
+
+    #[storage_mapper("staking_module:slashAmount")]
+    fn slash_amount(&self) -> SingleValueMapper<BigUint>;
+
+    #[storage_mapper("staking_module:totalSlashedAmount")]
+    fn total_slashed_amount(&self) -> SingleValueMapper<BigUint>;
+}

--- a/elrond-wasm-modules/src/staking.rs
+++ b/elrond-wasm-modules/src/staking.rs
@@ -132,7 +132,6 @@ pub trait StakingModule {
 
     fn remove_board_member(&self, user: &ManagedAddress) {
         let mut whitelist_mapper = self.user_whitelist();
-
         let was_whitelisted = whitelist_mapper.swap_remove(user);
         if !was_whitelisted {
             return;


### PR DESCRIPTION
A staking module that can be integrated into other smart contracts. Provided features:
- basic staking/unstaking
- mechanism to slash a member's stake if they're voted to be slashed by a certain number of other members
- adding/removing board members

The contract integrating this can decide if any view functions are needed and what it decides to do with the slashed amounts.