### PR TITLE
nft partial splitting

### DIFF
--- a/contracts/feature-tests/use-module/tests/token_merge_module_test.rs
+++ b/contracts/feature-tests/use-module/tests/token_merge_module_test.rs
@@ -6,7 +6,7 @@ use elrond_wasm::{
     contract_base::ContractBase,
     elrond_codec::Empty,
     storage::mappers::StorageTokenWrapper,
-    types::{EsdtLocalRole, EsdtTokenPayment, ManagedBuffer, ManagedVec},
+    types::{EsdtLocalRole, EsdtTokenPayment, ManagedBuffer, ManagedVec, MultiValueEncoded},
 };
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_buffer, managed_token_id, rust_biguint,
@@ -202,7 +202,7 @@ fn test_token_merge() {
                     SECOND_NFT_NONCE,
                     managed_biguint!(NFT_AMOUNT),
                 ));
-                assert_eq!(output_tokens, expected_output_tokens);
+                assert_eq!(output_tokens.to_vec(), expected_output_tokens);
             },
         )
         .assert_ok();
@@ -406,7 +406,7 @@ fn test_token_merge() {
                     managed_biguint!(NFT_AMOUNT),
                 ));
 
-                assert_eq!(output_tokens, expected_output_tokens);
+                assert_eq!(output_tokens.to_vec(), expected_output_tokens);
             },
         )
         .assert_ok();
@@ -426,6 +426,237 @@ fn test_token_merge() {
         Option::<&Empty>::None,
     );
     b_mock.check_esdt_balance(&user, FUNGIBLE_TOKEN_ID, &rust_biguint!(FUNGIBLE_AMOUNT));
+}
+
+#[test]
+fn partial_split_test() {
+    let rust_zero = rust_biguint!(0);
+    let mut b_mock = BlockchainStateWrapper::new();
+    let owner = b_mock.create_user_account(&rust_zero);
+    let user = b_mock.create_user_account(&rust_zero);
+    let merging_sc = b_mock.create_sc_account(
+        &rust_zero,
+        Some(&owner),
+        use_module::contract_obj,
+        "wasm path",
+    );
+
+    b_mock
+        .execute_tx(&owner, &merging_sc, &rust_zero, |sc| {
+            sc.merged_token()
+                .set_token_id(&managed_token_id!(MERGED_TOKEN_ID));
+            let _ = sc
+                .mergeable_tokens_whitelist()
+                .insert(managed_token_id!(NFT_TOKEN_ID));
+            let _ = sc
+                .mergeable_tokens_whitelist()
+                .insert(managed_token_id!(FUNGIBLE_TOKEN_ID));
+        })
+        .assert_ok();
+    b_mock.set_esdt_local_roles(
+        merging_sc.address_ref(),
+        MERGED_TOKEN_ID,
+        &[EsdtLocalRole::NftCreate, EsdtLocalRole::NftBurn],
+    );
+
+    b_mock.set_esdt_balance(&user, FUNGIBLE_TOKEN_ID, &rust_biguint!(FUNGIBLE_AMOUNT));
+    b_mock.set_nft_balance_all_properties(
+        &user,
+        NFT_TOKEN_ID,
+        FIRST_NFT_NONCE,
+        &rust_biguint!(NFT_AMOUNT),
+        &FIRST_ATTRIBUTES.to_vec(),
+        FIRST_ROYALTIES,
+        None,
+        None,
+        None,
+        &uris_to_vec(FIRST_URIS),
+    );
+    b_mock.set_nft_balance_all_properties(
+        &user,
+        NFT_TOKEN_ID,
+        SECOND_NFT_NONCE,
+        &rust_biguint!(NFT_AMOUNT),
+        &SECOND_ATTRIBUTES.to_vec(),
+        SECOND_ROYALTIES,
+        None,
+        None,
+        None,
+        &uris_to_vec(SECOND_URIS),
+    );
+
+    // merge 2 NFTs and a fungible token
+    let esdt_transfers = vec![
+        TxInputESDT {
+            token_identifier: NFT_TOKEN_ID.to_vec(),
+            nonce: FIRST_NFT_NONCE,
+            value: rust_biguint!(NFT_AMOUNT),
+        },
+        TxInputESDT {
+            token_identifier: NFT_TOKEN_ID.to_vec(),
+            nonce: SECOND_NFT_NONCE,
+            value: rust_biguint!(NFT_AMOUNT),
+        },
+        TxInputESDT {
+            token_identifier: FUNGIBLE_TOKEN_ID.to_vec(),
+            nonce: 0,
+            value: rust_biguint!(FUNGIBLE_AMOUNT),
+        },
+    ];
+    b_mock
+        .execute_esdt_multi_transfer(&user, &merging_sc, &esdt_transfers, |sc| {
+            let merged_token = sc.merge_tokens();
+            assert_eq!(
+                merged_token.token_identifier,
+                managed_token_id!(MERGED_TOKEN_ID)
+            );
+            assert_eq!(merged_token.token_nonce, 1);
+            assert_eq!(merged_token.amount, managed_biguint!(NFT_AMOUNT));
+
+            let merged_token_data = sc.blockchain().get_esdt_token_data(
+                &managed_address!(&user),
+                &managed_token_id!(MERGED_TOKEN_ID),
+                1,
+            );
+
+            let mut expected_attributes = ArrayVec::new();
+            expected_attributes.push(TokenAttributesInstance {
+                original_token_id_raw: ArrayVec::try_from(FUNGIBLE_TOKEN_ID).unwrap(),
+                original_token_nonce: 0,
+                original_token_amount: managed_biguint!(FUNGIBLE_AMOUNT),
+                attributes_raw: ManagedBuffer::new(),
+                royalties: managed_biguint!(0),
+                uris: ManagedVec::new(),
+            });
+            expected_attributes.push(TokenAttributesInstance {
+                original_token_id_raw: ArrayVec::try_from(NFT_TOKEN_ID).unwrap(),
+                original_token_nonce: FIRST_NFT_NONCE,
+                original_token_amount: managed_biguint!(NFT_AMOUNT),
+                attributes_raw: managed_buffer!(FIRST_ATTRIBUTES),
+                royalties: managed_biguint!(FIRST_ROYALTIES),
+                uris: uris_to_managed_vec(FIRST_URIS),
+            });
+            expected_attributes.push(TokenAttributesInstance {
+                original_token_id_raw: ArrayVec::try_from(NFT_TOKEN_ID).unwrap(),
+                original_token_nonce: SECOND_NFT_NONCE,
+                original_token_amount: managed_biguint!(NFT_AMOUNT),
+                attributes_raw: managed_buffer!(SECOND_ATTRIBUTES),
+                royalties: managed_biguint!(SECOND_ROYALTIES),
+                uris: uris_to_managed_vec(SECOND_URIS),
+            });
+
+            let decoded_attributes = merged_token_data
+                .decode_attributes::<ArrayVec<TokenAttributesInstance<DebugApi>, MAX_MERGED_TOKENS>>();
+            assert_eq!(decoded_attributes, expected_attributes);
+        })
+        .assert_ok();
+
+    // split part of the fungible token
+    b_mock
+        .execute_esdt_transfer(
+            &user,
+            &merging_sc,
+            MERGED_TOKEN_ID,
+            1,
+            &rust_biguint!(NFT_AMOUNT),
+            |sc| {
+                let mut tokens_to_remove = MultiValueEncoded::new();
+                tokens_to_remove.push(EsdtTokenPayment::new(
+                    managed_token_id!(FUNGIBLE_TOKEN_ID),
+                    0,
+                    managed_biguint!(40),
+                ));
+                let output_payments = sc.split_token_partial(tokens_to_remove);
+
+                let mut expected_output_payments = ManagedVec::new();
+                expected_output_payments.push(EsdtTokenPayment::new(
+                    managed_token_id!(FUNGIBLE_TOKEN_ID),
+                    0,
+                    managed_biguint!(40),
+                ));
+                expected_output_payments.push(EsdtTokenPayment::new(
+                    managed_token_id!(MERGED_TOKEN_ID),
+                    2,
+                    managed_biguint!(NFT_AMOUNT),
+                ));
+                assert_eq!(output_payments.to_vec(), expected_output_payments);
+            },
+        )
+        .assert_ok();
+
+    // fully remove instance
+    b_mock
+        .execute_esdt_transfer(
+            &user,
+            &merging_sc,
+            MERGED_TOKEN_ID,
+            2,
+            &rust_biguint!(NFT_AMOUNT),
+            |sc| {
+                let mut tokens_to_remove = MultiValueEncoded::new();
+                tokens_to_remove.push(EsdtTokenPayment::new(
+                    managed_token_id!(NFT_TOKEN_ID),
+                    FIRST_NFT_NONCE,
+                    managed_biguint!(NFT_AMOUNT),
+                ));
+                let output_payments = sc.split_token_partial(tokens_to_remove);
+
+                let mut expected_output_payments = ManagedVec::new();
+                expected_output_payments.push(EsdtTokenPayment::new(
+                    managed_token_id!(NFT_TOKEN_ID),
+                    FIRST_NFT_NONCE,
+                    managed_biguint!(NFT_AMOUNT),
+                ));
+                expected_output_payments.push(EsdtTokenPayment::new(
+                    managed_token_id!(MERGED_TOKEN_ID),
+                    3,
+                    managed_biguint!(NFT_AMOUNT),
+                ));
+                assert_eq!(output_payments.to_vec(), expected_output_payments);
+
+                // check newest token attributes
+                let merged_token_data = sc.blockchain().get_esdt_token_data(
+                    &managed_address!(&user),
+                    &managed_token_id!(MERGED_TOKEN_ID),
+                    3,
+                );
+
+                let mut expected_attributes = ArrayVec::new();
+                expected_attributes.push(TokenAttributesInstance {
+                    original_token_id_raw: ArrayVec::try_from(FUNGIBLE_TOKEN_ID).unwrap(),
+                    original_token_nonce: 0,
+                    original_token_amount: managed_biguint!(FUNGIBLE_AMOUNT - 40),
+                    attributes_raw: ManagedBuffer::new(),
+                    royalties: managed_biguint!(0),
+                    uris: ManagedVec::new(),
+                });
+                expected_attributes.push(TokenAttributesInstance {
+                    original_token_id_raw: ArrayVec::try_from(NFT_TOKEN_ID).unwrap(),
+                    original_token_nonce: SECOND_NFT_NONCE,
+                    original_token_amount: managed_biguint!(NFT_AMOUNT),
+                    attributes_raw: managed_buffer!(SECOND_ATTRIBUTES),
+                    royalties: managed_biguint!(SECOND_ROYALTIES),
+                    uris: uris_to_managed_vec(SECOND_URIS),
+                });
+
+                let decoded_attributes = merged_token_data
+                    .decode_attributes::<ArrayVec<TokenAttributesInstance<DebugApi>, MAX_MERGED_TOKENS>>();
+                assert_eq!(decoded_attributes, expected_attributes);
+
+                let mut expected_uris = ManagedVec::new();
+                for uri in SECOND_URIS {
+                    expected_uris.push(managed_buffer!(*uri));
+                }
+
+                assert_eq!(merged_token_data.uris, expected_uris);
+
+                assert_eq!(
+                    merged_token_data.royalties,
+                    managed_biguint!(SECOND_ROYALTIES)
+                );
+            },
+        )
+        .assert_ok();
 }
 
 fn uris_to_vec(uris: &[&[u8]]) -> Vec<Vec<u8>> {

--- a/elrond-wasm-modules/src/token_merge/merged_token_attributes.rs
+++ b/elrond-wasm-modules/src/token_merge/merged_token_attributes.rs
@@ -7,6 +7,8 @@ pub const MAX_MERGED_TOKENS: usize = 10;
 pub const MAX_TOKEN_ID_LEN: usize = 17; // 10 for ticker + '-' + 6 random hex chars
 
 pub static TOO_MANY_TOKENS_ERR_MESG: &[u8] = b"Too many tokens to merge";
+pub static INSUFFICIENT_BALANCE_IN_MERGED_INST_ERR_MSG: &[u8] =
+    b"Insufficient token balance to deduct from merged instance";
 
 #[derive(TypeAbi, TopEncode, TopDecode, NestedEncode, NestedDecode, Debug, Clone, PartialEq)]
 pub struct TokenAttributesInstance<M: ManagedTypeApi> {
@@ -55,17 +57,10 @@ impl<M: ManagedTypeApi> MergedTokenAttributes<M> {
     }
 
     pub fn add_or_update_instance(&mut self, new_instance: TokenAttributesInstance<M>) {
-        let search_result = self.instances.binary_search_by(|item| {
-            let token_id_cmp_result = item
-                .original_token_id_raw
-                .cmp(&new_instance.original_token_id_raw);
-            if token_id_cmp_result != Ordering::Equal {
-                return token_id_cmp_result;
-            }
-
-            item.original_token_nonce
-                .cmp(&new_instance.original_token_nonce)
-        });
+        let search_result = self.binary_search_instance(
+            &new_instance.original_token_id_raw,
+            new_instance.original_token_nonce,
+        );
         match search_result {
             core::result::Result::Ok(existing_index) => {
                 self.instances[existing_index].original_token_amount +=
@@ -87,6 +82,28 @@ impl<M: ManagedTypeApi> MergedTokenAttributes<M> {
     ) {
         for inst in other {
             self.add_or_update_instance(inst);
+        }
+    }
+
+    pub fn deduct_balance_for_instance(&mut self, tokens_to_deduct: &EsdtTokenPayment<M>) {
+        let token_id_raw = token_id_to_array_vec(&tokens_to_deduct.token_identifier);
+        let search_result =
+            self.binary_search_instance(&token_id_raw, tokens_to_deduct.token_nonce);
+        match search_result {
+            core::result::Result::Ok(index) => {
+                let found_instance = &mut self.instances[index];
+                if found_instance.original_token_amount < tokens_to_deduct.amount {
+                    M::error_api_impl().signal_error(INSUFFICIENT_BALANCE_IN_MERGED_INST_ERR_MSG);
+                }
+
+                found_instance.original_token_amount -= &tokens_to_deduct.amount;
+                if found_instance.original_token_amount == 0 {
+                    let _ = self.instances.remove(index);
+                }
+            },
+            core::result::Result::Err(_) => {
+                M::error_api_impl().signal_error(INSUFFICIENT_BALANCE_IN_MERGED_INST_ERR_MSG)
+            },
         }
     }
 
@@ -115,9 +132,24 @@ impl<M: ManagedTypeApi> MergedTokenAttributes<M> {
     pub fn into_instances(self) -> ArrayVec<TokenAttributesInstance<M>, MAX_MERGED_TOKENS> {
         self.instances
     }
+
+    fn binary_search_instance(
+        &self,
+        original_token_id_raw: &ArrayVec<u8, MAX_TOKEN_ID_LEN>,
+        original_token_nonce: u64,
+    ) -> Result<usize, usize> {
+        self.instances.binary_search_by(|item| {
+            let token_id_cmp_result = item.original_token_id_raw.cmp(original_token_id_raw);
+            if token_id_cmp_result != Ordering::Equal {
+                return token_id_cmp_result;
+            }
+
+            item.original_token_nonce.cmp(&original_token_nonce)
+        })
+    }
 }
 
-pub fn token_id_to_array_vec<M: ManagedTypeApi>(
+fn token_id_to_array_vec<M: ManagedTypeApi>(
     token_id: &TokenIdentifier<M>,
 ) -> ArrayVec<u8, MAX_TOKEN_ID_LEN> {
     let mut array_vec = ArrayVec::new();


### PR DESCRIPTION
New endpoint that allows splitting a merged NFT only partially. A new Merged NFT with the remaining parts is created and the removed tokens are sent to the user.