### PR TITLE
send single payment

### DIFF
--- a/elrond-wasm/src/contract_base/wrappers/send_wrapper.rs
+++ b/elrond-wasm/src/contract_base/wrappers/send_wrapper.rs
@@ -63,6 +63,7 @@ where
 
     /// Sends either EGLD, ESDT or NFT to the target address,
     /// depending on the token identifier and nonce
+    #[inline]
     pub fn direct<D>(
         &self,
         to: &ManagedAddress<A>,
@@ -74,6 +75,22 @@ where
         D: Into<ManagedBuffer<A>>,
     {
         self.direct_with_gas_limit(to, token, nonce, amount, 0, data, &[]);
+    }
+
+    #[inline]
+    pub fn direct_single<D>(&self, to: &ManagedAddress<A>, payment: &EsdtTokenPayment<A>, data: D)
+    where
+        D: Into<ManagedBuffer<A>>,
+    {
+        self.direct_with_gas_limit(
+            to,
+            &payment.token_identifier,
+            payment.token_nonce,
+            &payment.amount,
+            0,
+            data,
+            &[],
+        );
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
- convenience method for sending `EsdtTokenPayment` directly instead of manually splitting the fields and using `self.send().direct()`