### PR TITLE
Price aggregator decimals change

### DIFF
--- a/contracts/core/price-aggregator/README.md
+++ b/contracts/core/price-aggregator/README.md
@@ -8,15 +8,29 @@ Compared to the other chainlink contracts, it is a simplified and easier to use 
 ## Deployment
 
 Arguments:
+- `staking_token` - the token used for staking and slashing
+- `staking_amount` - the minimum staked amount required for a used to be considered a board member
+- `slash_amount` - the amount to be slashed from a board member on a successful slash vote
+- `slash_quorum` - the minimum number of board members required for a vote to be considered successful
 - `oracles` - the list of addresses which are allowed to submit price feed updates
 - `submission_count` - the minimum number of submissions from different oracles which trigger an update of the price feed
-- `decimals` - the number of decimals of the price feed
+
+## Configuring the number of decimals
+
+The number of decimals for a given token pair can be set by calling `setPairDecimals(from, to, decimals)`. Notes:
+- only the owner can configure the number of decimals
+- the contract must be paused first
+- this method also clears the submissions accumulated so far
+- no submissions will be accepted for any given pair unless the number of decimals is configured first
+- every oracle must change its configuration to provide submissions with the new number of decimals, as any mismatch will be considered a configuration error and the submission will be rejected
 
 ## Submitting price feed updates
 
 An oracle can submit a price feed update using one of the endpoints:
-- `submit` - submit a single price feed as 3 arguments (`from`, `to` and `price`).
-- `submitBatch` - submit multiple price feeds simultaneously. The number of arguments must be a multiple of 3.
+- `submit` - submit a single price feed as 5 arguments (`from`, `to`, `submission_timestamp`, `price` and `decimals`).
+- `submitBatch` - submit multiple price feeds simultaneously. The number of arguments must be a multiple of 5.
+
+Note: the decimals argument must match the value returned by `getPairDecimals` for that specific pair, otherwise the submission will be rejected.
 
 ## Rounds
 

--- a/contracts/core/price-aggregator/src/lib.rs
+++ b/contracts/core/price-aggregator/src/lib.rs
@@ -12,6 +12,8 @@ const SUBMISSION_LIST_MAX_LEN: usize = 50;
 const FIRST_SUBMISSION_TIMESTAMP_MAX_DIFF_SECONDS: u64 = 6;
 pub const MAX_ROUND_DURATION_SECONDS: u64 = 1_800; // 30 minutes
 static PAUSED_ERROR_MSG: &[u8] = b"Contract is paused";
+static PAIR_DECIMALS_NOT_CONFIGURED_ERROR: &[u8] = b"pair decimals not configured";
+static WRONG_NUMBER_OF_DECIMALS_ERROR: &[u8] = b"wrong number of decimals";
 
 #[elrond_wasm::contract]
 pub trait PriceAggregator:
@@ -25,7 +27,6 @@ pub trait PriceAggregator:
         slash_amount: BigUint,
         slash_quorum: usize,
         submission_count: usize,
-        decimals: u8,
         oracles: MultiValueEncoded<ManagedAddress>,
     ) {
         self.init_staking_module(
@@ -35,12 +36,6 @@ pub trait PriceAggregator:
             slash_quorum,
             &oracles.to_vec(),
         );
-
-        let is_deploy_call = !self.was_contract_deployed().get();
-        if is_deploy_call {
-            self.decimals().set(decimals);
-            self.was_contract_deployed().set(true);
-        }
 
         self.add_oracles(oracles);
 
@@ -90,6 +85,7 @@ pub trait PriceAggregator:
         to: ManagedBuffer,
         submission_timestamp: u64,
         price: BigUint,
+        decimals: u8,
     ) {
         self.require_not_paused();
         self.require_is_oracle();
@@ -100,7 +96,9 @@ pub trait PriceAggregator:
             "Timestamp is from the future"
         );
 
-        self.submit_unchecked(from, to, submission_timestamp, price);
+        self.check_decimals(&from, &to, decimals);
+
+        self.submit_unchecked(from, to, submission_timestamp, price, decimals);
     }
 
     fn submit_unchecked(
@@ -109,6 +107,7 @@ pub trait PriceAggregator:
         to: ManagedBuffer,
         submission_timestamp: u64,
         price: BigUint,
+        decimals: u8,
     ) {
         let token_pair = TokenPair { from, to };
         let mut submissions = self
@@ -152,7 +151,7 @@ pub trait PriceAggregator:
             submissions.insert(caller, price);
             last_sub_time_mapper.set(current_timestamp);
 
-            self.create_new_round(token_pair, submissions);
+            self.create_new_round(token_pair, submissions, decimals);
         }
 
         self.oracle_status()
@@ -173,13 +172,13 @@ pub trait PriceAggregator:
     #[endpoint(submitBatch)]
     fn submit_batch(
         &self,
-        submissions: MultiValueEncoded<MultiValue4<ManagedBuffer, ManagedBuffer, u64, BigUint>>,
+        submissions: MultiValueEncoded<MultiValue5<ManagedBuffer, ManagedBuffer, u64, BigUint, u8>>,
     ) {
         self.require_not_paused();
         self.require_is_oracle();
 
         let current_timestamp = self.blockchain().get_block_timestamp();
-        for (from, to, submission_timestamp, price) in submissions
+        for (from, to, submission_timestamp, price, decimals) in submissions
             .into_iter()
             .map(|submission| submission.into_tuple())
         {
@@ -188,7 +187,9 @@ pub trait PriceAggregator:
                 "Timestamp is from the future"
             );
 
-            self.submit_unchecked(from, to, submission_timestamp, price);
+            self.check_decimals(&from, &to, decimals);
+
+            self.submit_unchecked(from, to, submission_timestamp, price, decimals);
         }
     }
 
@@ -213,6 +214,7 @@ pub trait PriceAggregator:
         &self,
         token_pair: TokenPair<Self::Api>,
         mut submissions: MapMapper<ManagedAddress, BigUint>,
+        decimals: u8,
     ) {
         let submissions_len = submissions.len();
         if submissions_len >= self.submission_count().get() {
@@ -232,6 +234,7 @@ pub trait PriceAggregator:
             let price_feed = TimestampedPrice {
                 price,
                 timestamp: self.blockchain().get_block_timestamp(),
+                decimals,
             };
 
             submissions.clear();
@@ -314,7 +317,7 @@ pub trait PriceAggregator:
             to: token_pair.to,
             timestamp: last_price.timestamp,
             price: last_price.price,
-            decimals: self.decimals().get(),
+            decimals: last_price.decimals,
         }
     }
 
@@ -327,16 +330,49 @@ pub trait PriceAggregator:
         result
     }
 
-    #[storage_mapper("was_contract_deployed")]
-    fn was_contract_deployed(&self) -> SingleValueMapper<bool>;
+    fn clear_submissions(&self, token_pair: &TokenPair<Self::Api>) {
+        if let Some(mut pair_submission_mapper) = self.submissions().get(token_pair) {
+            pair_submission_mapper.clear();
+        }
+        self.first_submission_timestamp(token_pair).clear();
+        self.last_submission_timestamp(token_pair).clear();
+    }
+
+    #[only_owner]
+    #[endpoint(setPairDecimals)]
+    fn set_pair_decimals(&self, from: ManagedBuffer, to: ManagedBuffer, decimals: u8) {
+        self.require_paused();
+
+        self.pair_decimals(&from, &to).set(Some(decimals));
+        let pair = TokenPair { from, to };
+        self.clear_submissions(&pair);
+    }
+
+    fn check_decimals(&self, from: &ManagedBuffer, to: &ManagedBuffer, decimals: u8) {
+        let configured_decimals = self.get_pair_decimals(from, to);
+        require!(
+            decimals == configured_decimals,
+            WRONG_NUMBER_OF_DECIMALS_ERROR
+        )
+    }
+
+    #[view(getPairDecimals)]
+    fn get_pair_decimals(&self, from: &ManagedBuffer, to: &ManagedBuffer) -> u8 {
+        self.pair_decimals(from, to)
+            .get()
+            .unwrap_or_else(|| sc_panic!(PAIR_DECIMALS_NOT_CONFIGURED_ERROR))
+    }
+
+    #[storage_mapper("pair_decimals")]
+    fn pair_decimals(
+        &self,
+        from: &ManagedBuffer,
+        to: &ManagedBuffer,
+    ) -> SingleValueMapper<Option<u8>>;
 
     #[view]
     #[storage_mapper("submission_count")]
     fn submission_count(&self) -> SingleValueMapper<usize>;
-
-    #[view]
-    #[storage_mapper("decimals")]
-    fn decimals(&self) -> SingleValueMapper<u8>;
 
     #[storage_mapper("oracle_status")]
     fn oracle_status(&self) -> MapMapper<ManagedAddress, OracleStatus>;

--- a/contracts/core/price-aggregator/src/price_aggregator_data.rs
+++ b/contracts/core/price-aggregator/src/price_aggregator_data.rs
@@ -21,6 +21,7 @@ pub struct PriceFeed<M: ManagedTypeApi> {
 pub struct TimestampedPrice<M: ManagedTypeApi> {
     pub price: BigUint<M>,
     pub timestamp: u64,
+    pub decimals: u8,
 }
 
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, TypeAbi, Debug, PartialEq, Eq)]

--- a/contracts/core/price-aggregator/tests/price_agg_setup/mod.rs
+++ b/contracts/core/price-aggregator/tests/price_agg_setup/mod.rs
@@ -64,7 +64,6 @@ where
                     managed_biguint!(SLASH_AMOUNT),
                     SLASH_QUORUM,
                     SUBMISSION_COUNT,
-                    DECIMALS,
                     oracle_args,
                 );
             })
@@ -91,6 +90,14 @@ where
         }
     }
 
+    pub fn set_pair_decimals(&mut self, from: &[u8], to: &[u8], decimals: u8) {
+        self.b_mock
+            .execute_tx(&&self.owner, &self.price_agg, &rust_biguint!(0), |sc| {
+                sc.set_pair_decimals(managed_buffer!(from), managed_buffer!(to), decimals);
+            })
+            .assert_ok();
+    }
+
     pub fn unpause(&mut self) {
         self.b_mock
             .execute_tx(&self.owner, &self.price_agg, &rust_biguint!(0), |sc| {
@@ -107,6 +114,7 @@ where
                     managed_buffer!(USD_TICKER),
                     timestamp,
                     managed_biguint!(price),
+                    DECIMALS,
                 );
             })
     }

--- a/contracts/core/price-aggregator/tests/price_agg_tests.rs
+++ b/contracts/core/price-aggregator/tests/price_agg_tests.rs
@@ -14,6 +14,9 @@ fn price_agg_submit_test() {
     let current_timestamp = 100;
     let oracles = pa_setup.oracles.clone();
 
+    // configure the number of decimals
+    pa_setup.set_pair_decimals(EGLD_TICKER, USD_TICKER, DECIMALS);
+
     // try submit while paused
     pa_setup
         .submit(&oracles[0], 99, 100)
@@ -89,6 +92,9 @@ fn price_agg_submit_round_ok_test() {
     let mut pa_setup = PriceAggSetup::new(elrond_sc_price_aggregator::contract_obj);
     let oracles = pa_setup.oracles.clone();
 
+    // configure the number of decimals
+    pa_setup.set_pair_decimals(EGLD_TICKER, USD_TICKER, DECIMALS);
+
     // unpause
     pa_setup.unpause();
 
@@ -126,7 +132,14 @@ fn price_agg_submit_round_ok_test() {
 
             let rounds = sc.rounds().get(&token_pair).unwrap();
             assert_eq!(rounds.len(), 1);
-            assert_eq!(rounds.get(1), TimestampedPrice { timestamp, price });
+            assert_eq!(
+                rounds.get(1),
+                TimestampedPrice {
+                    timestamp,
+                    price,
+                    decimals
+                }
+            );
         })
         .assert_ok();
 }
@@ -135,6 +148,9 @@ fn price_agg_submit_round_ok_test() {
 fn price_agg_discarded_round_test() {
     let mut pa_setup = PriceAggSetup::new(elrond_sc_price_aggregator::contract_obj);
     let oracles = pa_setup.oracles.clone();
+
+    // configure the number of decimals
+    pa_setup.set_pair_decimals(EGLD_TICKER, USD_TICKER, DECIMALS);
 
     // unpause
     pa_setup.unpause();

--- a/contracts/core/price-aggregator/wasm/src/lib.rs
+++ b/contracts/core/price-aggregator/wasm/src/lib.rs
@@ -8,8 +8,8 @@ elrond_wasm_node::wasm_endpoints! {
     elrond_sc_price_aggregator
     (
         addOracles
-        decimals
         getOracles
+        getPairDecimals
         isPaused
         latestPriceFeed
         latestPriceFeedOptional
@@ -17,6 +17,7 @@ elrond_wasm_node::wasm_endpoints! {
         pause
         removeOracles
         setSubmissionCount
+        set_pair_decimals
         slashMember
         stake
         submission_count


### PR DESCRIPTION
- changed the `decimals` configuration from global to one-per-pair
- added endpoints for interacting with the `decimals` configuration: `setPairDecimals`, `getPairDecimals`
- breaking change: the `submit` and `submitBatch` endpoints must now provide the `decimals` as well, to ensure that a submission is not interpreted with the wrong number of decimals by mistake
- updated the existing tests
- updated the documentation