### PR TITLE
decode results to any type for sync calls

### DIFF
--- a/elrond-wasm/src/types/interaction/contract_call.rs
+++ b/elrond-wasm/src/types/interaction/contract_call.rs
@@ -1,4 +1,4 @@
-use elrond_codec::{CodecFrom, TopEncodeMulti};
+use elrond_codec::{TopDecodeMulti, TopEncodeMulti};
 
 use crate::{
     api::{
@@ -349,7 +349,7 @@ where
         raw_result: ManagedVec<SA, ManagedBuffer<SA>>,
     ) -> RequestedResult
     where
-        RequestedResult: CodecFrom<OriginalResult>,
+        RequestedResult: TopDecodeMulti,
     {
         let mut loader = ManagedResultArgLoader::new(raw_result);
         let arg_id = ArgId::from(&b"sync result"[..]);
@@ -362,7 +362,7 @@ where
     /// Only works if the target contract is in the same shard.
     pub fn execute_on_dest_context<RequestedResult>(mut self) -> RequestedResult
     where
-        RequestedResult: CodecFrom<OriginalResult>,
+        RequestedResult: TopDecodeMulti,
     {
         self = self.convert_to_esdt_transfer_call();
         let raw_result = SendRawWrapper::<SA>::new().execute_on_dest_context_raw(
@@ -380,12 +380,30 @@ where
 
     pub fn execute_on_dest_context_readonly<RequestedResult>(mut self) -> RequestedResult
     where
-        RequestedResult: CodecFrom<OriginalResult>,
+        RequestedResult: TopDecodeMulti,
     {
         self = self.convert_to_esdt_transfer_call();
         let raw_result = SendRawWrapper::<SA>::new().execute_on_dest_context_readonly_raw(
             self.resolve_gas_limit(),
             &self.to,
+            &self.endpoint_name,
+            &self.arg_buffer,
+        );
+
+        SendRawWrapper::<SA>::new().clean_return_data();
+
+        Self::decode_result(raw_result)
+    }
+
+    pub fn execute_on_same_context<RequestedResult>(mut self) -> RequestedResult
+    where
+        RequestedResult: TopDecodeMulti,
+    {
+        self = self.convert_to_esdt_transfer_call();
+        let raw_result = SendRawWrapper::<SA>::new().execute_on_same_context_raw(
+            self.resolve_gas_limit(),
+            &self.to,
+            &self.egld_payment,
             &self.endpoint_name,
             &self.arg_buffer,
         );
@@ -408,19 +426,6 @@ where
     pub fn execute_on_dest_context_ignore_result(mut self) {
         self = self.convert_to_esdt_transfer_call();
         let _ = SendRawWrapper::<SA>::new().execute_on_dest_context_raw(
-            self.resolve_gas_limit(),
-            &self.to,
-            &self.egld_payment,
-            &self.endpoint_name,
-            &self.arg_buffer,
-        );
-
-        SendRawWrapper::<SA>::new().clean_return_data();
-    }
-
-    pub fn execute_on_same_context(mut self) {
-        self = self.convert_to_esdt_transfer_call();
-        let _ = SendRawWrapper::<SA>::new().execute_on_same_context_raw(
             self.resolve_gas_limit(),
             &self.to,
             &self.egld_payment,


### PR DESCRIPTION
- decode to any type provided by the caller instead of restricting by CodecFrom. The previous implementation makes it almost impossible to integrate existing mainnet contracts, as they often have an older elrond-wasm version, meaning some types have different implementations, unwanted results are being propagated, etc.
- also added result for execute_on_same_context, which was previously ignored.