### PR TITLE
Add lldb pretty printers

### DIFF
--- a/.github/workflows/lldb-formatter-tests.yml
+++ b/.github/workflows/lldb-formatter-tests.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  format_tests:
+    name: LLDB formatter tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          default: true
+          toolchain: nightly-2022-10-12
+
+      - name: Download vscode-lldb
+        uses: robinraju/release-downloader@v1.5
+        with:
+          repository: vadimcn/vscode-lldb
+          latest: true
+          fileName: codelldb-x86_64-linux.vsix
+
+      - name: Setup vscode-lldb
+        run: |
+          unzip codelldb-x86_64-linux.vsix -d vscode-lldb
+          mkdir -p $HOME/.vscode/extensions/vadimcn.vscode-lldb-x.x.x/
+          mv vscode-lldb/extension/* $HOME/.vscode/extensions/vadimcn.vscode-lldb-x.x.x/
+
+      - name: Run the rust tests
+        run: |
+          cd tools/rust-debugger/format-tests
+          cargo test

--- a/elrond-wasm-debug/src/api/mod.rs
+++ b/elrond-wasm-debug/src/api/mod.rs
@@ -11,3 +11,5 @@ mod print_api_mock;
 mod send_api_mock;
 mod storage_api_mock;
 mod vm_api_mock;
+
+pub use debug_handle_mock::DebugHandle;

--- a/tools/rust-debugger/format-tests/Cargo.toml
+++ b/tools/rust-debugger/format-tests/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "format-tests"
+version = "0.1.0"
+edition = "2021"
+
+
+[[bin]]
+name = "format-tests"
+path = "src/format_tests.rs"
+
+[dependencies.elrond-wasm]
+version = "0.36.0"
+path = "../../../elrond-wasm"
+
+[dependencies.elrond-wasm-debug]
+version = "0.36.0"
+path = "../../../elrond-wasm-debug"
+
+[dev-dependencies]
+glob = "0.3.0"
+home = "0.5.3"
+
+[workspace]
+members = ["."]

--- a/tools/rust-debugger/format-tests/src/check_debugger_values.py
+++ b/tools/rust-debugger/format-tests/src/check_debugger_values.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from typing import List
+import lldb
+from lldb import SBDebugger, SBValue, SBFrame, SBBreakpointLocation
+
+
+def __lldb_init_module(debugger: SBDebugger, dict):
+    debugger.HandleCommand("breakpoint set --name breakpoint_marker_end_of_main")
+    python_module_name = Path(__file__).with_suffix('').name
+    breakpoint_function_name = end_of_main_breakpoint_handler.__name__
+    debugger.HandleCommand(f"breakpoint command add -F {python_module_name}.{breakpoint_function_name}")
+
+
+def get_string(rust_string: lldb.value) -> str:
+    return rust_string.sbvalue.GetSummary()[1:-1] # remove surrounding quotes
+
+
+def end_of_main_breakpoint_handler(frame: SBFrame, bp_loc: SBBreakpointLocation, internal_dict):
+    print("TEST REPORT BEGIN")
+    main_frame: SBFrame = frame.get_parent_frame()
+    variables: List[SBValue] = main_frame.variables
+    variable_summaries = {}
+    for variable in variables:
+        name = variable.GetName()
+        if name == "to_check":
+            to_check = variable
+        summary = variable.GetSummary()
+        variable_summaries[name] = summary
+    correct = 0
+    incorrect = 0
+    duplicate = 0
+    checked = set()
+    for item in lldb.value(to_check):
+        variable_name_string, value_to_check_string = item
+        variable_name = get_string(variable_name_string)
+        value_to_check = get_string(value_to_check_string)
+        found = variable_summaries[variable_name]
+        expected = value_to_check
+        is_duplicate = variable_name in checked
+        checked.add(variable_name)
+        is_correct = found == expected
+        if is_duplicate:
+            duplicate += 1
+            print(f"{variable_name} DUPLICATE")
+        elif not is_correct:
+            incorrect += 1
+            print(f"{variable_name} MISMATCH: Found:\"{found}\", Expected:\"{expected}\"")
+        else:
+            correct += 1
+            print(f"{variable_name} OK")
+    if incorrect > 0 or duplicate > 0:
+        test_result = "FAILED"
+    else:
+        test_result = "OK"
+    print(f"Test {test_result} - correct ({correct}), incorrect ({incorrect}), duplicate({duplicate})")
+    print("TEST REPORT END")

--- a/tools/rust-debugger/format-tests/src/format_tests.rs
+++ b/tools/rust-debugger/format-tests/src/format_tests.rs
@@ -1,0 +1,231 @@
+use elrond_wasm::{
+    elrond_codec::multi_types::OptionalValue,
+    esdt::ESDTSystemSmartContractProxy,
+    types::{
+        heap::{Address, BoxedBytes},
+        BigFloat, BigInt, BigUint, EgldOrEsdtTokenIdentifier, EsdtTokenPayment, ManagedAddress,
+        ManagedBuffer, ManagedByteArray, ManagedOption, ManagedType, ManagedVec, TokenIdentifier,
+    },
+};
+use elrond_wasm_debug::{
+    api::DebugHandle,
+    num_bigint::{BigInt as RustBigInt, BigUint as RustBigUint},
+    DebugApi,
+};
+
+macro_rules! push {
+    ($list: ident, $name:ident, $expected: expr ) => {{
+        // Ensure the identifier is a valid variable name
+        let _ = $name;
+        $list.push((stringify!($name).to_owned(), $expected.to_owned()));
+    }};
+}
+
+#[allow(unused_variables)]
+// Allow redundant_clone since the variables have to be available at the breakpoint location
+// they have to be cloned if used before that point
+#[allow(clippy::redundant_clone)]
+fn main() {
+    DebugApi::dummy();
+
+    // Used by the python script which checks the variable summaries
+    let mut to_check: Vec<(String, String)> = Vec::new();
+
+    let num_biguint: RustBigUint = 10u32.into();
+    push!(to_check, num_biguint, "10");
+
+    let num_bigint_small: RustBigInt = RustBigInt::from(-10);
+    push!(to_check, num_bigint_small, "-10");
+
+    let num_bigint_large: RustBigInt = RustBigInt::from(10).pow(30);
+    push!(
+        to_check,
+        num_bigint_large,
+        "1000000000000000000000000000000"
+    );
+
+    let num_bigint_negative: RustBigInt = RustBigInt::from(10).pow(30) * -1;
+    push!(
+        to_check,
+        num_bigint_negative,
+        "-1000000000000000000000000000000"
+    );
+
+    let biguint: BigUint<DebugApi> = num_bigint_large.to_biguint().unwrap().into();
+    push!(to_check, biguint, "1000000000000000000000000000000");
+
+    let bigint: BigInt<DebugApi> = num_bigint_negative.clone().into();
+    push!(to_check, bigint, "-1000000000000000000000000000000");
+
+    let bigfloat: BigFloat<DebugApi> = BigFloat::from_frac(-12345678, 10000);
+    push!(to_check, bigfloat, "-1234.5678");
+
+    let managed_buffer: ManagedBuffer<DebugApi> = ManagedBuffer::new_from_bytes(b"hello world");
+    push!(to_check, managed_buffer, "(11) 0x68656c6c6f20776f726c64");
+
+    let token_identifier: TokenIdentifier<DebugApi> = TokenIdentifier::from("MYTOK-123456");
+    push!(to_check, token_identifier, "\"MYTOK-123456\"");
+
+    let system_sc = ESDTSystemSmartContractProxy::<DebugApi>::new_proxy_obj();
+    let managed_address = system_sc.esdt_system_sc_address();
+    push!(
+        to_check,
+        managed_address,
+        "(32) 0x000000000000000000010000000000000000000000000000000000000002ffff"
+    );
+
+    let managed_byte_array: ManagedByteArray<DebugApi, 4> =
+        ManagedByteArray::new_from_bytes(b"test");
+    push!(to_check, managed_byte_array, "(4) 0x74657374");
+
+    let managed_option_some_token_identifier: ManagedOption<DebugApi, TokenIdentifier<DebugApi>> =
+        ManagedOption::some(token_identifier.clone());
+    push!(
+        to_check,
+        managed_option_some_token_identifier,
+        "ManagedOption::some(\"MYTOK-123456\")"
+    );
+
+    let managed_option_none: ManagedOption<DebugApi, TokenIdentifier<DebugApi>> =
+        ManagedOption::none();
+    push!(to_check, managed_option_none, "ManagedOption::none()");
+
+    let payment = EsdtTokenPayment {
+        token_identifier: TokenIdentifier::from("MYTOK-123456"),
+        token_nonce: 42,
+        amount: BigUint::from(1000u64),
+    };
+    push!(
+        to_check,
+        payment,
+        "{ token_identifier: \"MYTOK-123456\", nonce: 42, amount: 1000 }"
+    );
+
+    let mut managed_vec_of_biguints: ManagedVec<DebugApi, BigUint<DebugApi>> = ManagedVec::new();
+    managed_vec_of_biguints.push(BigUint::from(10u64).pow(10));
+    managed_vec_of_biguints.push(BigUint::from(10u64).pow(20));
+    push!(
+        to_check,
+        managed_vec_of_biguints,
+        "(2) { [0] = 10000000000, [1] = 100000000000000000000 }"
+    );
+
+    let mut managed_vec_of_payments: ManagedVec<DebugApi, EsdtTokenPayment<DebugApi>> =
+        ManagedVec::new();
+    managed_vec_of_payments.push(payment.clone());
+    managed_vec_of_payments.push(EsdtTokenPayment::new(
+        TokenIdentifier::from("MYTOK-abcdef"),
+        100,
+        5000u64.into(),
+    ));
+    push!(to_check, managed_vec_of_payments, "(2) { [0] = { token_identifier: \"MYTOK-123456\", nonce: 42, amount: 1000 }, [1] = { token_identifier: \"MYTOK-abcdef\", nonce: 100, amount: 5000 } }");
+
+    let egld_or_esdt_token_identifier_egld: EgldOrEsdtTokenIdentifier<DebugApi> =
+        EgldOrEsdtTokenIdentifier::egld();
+    push!(
+        to_check,
+        egld_or_esdt_token_identifier_egld,
+        "EgldOrEsdtTokenIdentifier::egld()"
+    );
+
+    let egld_or_esdt_token_identifier_esdt: EgldOrEsdtTokenIdentifier<DebugApi> =
+        EgldOrEsdtTokenIdentifier::esdt("MYTOK-123456");
+    push!(
+        to_check,
+        egld_or_esdt_token_identifier_esdt,
+        "EgldOrEsdtTokenIdentifier::esdt(\"MYTOK-123456\")"
+    );
+
+    // Nested type tests
+    let mut managed_vec_of_addresses: ManagedVec<DebugApi, ManagedAddress<DebugApi>> =
+        ManagedVec::new();
+    managed_vec_of_addresses.push(managed_address.clone());
+    push!(
+        to_check,
+        managed_vec_of_addresses,
+        "(1) { [0] = (32) 0x000000000000000000010000000000000000000000000000000000000002ffff }"
+    );
+
+    let managed_option_of_vec_of_addresses: ManagedOption<
+        DebugApi,
+        ManagedVec<DebugApi, ManagedAddress<DebugApi>>,
+    > = ManagedOption::some(managed_vec_of_addresses.clone());
+    push!(to_check, managed_option_of_vec_of_addresses, "ManagedOption::some((1) { [0] = (32) 0x000000000000000000010000000000000000000000000000000000000002ffff })");
+
+    // 5. Elrond wasm - heap
+    let heap_address: Address = managed_address.to_address();
+    push!(
+        to_check,
+        heap_address,
+        "(32) 0x000000000000000000010000000000000000000000000000000000000002ffff"
+    );
+
+    let boxed_bytes: BoxedBytes = b"test"[..].into();
+    push!(to_check, boxed_bytes, "(4) 0x74657374");
+
+    let mut managed_vec_of_managed_buffers: ManagedVec<DebugApi, ManagedBuffer<DebugApi>> =
+        ManagedVec::new();
+    for value in ["ab", "abcd", "abcdefghijkl"] {
+        managed_vec_of_managed_buffers.push(value.into());
+    }
+    push!(
+        to_check,
+        managed_vec_of_managed_buffers,
+        "(3) { [0] = (2) 0x6162, [1] = (4) 0x61626364, [2] = (12) 0x6162636465666768696a6b6c }"
+    );
+
+    // 6. Elrond codec - Multi-types
+    let optional_value_some: OptionalValue<BigUint<DebugApi>> =
+        OptionalValue::Some(BigUint::from(42u64));
+    push!(to_check, optional_value_some, "OptionalValue::Some(42)");
+
+    let optional_value_none: OptionalValue<BigUint<DebugApi>> = OptionalValue::None;
+    push!(to_check, optional_value_none, "OptionalValue::None");
+
+    // Invalid handle tests
+
+    let invalid_handle = DebugHandle::from(-1000);
+    let biguint_with_invalid_handle: BigUint<DebugApi> =
+        BigUint::from_handle(invalid_handle.clone());
+    push!(
+        to_check,
+        biguint_with_invalid_handle,
+        "<invalid handle: raw_handle -1000 not found in big_int_map>"
+    );
+
+    let big_float_with_invalid_handle: BigFloat<DebugApi> =
+        BigFloat::from_handle(invalid_handle.clone());
+    push!(
+        to_check,
+        big_float_with_invalid_handle,
+        "<invalid handle: raw_handle -1000 not found in big_float_map>"
+    );
+
+    let managed_buffer_with_invalid_handle: ManagedBuffer<DebugApi> =
+        ManagedBuffer::from_handle(invalid_handle.clone());
+    push!(
+        to_check,
+        managed_buffer_with_invalid_handle,
+        "<invalid handle: raw_handle -1000 not found in managed_buffer_map>"
+    );
+
+    let token_identifier_with_invalid_handle: TokenIdentifier<DebugApi> =
+        TokenIdentifier::from_handle(invalid_handle.clone());
+    push!(
+        to_check,
+        token_identifier_with_invalid_handle,
+        "<invalid handle: raw_handle -1000 not found in managed_buffer_map>"
+    );
+
+    let optional_value_some_with_invalid_handle: OptionalValue<BigUint<DebugApi>> =
+        OptionalValue::Some(BigUint::from_handle(invalid_handle.clone()));
+    push!(
+        to_check,
+        optional_value_some_with_invalid_handle,
+        "OptionalValue::Some(<invalid handle: raw_handle -1000 not found in big_int_map>)"
+    );
+
+    breakpoint_marker_end_of_main();
+}
+
+fn breakpoint_marker_end_of_main() {}

--- a/tools/rust-debugger/format-tests/src/mypy.ini
+++ b/tools/rust-debugger/format-tests/src/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.9
+
+[mypy-lldb]
+ignore_missing_imports = True

--- a/tools/rust-debugger/format-tests/tests/run_format_tests.rs
+++ b/tools/rust-debugger/format-tests/tests/run_format_tests.rs
@@ -1,0 +1,112 @@
+#![feature(exit_status_error)]
+
+#[cfg(test)]
+use std::{io::BufRead, path::Path, process::Command};
+
+#[test]
+fn run_format_tests() {
+    let home_dir = home::home_dir().unwrap();
+
+    let mut vscode_lldb_plugin_lookup = home_dir.clone();
+    vscode_lldb_plugin_lookup.push(".vscode/extensions/vadimcn.vscode-lldb-*");
+
+    let vscode_lldb_plugin = glob::glob(vscode_lldb_plugin_lookup.as_os_str().to_str().unwrap())
+        .expect("Failed to read glob pattern")
+        .next()
+        .expect("No installed vscode-lldb found")
+        .expect("Glob failed");
+    check_path(&vscode_lldb_plugin);
+
+    let mut lldb = vscode_lldb_plugin.clone();
+    lldb.push("lldb/bin/lldb");
+    check_path(&lldb);
+
+    let workspace_root = Path::new(".").canonicalize().unwrap();
+    check_path(&workspace_root);
+
+    let format_tests_path = Path::new("./target/debug/format-tests")
+        .canonicalize()
+        .unwrap();
+    check_path(&format_tests_path);
+
+    let mut rust_formatters = vscode_lldb_plugin.clone();
+    rust_formatters.push("formatters");
+    check_path(&rust_formatters);
+
+    let pretty_printers = Path::new("../pretty-printers/elrond_wasm_lldb_pretty_printers.py")
+        .canonicalize()
+        .unwrap();
+    check_path(&pretty_printers);
+
+    let check_debugger_values = Path::new("./src/check_debugger_values.py")
+        .canonicalize()
+        .unwrap();
+    check_path(&check_debugger_values);
+
+    let debugger_output = Command::new(lldb)
+        .arg(format_tests_path)
+        .arg("-o")
+        .arg(command_script_import(&rust_formatters))
+        .arg("-o")
+        .arg(command_script_import(&pretty_printers))
+        .arg("-o")
+        .arg(command_script_import(&check_debugger_values))
+        .arg("-o")
+        .arg("run")
+        .arg("-o")
+        .arg("continue")
+        .arg("-o")
+        .arg("exit")
+        .output()
+        .expect("Failed to run debugger");
+
+    debugger_output
+        .status
+        .exit_ok()
+        .expect("Debugger returned a non-zero status");
+
+    let stdout_lines: Vec<String> = debugger_output
+        .stdout
+        .lines()
+        .map(|line| line.unwrap())
+        .collect();
+    let begin_index = stdout_lines
+        .iter()
+        .position(|line| line == "TEST REPORT BEGIN")
+        .unwrap_or_else(|| panic_with_stdout("Report begin marker not found", &stdout_lines));
+    let end_index = stdout_lines
+        .iter()
+        .position(|line| line == "TEST REPORT END")
+        .expect("Report end marker not found");
+    let report: Vec<String> = stdout_lines
+        .into_iter()
+        .skip(begin_index + 1)
+        .take(end_index - begin_index - 1)
+        .collect();
+    let last_line = report.last().unwrap();
+    if last_line.starts_with("Test OK") {
+        // all good
+    } else if last_line.starts_with("Test FAILED") {
+        let report_string = report.join("\n");
+        panic!("Test failed - see report:\n{}\n", report_string);
+    } else {
+        panic!("The report has an invalid format: {:?}", report)
+    }
+}
+
+fn panic_with_stdout(message: &str, stdout_lines: &Vec<String>) -> ! {
+    let debugger_output = stdout_lines.join("\n");
+    panic!("{} - see debugger output:\n{}\n", message, debugger_output);
+}
+
+fn check_path<P: AsRef<Path>>(path: P) {
+    assert!(
+        path.as_ref().exists(),
+        "Missing {}",
+        path.as_ref().display()
+    );
+}
+
+fn command_script_import(script_path: &Path) -> String {
+    format!("command script import {}", script_path.display())
+}

--- a/tools/rust-debugger/pretty-printers/elrond_wasm_lldb_pretty_printers.py
+++ b/tools/rust-debugger/pretty-printers/elrond_wasm_lldb_pretty_printers.py
@@ -1,0 +1,522 @@
+from functools import partial
+from typing import Callable, Collection, Iterable, List, Tuple, Type
+from lldb import SBValue, SBDebugger
+import lldb
+from pathlib import Path
+import re
+import struct
+
+DEBUG_API_TYPE = "elrond_wasm_debug::tx_mock::tx_context_ref::TxContextRef"
+ANY_NUMBER = "[0-9]+"
+ANY_TYPE = ".*"
+SOME_OR_NONE = "(Some|None)"
+
+# 1. num_bigint library
+NUM_BIG_INT_TYPE = "num_bigint::bigint::BigInt"
+NUM_BIG_UINT_TYPE = "num_bigint::biguint::BigUint"
+
+# 2. Elrond wasm - Managed basic types
+MOD_PATH = "elrond_wasm::types::managed::basic"
+
+BIG_INT_TYPE = f"{MOD_PATH}::big_int::BigInt<{DEBUG_API_TYPE}>"
+BIG_UINT_TYPE = f"{MOD_PATH}::big_uint::BigUint<{DEBUG_API_TYPE}>"
+BIG_FLOAT_TYPE = f"{MOD_PATH}::big_float::BigFloat<{DEBUG_API_TYPE}>"
+MANAGED_BUFFER_TYPE = f"{MOD_PATH}::managed_buffer::ManagedBuffer<{DEBUG_API_TYPE}>"
+
+# 3. Elrond wasm - Managed wrapped types
+MOD_PATH = "elrond_wasm::types::managed::wrapped"
+
+TOKEN_IDENTIFIER_TYPE = f"{MOD_PATH}::token_identifier::TokenIdentifier<{DEBUG_API_TYPE}>"
+MANAGED_ADDRESS_TYPE = f"{MOD_PATH}::managed_address::ManagedAddress<{DEBUG_API_TYPE}>"
+MANAGED_BYTE_ARRAY_TYPE = f"{MOD_PATH}::managed_byte_array::ManagedByteArray<{DEBUG_API_TYPE}, {ANY_NUMBER}>"
+
+# ManagedOption
+MANAGED_OPTION_INNER_TYPE_INDEX = 1
+MANAGED_OPTION_NONE_HANDLE = 2147483646  # i32::MAX - 1
+MANAGED_OPTION_TYPE = f"{MOD_PATH}::managed_option::ManagedOption<{DEBUG_API_TYPE}, {ANY_TYPE}>"
+
+ESDT_TOKEN_PAYMENT_TYPE = f"{MOD_PATH}::esdt_token_payment::EsdtTokenPayment<{DEBUG_API_TYPE}>"
+EGLD_OR_ESDT_TOKEN_IDENTIFIER_TYPE = f"{MOD_PATH}::egld_or_esdt_token_identifier::EgldOrEsdtTokenIdentifier<{DEBUG_API_TYPE}>"
+
+# ManagedVec
+MANAGED_VEC_INNER_TYPE_INDEX = 1
+MANAGED_VEC_TYPE = f"{MOD_PATH}::managed_vec::ManagedVec<{DEBUG_API_TYPE}, {ANY_TYPE}>"
+
+# 4. Elrond wasm - Managed multi value types
+
+# 5. Elrond wasm - heap
+MOD_PATH = "elrond_wasm::types::heap"
+
+HEAP_ADDRESS_TYPE = f"{MOD_PATH}::h256_address::Address"
+BOXED_BYTES_TYPE = f"{MOD_PATH}::boxed_bytes::BoxedBytes"
+
+# 6. Elrond codec - Multi-types
+MOD_PATH = "elrond_codec::multi_types"
+
+OPTIONAL_VALUE_TYPE = f"{MOD_PATH}::multi_value_optional::OptionalValue<{ANY_TYPE}>::{SOME_OR_NONE}"
+
+
+class InvalidHandle(Exception):
+    def __init__(self, raw_handle: int, map_: lldb.value) -> None:
+        map_name = map_.sbvalue.GetName()
+        error = f"<invalid handle: raw_handle {raw_handle} not found in {map_name}>"
+        super().__init__(error)
+
+
+def check_invalid_handle(callable: Callable) -> Callable:
+    def wrapped(*args) -> str:
+        try:
+            return callable(*args)
+        except InvalidHandle as e:
+            return str(e)
+    return wrapped
+
+
+def map_lookup(map_: lldb.value, raw_handle: int) -> lldb.value:
+    for key, value in map_.map:
+        if key == raw_handle:
+            return value
+    raise InvalidHandle(raw_handle, map_)
+
+
+def pick_big_int(managed_types: lldb.value) -> lldb.value:
+    return managed_types.big_int_map
+
+
+def pick_big_float(managed_types: lldb.value) -> lldb.value:
+    return managed_types.big_float_map
+
+
+def pick_managed_buffer(managed_types: lldb.value) -> lldb.value:
+    return managed_types.managed_buffer_map
+
+
+def u64_to_hex(val_u64: int) -> str:
+    """
+    Format int as a 0-padded 64 bit hex.
+    >>> u64_to_hex(1000000)
+    '00000000000f4240'
+    """
+    return f"{val_u64:0>16x}"
+
+
+def u8_to_hex(val_u8: int) -> str:
+    """
+    Format int as a 0-padded 8 bit hex.
+
+    >>> u8_to_hex(10)
+    '0a'
+    """
+    return f"{val_u8:0>2x}"
+
+
+def sb_value_to_hex(valobj_u64: SBValue) -> str:
+    return u64_to_hex(valobj_u64.GetValueAsUnsigned())
+
+
+def hex_to_int(value_hex: str) -> int:
+    """
+    Converts a hex-encoded value to an int.
+
+    >>> hex_to_int("")
+    0
+
+    >>> hex_to_int("000003e8")
+    1000
+    """
+    if len(value_hex) > 0:
+        return int(value_hex, 16)
+    else:
+        return 0
+
+
+def bytes_to_int(bytes: Collection[int]) -> int:
+    bytes_hex = ints_to_hex(bytes)
+    return hex_to_int(bytes_hex)
+
+
+def num_bigint_data_to_int(value_vec_u64: lldb.value) -> int:
+    value_hex = ''.join(reversed(list(map(sb_value_to_hex, value_vec_u64.sbvalue))))
+    return hex_to_int(value_hex)
+
+
+def ints_to_hex(ints: Iterable[int]) -> str:
+    return ''.join(map(u8_to_hex, ints))
+
+
+def buffer_to_bytes(buffer: lldb.value) -> List[int]:
+    return list(map(int, buffer))
+
+
+def buffer_to_hex(buffer: lldb.value) -> str:
+    ints = buffer_to_bytes(buffer)
+    return ints_to_hex(ints)
+
+
+def bytes_to_handle(bytes: List[int]) -> int:
+    """
+    Parses a handle as a signed 32-bit int.
+
+    >>> bytes_to_handle([255, 255, 255, 146])
+    -110
+
+    >>> bytes_to_handle([255, 255, 255, 144])
+    -112
+    """
+    bytes_hex = ints_to_hex(bytes)
+    return struct.unpack('>i', bytearray.fromhex(bytes_hex))[0]
+
+
+def format_buffer_hex_string(buffer_hex: str) -> str:
+    byte_count = len(buffer_hex) // 2
+    return f"({byte_count}) 0x{buffer_hex}"
+
+
+def format_buffer_hex(buffer: lldb.value) -> str:
+    buffer_hex = buffer_to_hex(buffer)
+    return format_buffer_hex_string(buffer_hex)
+
+
+def ascii_to_string(buffer_iterator: Iterable[int]) -> str:
+    """
+    Converts ascii codes to the coresponding string.
+
+    >>> ascii_to_string([116, 101, 115, 116])
+    'test'
+    """
+    return ''.join(map(chr, buffer_iterator))
+
+
+def buffer_as_string(buffer: lldb.value) -> str:
+    buffer_string = ascii_to_string(buffer)
+    return f'"{buffer_string}"'
+
+
+def parse_handles_from_buffer_hex(buffer_hex: str) -> List[int]:
+    """
+    Parses a list of raw handles (signed 32 bit values) from a hex-encoded buffer.
+    >>> parse_handles_from_buffer_hex("ffffff86ffffff83ffffff80")
+    [-122, -125, -128]
+    """
+    raw_handles = []
+    for handle_bytes_iter in zip(*[iter(buffer_hex)] * 8):
+        handle_bytes_hex = ''.join(handle_bytes_iter)
+        raw_handle = struct.unpack('>i', bytearray.fromhex(handle_bytes_hex))[0]
+        raw_handles.append(raw_handle)
+    return raw_handles
+
+
+def format_vec(items: Collection[str]) -> str:
+    """
+    Formats a vec of items.
+    >>> format_vec(["foo", "bar"])
+    '(2) { [0] = foo, [1] = bar }'
+    """
+    count = len(items)
+    indexed_items = [f"[{index}] = {item}" for index, item in enumerate(items)]
+    joined_items = ", ".join(indexed_items)
+    return f"({count}) {{ {joined_items} }}"
+
+
+def sbdata_get_u8_at_index(sbdata: lldb.SBData, err, index: int) -> str:
+    return sbdata.GetUnsignedInt8(err, index)
+
+
+class Handler:
+    def __init__(self) -> None:
+        self.actual_type = None
+
+    def get_actual_type(self) -> lldb.SBType:
+        return self.actual_type
+
+    def summary(self, value: lldb.value) -> str:
+        pass
+
+
+class ManagedType(Handler):
+    def map_picker(self) -> Callable:
+        return pick_managed_buffer
+
+    def lookup(self, full_value: lldb.value) -> lldb.value:
+        return full_value
+
+    def extract_value_from_raw_handle(self, context: lldb.value, raw_handle: int, map_picker: Callable) -> lldb.value:
+        managed_types = context.managed_types
+        chosen_map = map_picker(managed_types)
+        value = map_lookup(chosen_map, raw_handle)
+        return value
+
+    @check_invalid_handle
+    def summary_from_raw_handle(self, raw_handle: int, context: lldb.value, type_info: lldb.SBType) -> str:
+        map_picker = self.map_picker()
+        value = self.extract_value_from_raw_handle(context, raw_handle, map_picker)
+        return self.value_summary(value, context, type_info)
+
+    def summary(self, original_value: lldb.value) -> str:
+        type_info = original_value.sbvalue.GetType()
+        managed_value = self.lookup(original_value)
+        handle = managed_value.handle
+        raw_handle = int(handle.raw_handle)
+        context = handle.context
+        return self.summary_from_raw_handle(raw_handle, context, type_info)
+
+    def value_summary(self, value: lldb.value, context: lldb.value, type_info: lldb.SBType) -> str:
+        pass
+
+
+class ManagedVecItem(Handler):
+    def item_size(self) -> int:
+        pass
+
+    def summarize_item(self, bytes: List[int], context: lldb.value, type_info: lldb.SBType) -> str:
+        pass
+
+
+class PlainManagedVecItem(ManagedVecItem, ManagedType):
+    """
+    ManagedVecItem implementation for any ManagedType which is stored in the ManagedVec only by its handle.
+    """
+
+    def item_size(self) -> int:
+        return 4
+
+    def summarize_item(self, handle_bytes: List[int], context: lldb.value, type_info: lldb.SBType) -> str:
+        raw_handle = bytes_to_handle(handle_bytes)
+        return self.summary_from_raw_handle(raw_handle, context, type_info)
+
+
+class NumBigInt(Handler):
+    def summary(self, num_big_int: lldb.value) -> str:
+        value_int = num_bigint_data_to_int(num_big_int.data.data)
+        if num_big_int.sign.sbvalue.GetValue() == 'num_bigint::bigint::Sign::Minus':
+            return str(-value_int)
+        return str(value_int)
+
+
+class NumBigUint(Handler):
+    def summary(self, num_big_uint: lldb.value) -> str:
+        value_int = num_bigint_data_to_int(num_big_uint.data)
+        return str(value_int)
+
+
+class BigInt(PlainManagedVecItem, ManagedType):
+    def map_picker(self) -> Callable:
+        return pick_big_int
+
+    def value_summary(self, value: lldb.value, context: lldb.value, type_info: lldb.SBType) -> str:
+        return str(value.sbvalue.GetSummary())
+
+
+class BigFloat(PlainManagedVecItem, ManagedType):
+    def map_picker(self) -> Callable:
+        return pick_big_float
+
+    def value_summary(self, value: lldb.value, context: lldb.value, type_info: lldb.SBType) -> str:
+        return str(value.sbvalue.GetValue())
+
+
+class ManagedBuffer(PlainManagedVecItem, ManagedType):
+    def value_summary(self, buffer: lldb.value, context: lldb.value, type_info: lldb.SBType) -> str:
+        return format_buffer_hex(buffer)
+
+
+class TokenIdentifier(PlainManagedVecItem, ManagedType):
+    def lookup(self, token_identifier: lldb.value) -> lldb.value:
+        return token_identifier.buffer
+
+    def value_summary(self, buffer: lldb.value, context: lldb.value, type_info: lldb.SBType) -> str:
+        return buffer_as_string(buffer)
+
+
+class ManagedAddress(PlainManagedVecItem, ManagedType):
+    def lookup(self, managed_address: lldb.value) -> lldb.value:
+        return managed_address.bytes.buffer
+
+    def value_summary(self, buffer: lldb.value, context: lldb.value, type_info: lldb.SBType) -> str:
+        return format_buffer_hex(buffer)
+
+
+class ManagedByteArray(PlainManagedVecItem, ManagedType):
+    def lookup(self, managed_byte_array: lldb.value) -> lldb.value:
+        return managed_byte_array.buffer
+
+    def value_summary(self, buffer: lldb.value, context: lldb.value, type_info: lldb.SBType) -> str:
+        return format_buffer_hex(buffer)
+
+
+class ManagedOption(PlainManagedVecItem, ManagedType):
+    def summary_from_raw_handle(self, raw_handle: int, context: lldb.value, type_info: lldb.SBType) -> str:
+        if raw_handle == MANAGED_OPTION_NONE_HANDLE:
+            return "ManagedOption::none()"
+        inner_type_handler, inner_type = get_inner_type_handler(type_info, MANAGED_OPTION_INNER_TYPE_INDEX)
+        assert(isinstance(inner_type_handler, ManagedType))
+        inner_summary = inner_type_handler.summary_from_raw_handle(raw_handle, context, inner_type)
+        return f"ManagedOption::some({inner_summary})"
+
+
+def split_bytes(bytes: List[int], sizes: Iterable[int]) -> List[List[int]]:
+    """
+    Split a byte array into multiple chunks where the length varies.
+    >>> split_bytes([1, 2, 3, 4, 5, 6], [2, 3, 1])
+    [[1, 2], [3, 4, 5], [6]]
+    """
+    chunks = []
+    i = 0
+    for size in sizes:
+        chunks.append(bytes[i: i + size])
+        i += size
+    return chunks
+
+
+def split_bytes_fixed_size(bytes: List[int], size: int) -> List[List[int]]:
+    """
+    Split a byte array into fixed-size chunks.
+    >>> split_bytes_fixed_size([1, 2, 3, 4, 5, 6, 7, 8, 9], 3)
+    [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    """
+    chunks = []
+    i = 0
+    byte_count = len(bytes)
+    while i < byte_count:
+        chunks.append(bytes[i: i + size])
+        i += size
+    return chunks
+
+
+class EsdtTokenPayment(ManagedVecItem, ManagedType):
+    COMPONENT_SIZES = [4, 8, 4]
+
+    def summary(self, payment: lldb.value) -> str:
+        token_id = payment.token_identifier.sbvalue.GetSummary()
+        nonce = int(payment.token_nonce)
+        amount = payment.amount.sbvalue.GetSummary()
+        return self.to_string(token_id, nonce, amount)
+
+    def item_size(self) -> int:
+        return sum(self.COMPONENT_SIZES)
+
+    def summarize_item(self, bytes: List[int], context: lldb.value, type_info: lldb.SBType) -> str:
+        token_id_handle_bytes, nonce_bytes, amount_handle_bytes = split_bytes(bytes, self.COMPONENT_SIZES)
+        token_id = TokenIdentifier().summarize_item(token_id_handle_bytes, context, None)
+        nonce = bytes_to_int(nonce_bytes)
+        amount = BigInt().summarize_item(amount_handle_bytes, context, None)
+        return self.to_string(token_id, nonce, amount)
+
+    def to_string(self, token_id: str, nonce: int, amount: str) -> str:
+        return f"{{ token_identifier: {token_id}, nonce: {nonce}, amount: {amount} }}"
+
+
+class EgldOrEsdtTokenIdentifier(PlainManagedVecItem, ManagedType):
+    def lookup(self, egld_or_esdt_token_identifier: lldb.value) -> lldb.value:
+        return egld_or_esdt_token_identifier.data
+
+    @check_invalid_handle
+    def summary_from_raw_handle(self, raw_handle: int, context: lldb.value, type_info: lldb.SBType) -> str:
+        if raw_handle == MANAGED_OPTION_NONE_HANDLE:
+            return "EgldOrEsdtTokenIdentifier::egld()"
+        token_summary = TokenIdentifier().summary_from_raw_handle(raw_handle, context, None)
+        return f"EgldOrEsdtTokenIdentifier::esdt({token_summary})"
+
+
+class ManagedVec(PlainManagedVecItem, ManagedType):
+    def lookup(self, managed_vec: lldb.value) -> lldb.value:
+        return managed_vec.buffer
+
+    def value_summary(self, value: lldb.value, context: lldb.value, type_info: lldb.SBType) -> str:
+        item_handler, inner_type = get_inner_type_handler(type_info, MANAGED_VEC_INNER_TYPE_INDEX)
+        assert(isinstance(item_handler, ManagedVecItem))
+        buffer_bytes = buffer_to_bytes(value)
+        item_size = item_handler.item_size()
+        bytes_of_all_items = split_bytes_fixed_size(buffer_bytes, item_size)
+        items = [item_handler.summarize_item(bytes, context, inner_type) for bytes in bytes_of_all_items]
+        return format_vec(items)
+
+
+class HeapAddress(Handler):
+    def summary(self, heap_address: lldb.value) -> str:
+        buffer = lldb.value(heap_address.sbvalue.GetChildAtIndex(0).GetChildAtIndex(0))
+        return format_buffer_hex(buffer)
+
+
+class BoxedBytes(Handler):
+    def summary(self, boxed_bytes: lldb.value) -> str:
+        box = lldb.value(boxed_bytes.sbvalue.GetChildAtIndex(0))
+        length = int(box.length)
+        data = box.data_ptr.sbvalue.GetPointeeData(0, length)
+        raw = lldb.SBData.read_data_helper(data, sbdata_get_u8_at_index, 1).all()
+        buffer_hex = ints_to_hex(raw)
+        return format_buffer_hex_string(buffer_hex)
+
+
+class OptionalValue(Handler):
+    def summary(self, optional_value: lldb.value) -> str:
+        if optional_value.sbvalue.GetType().GetName().endswith('::Some'):
+            summary = optional_value.sbvalue.GetChildAtIndex(0).GetSummary()
+            return f"OptionalValue::Some({summary})"
+        return "OptionalValue::None"
+
+
+ELROND_WASM_TYPE_HANDLERS = [
+    # 1. num_bigint library
+    (NUM_BIG_INT_TYPE, NumBigInt),
+    (NUM_BIG_UINT_TYPE, NumBigUint),
+    # 2. Elrond wasm - Managed basic types
+    (BIG_INT_TYPE, BigInt),
+    (BIG_UINT_TYPE, BigInt),
+    (BIG_FLOAT_TYPE, BigFloat),
+    (MANAGED_BUFFER_TYPE, ManagedBuffer),
+    # 3. Elrond wasm - Managed wrapped types
+    (TOKEN_IDENTIFIER_TYPE, TokenIdentifier),
+    (MANAGED_ADDRESS_TYPE, ManagedAddress),
+    (MANAGED_BYTE_ARRAY_TYPE, ManagedByteArray),
+    (MANAGED_OPTION_TYPE, ManagedOption),
+    (ESDT_TOKEN_PAYMENT_TYPE, EsdtTokenPayment),
+    (EGLD_OR_ESDT_TOKEN_IDENTIFIER_TYPE, EgldOrEsdtTokenIdentifier),
+    (MANAGED_VEC_TYPE, ManagedVec),
+    # 4. Elrond wasm - Managed multi value types
+    # 5. Elrond wasm - heap
+    (HEAP_ADDRESS_TYPE, HeapAddress),
+    (BOXED_BYTES_TYPE, BoxedBytes),
+    # 6. Elrond codec - Multi-types
+    (OPTIONAL_VALUE_TYPE, OptionalValue),
+]
+
+
+class UnknownType(Exception):
+    def __init__(self, type_name: str) -> None:
+        super().__init__(f'unknown type: {type_name}')
+
+
+def get_inner_type_handler(type_info: lldb.SBType, inner_type_index: int) -> Tuple[Handler, lldb.SBType]:
+    inner_type = type_info.GetTemplateArgumentType(inner_type_index).GetCanonicalType()
+    handler = get_handler(inner_type.GetName())
+    return handler, inner_type
+
+
+def get_handler(type_name: str) -> Handler:
+    for rust_type, handler_class in ELROND_WASM_TYPE_HANDLERS:
+        if re.fullmatch(rust_type, type_name) is not None:
+            return handler_class()
+    raise UnknownType(type_name)
+
+
+def summarize_handler(handler_type: Type[Handler], valobj: SBValue, dictionary) -> str:
+    handler: Handler = handler_type()
+    value = lldb.value(valobj)
+    return handler.summary(value)
+
+
+def __lldb_init_module(debugger: SBDebugger, dict):
+    python_module_name = Path(__file__).with_suffix('').name
+
+    for rust_type, handler_class in ELROND_WASM_TYPE_HANDLERS:
+        # Add summary binding
+        summary_function_name = f"handle{handler_class.__name__}"
+        globals()[summary_function_name] = partial(summarize_handler, handler_class)
+
+        summary_command = f'type summary add -x "^{rust_type}$" -F {python_module_name}.{summary_function_name} --category elrond-wasm'
+        debugger.HandleCommand(summary_command)
+        # print(f"Registered: {summary_command}")
+
+    # Enable categories
+    debugger.HandleCommand('type category enable elrond-wasm')

--- a/tools/rust-debugger/pretty-printers/mypy.ini
+++ b/tools/rust-debugger/pretty-printers/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.9
+
+[mypy-lldb]
+ignore_missing_imports = True


### PR DESCRIPTION
Added `elrond_wasm_lldb_pretty_printers.py` - a script which contains pretty printers for most managed types, in order to display them properly when running the rust debugger on any contract test. This script is automatically loaded by LLDB (the debugger used by rust), provided that it has been installed. The installation of the script is handled by the Elrond VS code extension in PR https://github.com/ElrondNetwork/elrond-ide-vscode/pull/55.

Added unit tests in the `tools/rust-debugger/format-tests` folder, as well as a github action (`.github/workflows/lldb-formatter-tests.yml`) which runs them. The tests are structured as follows:
- In `format-tests/src/format_tests.rs` we set up some variables (managed types, collections etc.) that we want to check, together with their expected representation in the rust debugger.
- The `format-tests/src/check_debugger_values.py` script is a helper which checks that the variables defined in `format_tests.rs` have the expected values. It generates a report.
- The `format-tests/tests/run_format_tests.rs` sets up the debugger, configures LLDB and starts it, then it parses the report generated by the `check_debugger_values.py`

Note that the tests are in a separate cargo workspace and will not run if `cargo test` is called normally in the root folder. In order to run the tests, first navigate to the proper folder.
```
cd tools/rust-debugger/format-tests
cargo test
```
Additionally, this test assumes that Visual Studio Code and the [CodeLLDB](https://github.com/vadimcn/vscode-lldb) extension are installed.