### PR TITLE
added missing require

### DIFF
--- a/contracts/examples/token-release/src/token_release.rs
+++ b/contracts/examples/token-release/src/token_release.rs
@@ -207,6 +207,7 @@ pub trait TokenRelease {
     #[only_owner]
     #[endpoint(endSetupPeriod)]
     fn end_setup_period(&self) {
+        self.require_setup_period_live();
         let token_identifier = self.token_identifier().get();
         let total_mint_tokens = self.token_total_supply().get();
         self.mint_all_tokens(&token_identifier, &total_mint_tokens);


### PR DESCRIPTION
It seems that the `require_setup_period_live();` method should be called at `end_setup_period`. Otherwise, this method could be called by the owner multiple times and more tokens will be minted.