### PR TITLE
implement FromIterator trait for ManagedVec

### DIFF
--- a/elrond-wasm-debug/tests/managed_vec_test.rs
+++ b/elrond-wasm-debug/tests/managed_vec_test.rs
@@ -28,6 +28,23 @@ fn test_managed_vec_iter_rev() {
 }
 
 #[test]
+fn test_managed_vec_from_iterator_trait() {
+    let _ = DebugApi::dummy();
+    let mut managed_vec = ManagedVec::<DebugApi, i32>::new();
+    for i in 1..=10 {
+        managed_vec.push(i);
+    }
+    let mut expected_vec = ManagedVec::<DebugApi, i32>::new();
+    for i in 1..=5 {
+        expected_vec.push(i);
+    }
+
+    let collected_vec = managed_vec.iter().filter(|x| x <= &5).collect::<ManagedVec<DebugApi, i32>>();
+
+    assert_eq!(collected_vec, expected_vec);
+}
+
+#[test]
 fn test_managed_vec_iter_exact_size_trait() {
     let _ = DebugApi::dummy();
 

--- a/elrond-wasm/src/types/managed/wrapped/managed_vec.rs
+++ b/elrond-wasm/src/types/managed/wrapped/managed_vec.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use alloc::vec::Vec;
-use core::{borrow::Borrow, marker::PhantomData};
+use core::{borrow::Borrow, iter::FromIterator, marker::PhantomData};
 use elrond_codec::{
     DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
     NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeMultiOutput,
@@ -518,5 +518,17 @@ where
         arg.top_encode_or_handle_err(&mut result, h)?;
         self.push(result);
         Ok(())
+    }
+}
+
+impl<M, V> FromIterator<V> for ManagedVec<M, V>
+where
+    M: ManagedTypeApi,
+    V: ManagedVecItem,
+{
+    fn from_iter<T: IntoIterator<Item = V>>(iter: T) -> Self {
+        let mut result: ManagedVec<M, V> = ManagedVec::new();
+        iter.into_iter().for_each(|f| result.push(f));
+        result
     }
 }


### PR DESCRIPTION
With this PR, devs can use the more ergonomic collect fn instead of manually doing a for_each or for loop over the filtered/mapped iterator

Before:
```rust
let mut collected_vec: ManagedVec<i32> = ManagedVec::new();
managed_vec.iter().filter(|x| x <= &5).for_each(|el| collected_vec.push(el));
```
After:

```rust
let collected_vec = managed_vec.iter().filter(|x| x <= &5).collect::<ManagedVec<i32>>();
```
