### PR TITLE
warning fix

### DIFF
--- a/elrond-wasm/src/storage/storage_key.rs
+++ b/elrond-wasm/src/storage/storage_key.rs
@@ -24,7 +24,6 @@ where
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.buffer.get_raw_handle()
     }

--- a/elrond-wasm/src/types/interaction/arg_buffer_managed.rs
+++ b/elrond-wasm/src/types/interaction/arg_buffer_managed.rs
@@ -31,7 +31,6 @@ where
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.data.get_raw_handle()
     }

--- a/elrond-wasm/src/types/managed/basic/big_int.rs
+++ b/elrond-wasm/src/types/managed/basic/big_int.rs
@@ -19,7 +19,6 @@ pub struct BigInt<M: ManagedTypeApi> {
 }
 
 impl<M: ManagedTypeApi> ManagedType<M> for BigInt<M> {
-    #[doc(hidden)]
     fn from_raw_handle(handle: Handle) -> Self {
         BigInt {
             handle,
@@ -27,7 +26,6 @@ impl<M: ManagedTypeApi> ManagedType<M> for BigInt<M> {
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.handle
     }

--- a/elrond-wasm/src/types/managed/basic/big_uint.rs
+++ b/elrond-wasm/src/types/managed/basic/big_uint.rs
@@ -22,7 +22,6 @@ pub struct BigUint<M: ManagedTypeApi> {
 }
 
 impl<M: ManagedTypeApi> ManagedType<M> for BigUint<M> {
-    #[doc(hidden)]
     fn from_raw_handle(handle: Handle) -> Self {
         BigUint {
             handle,
@@ -30,7 +29,6 @@ impl<M: ManagedTypeApi> ManagedType<M> for BigUint<M> {
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.handle
     }

--- a/elrond-wasm/src/types/managed/basic/elliptic_curve.rs
+++ b/elrond-wasm/src/types/managed/basic/elliptic_curve.rs
@@ -25,7 +25,6 @@ pub struct EllipticCurve<M: ManagedTypeApi> {
 }
 
 impl<M: ManagedTypeApi> ManagedType<M> for EllipticCurve<M> {
-    #[doc(hidden)]
     fn from_raw_handle(handle: Handle) -> Self {
         EllipticCurve {
             handle,
@@ -33,7 +32,6 @@ impl<M: ManagedTypeApi> ManagedType<M> for EllipticCurve<M> {
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.handle
     }

--- a/elrond-wasm/src/types/managed/basic/managed_buffer.rs
+++ b/elrond-wasm/src/types/managed/basic/managed_buffer.rs
@@ -32,7 +32,6 @@ impl<M: ManagedTypeApi> ManagedType<M> for ManagedBuffer<M> {
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.handle
     }

--- a/elrond-wasm/src/types/managed/managed_type_trait.rs
+++ b/elrond-wasm/src/types/managed/managed_type_trait.rs
@@ -7,14 +7,12 @@ pub trait ManagedType<M: ManagedTypeApi>: Sized {
     #[doc(hidden)]
     fn from_raw_handle(handle: Handle) -> Self;
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle;
 
     /// Implement carefully, since the underlying transmutation is an unsafe operation.
     /// For types that wrap a handle to some VM-managed data,
     /// make sure the type only contains the handle (plus ZSTs if necessary).
     /// For types that just wrap another managed type it is easier, call for the wrapped object.
-    #[doc(hidden)]
     fn transmute_from_handle_ref(handle_ref: &Handle) -> &Self;
 
     fn as_ref(&self) -> ManagedRef<'_, M, Self> {

--- a/elrond-wasm/src/types/managed/wrapped/managed_address.rs
+++ b/elrond-wasm/src/types/managed/wrapped/managed_address.rs
@@ -138,7 +138,6 @@ where
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.bytes.get_raw_handle()
     }

--- a/elrond-wasm/src/types/managed/wrapped/managed_byte_array.rs
+++ b/elrond-wasm/src/types/managed/wrapped/managed_byte_array.rs
@@ -37,7 +37,6 @@ where
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.buffer.get_raw_handle()
     }

--- a/elrond-wasm/src/types/managed/wrapped/managed_vec.rs
+++ b/elrond-wasm/src/types/managed/wrapped/managed_vec.rs
@@ -43,12 +43,10 @@ where
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.buffer.get_raw_handle()
     }
 
-    #[doc(hidden)]
     fn transmute_from_handle_ref(handle_ref: &Handle) -> &Self {
         unsafe { core::mem::transmute(handle_ref) }
     }

--- a/elrond-wasm/src/types/managed/wrapped/token_identifier.rs
+++ b/elrond-wasm/src/types/managed/wrapped/token_identifier.rs
@@ -25,12 +25,10 @@ impl<M: ManagedTypeApi> ManagedType<M> for TokenIdentifier<M> {
         }
     }
 
-    #[doc(hidden)]
     fn get_raw_handle(&self) -> Handle {
         self.buffer.get_raw_handle()
     }
 
-    #[doc(hidden)]
     fn transmute_from_handle_ref(handle_ref: &Handle) -> &Self {
         unsafe { core::mem::transmute(handle_ref) }
     }


### PR DESCRIPTION
`#[doc(hidden)]` placed on implementations doesn't really make sense and is now a Rust warning