### PR TITLE
add create nft with uris in non fungible token mapper

### DIFF
--- a/contracts/feature-tests/basic-features/src/storage_mapper_non_fungible_token.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_non_fungible_token.rs
@@ -52,6 +52,48 @@ pub trait NonFungibleTokenMapperFeatures:
             .nft_create_and_send(&to, amount, &attributes)
     }
 
+    #[endpoint()]
+    fn mapper_nft_create_with_uris(
+        &self,
+        amount: BigUint,
+        name: ManagedBuffer,
+        royalties: BigUint,
+        attributes: RgbColor,
+    ) -> EsdtTokenPayment<Self::Api> {
+        let mut uris = ManagedVec::new();
+        uris.push(ManagedBuffer::new());
+
+        self.non_fungible_token_mapper().nft_create_with_uris(
+            amount,
+            &name,
+            royalties,
+            &attributes,
+            &uris
+        )
+    }
+
+    #[endpoint()]
+    fn mapper_nft_create_with_uris_and_send(
+        &self,
+        to: ManagedAddress,
+        amount: BigUint,
+        name: ManagedBuffer,
+        royalties: BigUint,
+        attributes: RgbColor,
+    ) -> EsdtTokenPayment<Self::Api> {
+        let mut uris = ManagedVec::new();
+        uris.push(ManagedBuffer::new());
+
+        self.non_fungible_token_mapper().nft_create_with_uris_and_send(
+            &to,
+            amount,
+            &name,
+            royalties,
+            &attributes,
+            &uris
+        )
+    }
+
     #[endpoint]
     fn mapper_nft_add_quantity(
         &self,

--- a/contracts/feature-tests/basic-features/src/storage_mapper_non_fungible_token.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_non_fungible_token.rs
@@ -52,6 +52,48 @@ pub trait NonFungibleTokenMapperFeatures:
             .nft_create_and_send(&to, amount, &attributes)
     }
 
+    #[endpoint()]
+    fn mapper_nft_create_with_uris(
+        &self,
+        amount: BigUint,
+        name: ManagedBuffer,
+        royalties: BigUint,
+        attributes: RgbColor,
+    ) -> EsdtTokenPayment<Self::Api> {
+        let mut uris = ManagedVec::new();
+        uris.push(ManagedBuffer::new());
+
+        self.non_fungible_token_mapper().nft_create_with_uris(
+            amount,
+            &name,
+            royalties,
+            attributes,
+            uris
+        )
+    }
+
+    #[endpoint()]
+    fn mapper_nft_create_with_uris_and_send(
+        &self,
+        to: ManagedAddress,
+        amount: BigUint,
+        name: ManagedBuffer,
+        royalties: BigUint,
+        attributes: RgbColor,
+    ) -> EsdtTokenPayment<Self::Api> {
+        let mut uris = ManagedVec::new();
+        uris.push(ManagedBuffer::new());
+
+        self.non_fungible_token_mapper().nft_create_with_uris_and_send(
+            &to,
+            amount,
+            &name,
+            royalties,
+            attributes,
+            uris
+        )
+    }
+
     #[endpoint]
     fn mapper_nft_add_quantity(
         &self,

--- a/contracts/feature-tests/basic-features/src/storage_mapper_non_fungible_token.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_non_fungible_token.rs
@@ -52,48 +52,6 @@ pub trait NonFungibleTokenMapperFeatures:
             .nft_create_and_send(&to, amount, &attributes)
     }
 
-    #[endpoint()]
-    fn mapper_nft_create_with_uris(
-        &self,
-        amount: BigUint,
-        name: ManagedBuffer,
-        royalties: BigUint,
-        attributes: RgbColor,
-    ) -> EsdtTokenPayment<Self::Api> {
-        let mut uris = ManagedVec::new();
-        uris.push(ManagedBuffer::new());
-
-        self.non_fungible_token_mapper().nft_create_with_uris(
-            amount,
-            &name,
-            royalties,
-            attributes,
-            uris
-        )
-    }
-
-    #[endpoint()]
-    fn mapper_nft_create_with_uris_and_send(
-        &self,
-        to: ManagedAddress,
-        amount: BigUint,
-        name: ManagedBuffer,
-        royalties: BigUint,
-        attributes: RgbColor,
-    ) -> EsdtTokenPayment<Self::Api> {
-        let mut uris = ManagedVec::new();
-        uris.push(ManagedBuffer::new());
-
-        self.non_fungible_token_mapper().nft_create_with_uris_and_send(
-            &to,
-            amount,
-            &name,
-            royalties,
-            attributes,
-            uris
-        )
-    }
-
     #[endpoint]
     fn mapper_nft_add_quantity(
         &self,

--- a/elrond-wasm/src/storage/mappers/non_fungible_token_mapper.rs
+++ b/elrond-wasm/src/storage/mappers/non_fungible_token_mapper.rs
@@ -310,7 +310,7 @@ where
         send_wrapper.esdt_local_burn(&token_id, token_nonce, amount);
     }
 
-    pub fn get_all_token_data(&self, token_nonce: u64) -> EsdtTokenData<SA> {
+    pub fn get_token_data(&self, token_nonce: u64) -> EsdtTokenData<SA> {
         let b_wrapper = BlockchainWrapper::new();
         let own_sc_address = Self::get_sc_address();
         let token_id = self.get_token_id();
@@ -327,7 +327,7 @@ where
     }
 
     pub fn get_token_attributes<T: TopDecode>(&self, token_nonce: u64) -> T {
-        let token_data = self.get_all_token_data(token_nonce);
+        let token_data = self.get_token_data(token_nonce);
         token_data.decode_attributes()
     }
 

--- a/elrond-wasm/src/storage/mappers/non_fungible_token_mapper.rs
+++ b/elrond-wasm/src/storage/mappers/non_fungible_token_mapper.rs
@@ -312,7 +312,7 @@ where
         send_wrapper.esdt_local_burn(&token_id, token_nonce, amount);
     }
 
-    pub fn get_all_token_data(&self, token_nonce: u64) -> EsdtTokenData<SA> {
+    pub fn get_token_data(&self, token_nonce: u64) -> EsdtTokenData<SA> {
         let b_wrapper = BlockchainWrapper::new();
         let own_sc_address = Self::get_sc_address();
         let token_id = self.get_token_id();
@@ -329,7 +329,7 @@ where
     }
 
     pub fn get_token_attributes<T: TopDecode>(&self, token_nonce: u64) -> T {
-        let token_data = self.get_all_token_data(token_nonce);
+        let token_data = self.get_token_data(token_nonce);
         token_data.decode_attributes()
     }
 

--- a/elrond-wasm/src/storage/mappers/non_fungible_token_mapper.rs
+++ b/elrond-wasm/src/storage/mappers/non_fungible_token_mapper.rs
@@ -242,6 +242,46 @@ where
         payment
     }
 
+    pub fn nft_create_with_uris<T: TopEncode>(
+        &self,
+        amount: BigUint<SA>,
+        name: &ManagedBuffer<SA>,
+        royalties: BigUint<SA>,
+        attributes: &T,
+        uris: &ManagedVec<A, ManagedBuffer<A>>
+    ) -> EsdtTokenPayment<SA> {
+        let send_wrapper = SendWrapper::<SA>::new();
+        let token_id = self.get_token_id();
+
+        let token_nonce = send_wrapper.esdt_nft_create(
+            &token_id,
+            &amount,
+            name,
+            &royalties,
+            &ManagedBuffer::new(),
+            attributes,
+            uris
+        );
+
+        EsdtTokenPayment::new(token_id, token_nonce, amount)
+    }
+
+    pub fn nft_create_with_uris_and_send<T: TopEncode>(
+        to: &ManagedAddress<SA>,
+        amount: BigUint<SA>,
+        name: &ManagedBuffer<SA>,
+        royalties: BigUint<SA>,
+        attributes: &T,
+        uris: &ManagedVec<A, ManagedBuffer<A>>
+    ) -> EsdtTokenPayment<SA> {
+        let payment = 
+            self.nft_create_with_uris(amount, name, royalties, attributes, uris);
+
+        self.send_payment(to, &payment);
+
+        payment
+    }
+
     pub fn nft_add_quantity(&self, token_nonce: u64, amount: BigUint<SA>) -> EsdtTokenPayment<SA> {
         let send_wrapper = SendWrapper::<SA>::new();
         let token_id = self.get_token_id();

--- a/elrond-wasm/src/storage/mappers/non_fungible_token_mapper.rs
+++ b/elrond-wasm/src/storage/mappers/non_fungible_token_mapper.rs
@@ -242,45 +242,6 @@ where
         payment
     }
 
-    pub fn nft_create_with_uris<T: TopEncode>(
-        &self,
-        amount: BigUint<SA>,
-        name: &ManagedBuffer<SA>,
-        royalties: BigUint<SA>,
-        attributes: &T,
-        uris: &ManagedVec<A, ManagedBuffer<A>>
-    ) -> EsdtTokenPayment<SA> {
-        let send_wrapper = SendWrapper::<SA>::new();
-        let token_id = self.get_token_id();
-
-        let token_nonce = send_wrapper.esdt_nft_create(
-            &token_id,
-            &amount,
-            name,
-            &royalties,
-            &ManagedBuffer::new(),
-            attributes,
-            uris
-        );
-
-        EsdtTokenPayment::new(token_id, token_nonce, amount)
-    }
-
-    pub fn nft_create_with_uris_and_send<T: TopEncode>(
-        to: &ManagedAddress<SA>,
-        amount: BigUint<SA>,
-        name: &ManagedBuffer<SA>,
-        royalties: BigUint<SA>,
-        attributes: &T,
-        uris: &ManagedVec<A, ManagedBuffer<A>>
-    ) -> EsdtTokenPayment<SA> {
-        let payment = 
-            self.nft_create_with_uris(amount, name, royalties, attributes, uris);
-
-        self.send_payment(to, &payment);
-
-        payment
-    }
 
     pub fn nft_add_quantity(&self, token_nonce: u64, amount: BigUint<SA>) -> EsdtTokenPayment<SA> {
         let send_wrapper = SendWrapper::<SA>::new();
@@ -310,7 +271,7 @@ where
         send_wrapper.esdt_local_burn(&token_id, token_nonce, amount);
     }
 
-    pub fn get_token_data(&self, token_nonce: u64) -> EsdtTokenData<SA> {
+    pub fn get_all_token_data(&self, token_nonce: u64) -> EsdtTokenData<SA> {
         let b_wrapper = BlockchainWrapper::new();
         let own_sc_address = Self::get_sc_address();
         let token_id = self.get_token_id();
@@ -327,7 +288,7 @@ where
     }
 
     pub fn get_token_attributes<T: TopDecode>(&self, token_nonce: u64) -> T {
-        let token_data = self.get_token_data(token_nonce);
+        let token_data = self.get_all_token_data(token_nonce);
         token_data.decode_attributes()
     }
 


### PR DESCRIPTION
The Non-Fungible Token Mapper is great but it lacks a function with the royalties & uris to use for NFT and SFT so I added the function.

I also renamed the `get_all_token_data` to `get_token_data` because I saw some misunderstandings due to the name, some people thought with the name and with the docs that say: _"Gets all the token data for the given nonce. The SC must own at least 1 token to use this function."_ think that you can actually get all the token data for every nonce in the collection if you have at least one token - which is wrong, you meant that when talking about MetaESDT/SFT.

I will also update the documentation with the new functions when this PR is merged. 