### PR TITLE
implement FromIterator trait for MultiValueEncoded, implement Debug +…

### DIFF
--- a/elrond-codec/src/multi_types/multi_value_tuple.rs
+++ b/elrond-codec/src/multi_types/multi_value_tuple.rs
@@ -3,12 +3,26 @@ use crate::{
     TopDecodeMultiLength, TopEncodeMulti, TopEncodeMultiOutput,
 };
 
-macro_rules! multi_value_impls {
-    ($(($mv_struct:ident $len:tt $($n:tt $name:ident)+) )+) => {
+macro_rules! multi_value_impls_debug {
+        ($(($mv_struct:ident $len:tt $($n:tt $name:ident)+) )+) => {
+        $(
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct $mv_struct<$($name,)+>(pub ($($name,)+));
+        )+
+    }
+}
+macro_rules! multi_value_impls_no_debug {
+        ($(($mv_struct:ident $len:tt $($n:tt $name:ident)+) )+) => {
         $(
             #[derive(Clone)]
             pub struct $mv_struct<$($name,)+>(pub ($($name,)+));
+        )+
+    }
+}
 
+macro_rules! multi_value_impls {
+    ($(($mv_struct:ident $len:tt $($n:tt $name:ident)+) )+) => {
+        $(
             impl<$($name),+> From<($($name,)+)> for $mv_struct<$($name,)+> {
                 #[inline]
                 fn from(tuple: ($($name,)+)) -> Self {
@@ -64,6 +78,28 @@ macro_rules! multi_value_impls {
             }
         )+
     }
+}
+
+multi_value_impls_debug! {
+    (MultiValue2   2 0 T0 1 T1)
+    (MultiValue3   3 0 T0 1 T1 2 T2)
+    (MultiValue4   4 0 T0 1 T1 2 T2 3 T3)
+    (MultiValue5   5 0 T0 1 T1 2 T2 3 T3 4 T4)
+    (MultiValue6   6 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5)
+    (MultiValue7   7 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6)
+    (MultiValue8   8 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7)
+    (MultiValue9   9 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8)
+    (MultiValue10 10 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9)
+    (MultiValue11 11 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10)
+}
+// tuples with size 12+ don't implement Debug + PartialEq traits
+// https://doc.rust-lang.org/std/primitive.tuple.html#trait-implementations-1
+multi_value_impls_no_debug! {
+    (MultiValue12 12 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11)
+    (MultiValue13 13 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12)
+    (MultiValue14 14 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13)
+    (MultiValue15 15 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14)
+    (MultiValue16 16 0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15)
 }
 
 multi_value_impls! {

--- a/elrond-wasm-debug/tests/multi_value_encoded_test.rs
+++ b/elrond-wasm-debug/tests/multi_value_encoded_test.rs
@@ -26,3 +26,41 @@ fn test_multi_value_encoded_5() {
     }
     assert_eq!(multi_value_1.len(), 11);
 }
+
+#[test]
+fn test_multi_value5_eq_test() {
+    let multi_value1 = MultiValue5::from((1, 2, 3, 4, 5));
+    let multi_value2 = MultiValue5::from((1, 2, 3, 4, 5));
+    assert_eq!(multi_value1, multi_value2)
+}
+
+#[test]
+fn test_multi_value5_ne_test() {
+    let multi_value1 = MultiValue5::from((1, 2, 3, 4, 5));
+    let multi_value2 = MultiValue5::from((1, 2, 3, 4, 4));
+    assert_ne!(multi_value1, multi_value2)
+}
+
+#[test]
+fn test_multi_value5_from_iterator_trait() {
+    let _ = DebugApi::dummy();
+    let mut multi_value1 =
+        MultiValueEncoded::<DebugApi, MultiValue5<u64, u64, u64, u64, u64>>::new();
+    for i in 1..=10 {
+        multi_value1.push(MultiValue5::from((i, i, i, i, i)));
+    }
+    let mut multi_value_expected =
+        MultiValueEncoded::<DebugApi, MultiValue5<u64, u64, u64, u64, u64>>::new();
+    for i in 1..=5 {
+        multi_value_expected.push(MultiValue5::from((i, i, i, i, i)));
+    }
+
+    let collected_vec = multi_value1
+        .into_iter()
+        .map(|x| x.into_tuple())
+        .filter(|(x, _, _, _, _)| x <= &5)
+        .map(|t| t.into())
+        .collect::<MultiValueEncoded<DebugApi, MultiValue5<u64, u64, u64, u64, u64>>>();
+
+    assert_eq!(collected_vec, multi_value_expected);
+}

--- a/elrond-wasm/src/types/managed/multi_value/multi_value_encoded.rs
+++ b/elrond-wasm/src/types/managed/multi_value/multi_value_encoded.rs
@@ -5,7 +5,7 @@ use crate::{
     err_msg,
     types::{ManagedArgBuffer, ManagedBuffer, ManagedType, ManagedVec, ManagedVecItem},
 };
-use core::marker::PhantomData;
+use core::{iter::FromIterator, marker::PhantomData};
 use elrond_codec::{
     try_cast_execute_or_else, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, TopDecode,
     TopDecodeMulti, TopDecodeMultiInput, TopDecodeMultiLength, TopEncode, TopEncodeMulti,
@@ -23,7 +23,7 @@ use elrond_codec::{
 ///
 /// Since it can contain multi-values, the number of actual items it contains cannot be determined without fully decoding.
 ///
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, PartialEq)]
 pub struct MultiValueEncoded<M, T>
 where
     M: ManagedTypeApi,
@@ -261,4 +261,16 @@ where
     T: TopEncodeMulti,
     U: CodecFrom<T>,
 {
+}
+
+impl<M, V> FromIterator<V> for MultiValueEncoded<M, V>
+where
+    M: ManagedTypeApi,
+    V: TopEncodeMulti,
+{
+    fn from_iter<T: IntoIterator<Item = V>>(iter: T) -> Self {
+        let mut result: MultiValueEncoded<M, V> = MultiValueEncoded::new();
+        iter.into_iter().for_each(|f| result.push(f));
+        result
+    }
 }


### PR DESCRIPTION
I implemented FromIterator trait for MultiValueEncoded and also the Debug + PartialEq Traits for MultiValue1 - MultiValue11

I couldn't implement them for MultiValue12+ as Rust tuples with size 12+ don't implement Debug + PartialEq traits (see: https://doc.rust-lang.org/std/primitive.tuple.html#trait-implementations-1)

I'm open to changing the code if you can think of a more elegant solution.

I think it is of value for developers to be able to easily check equality of MultiValues (even if it's just for length up until 11).