### PR TITLE
get by index + small test

### DIFF
--- a/elrond-wasm-debug/tests/test_hash_unordered_set_mapper.rs
+++ b/elrond-wasm-debug/tests/test_hash_unordered_set_mapper.rs
@@ -29,6 +29,7 @@ fn test_hash_set_simple() {
     set.insert(44);
     check_set(&set, vec![42, 43, 44]);
     assert_eq!(set.contains(&42), true);
+    assert_eq!(set.get_by_index(1), 42);
     assert_eq!(set.contains(&50), false);
 }
 

--- a/elrond-wasm/src/storage/mappers/unordered_set_mapper.rs
+++ b/elrond-wasm/src/storage/mappers/unordered_set_mapper.rs
@@ -70,6 +70,12 @@ where
         storage_get(self.item_index_key(value).as_ref())
     }
 
+    /// Get item at index from storage.
+    /// Index must be valid (1 <= index <= count).
+    pub fn get_by_index(&self, index: usize) -> T {
+        self.vec_mapper.get(index)
+    }
+
     fn set_index(&self, value: &T, index: usize) {
         storage_set(self.item_index_key(value).as_ref(), &index);
     }


### PR DESCRIPTION
feature: `get_by_index` gets an item at index from storage
Index must be valid (1 <= index <= count).