### PR TITLE
Multisig fixes after audit

### DIFF
--- a/contracts/examples/multisig/mandos/call_other_shard-1.scen.json
+++ b/contracts/examples/multisig/mandos/call_other_shard-1.scen.json
@@ -9,6 +9,23 @@
             "path": "steps/deploy_minimal.steps.json"
         },
         {
+            "step": "setState",
+            "accounts": {
+                "address:faucet": {
+                    "balance": "10"
+                }
+            }
+        },
+        {
+            "step": "transfer",
+            "id": "1",
+            "tx": {
+                "from": "address:faucet",
+                "to": "sc:multisig",
+                "egldValue": "10"
+            }
+        },
+        {
             "step": "scCall",
             "id": "propose-send-to-other-shard-1",
             "tx": {
@@ -17,7 +34,7 @@
                 "function": "proposeTransferExecute",
                 "arguments": [
                     "sc:other-shard-1",
-                    "0"
+                    "10"
                 ],
                 "gasLimit": "100,000,000",
                 "gasPrice": "0"

--- a/contracts/examples/multisig/mandos/changeBoard.scen.json
+++ b/contracts/examples/multisig/mandos/changeBoard.scen.json
@@ -22,6 +22,10 @@
         },
         {
             "step": "externalSteps",
+            "path": "steps/rem_unknown.steps.json"
+        },
+        {
+            "step": "externalSteps",
             "path": "steps/sign_unsign_bad_action.steps.json"
         }
     ]

--- a/contracts/examples/multisig/mandos/steps/rem_unknown.steps.json
+++ b/contracts/examples/multisig/mandos/steps/rem_unknown.steps.json
@@ -1,23 +1,22 @@
 {
-    "name": "adder",
-    "comment": "add then check",
+    "comment": "remove a user that doesn't exist",
     "steps": [
         {
             "step": "scCall",
-            "id": "rem-alice-prop",
+            "id": "rem-unknown-prop",
             "tx": {
                 "from": "address:paul",
                 "to": "sc:multisig",
                 "function": "proposeRemoveUser",
                 "arguments": [
-                    "address:alice"
+                    "address:unknown"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
             },
             "expect": {
                 "out": [
-                    "3"
+                    "4"
                 ],
                 "status": "",
                 "logs": "*",
@@ -27,13 +26,13 @@
         },
         {
             "step": "scCall",
-            "id": "rem-alice-sign-bob",
+            "id": "rem-unknown-sign-bob",
             "tx": {
                 "from": "address:bob",
                 "to": "sc:multisig",
                 "function": "sign",
                 "arguments": [
-                    "3"
+                    "4"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -48,13 +47,13 @@
         },
         {
             "step": "scCall",
-            "id": "rem-alice-sign-charlie",
+            "id": "rem-unknown-sign-charlie",
             "tx": {
                 "from": "address:charlie",
                 "to": "sc:multisig",
                 "function": "sign",
                 "arguments": [
-                    "3"
+                    "4"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -69,13 +68,13 @@
         },
         {
             "step": "scCall",
-            "id": "rem-alice--perform",
+            "id": "rem-unknown-perform",
             "tx": {
                 "from": "address:paul",
                 "to": "sc:multisig",
                 "function": "performAction",
                 "arguments": [
-                    "3"
+                    "4"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"

--- a/contracts/examples/multisig/src/multisig_perform.rs
+++ b/contracts/examples/multisig/src/multisig_perform.rs
@@ -32,7 +32,17 @@ pub trait MultisigPerformModule:
     /// - convert between board member and proposer
     /// Will keep the board size and proposer count in sync.
     fn change_user_role(&self, action_id: usize, user_address: ManagedAddress, new_role: UserRole) {
-        let user_id = self.user_mapper().get_or_create_user(&user_address);
+        let user_id = if new_role == UserRole::None {
+            // avoid creating a new user just to delete it
+            let user_id = self.user_mapper().get_user_id(&user_address);
+            if user_id == 0 {
+                return;
+            }
+            user_id
+        } else {
+            self.user_mapper().get_or_create_user(&user_address)
+        };
+
         let user_id_to_role_mapper = self.user_id_to_role(user_id);
         let old_role = user_id_to_role_mapper.get();
         user_id_to_role_mapper.set(new_role);

--- a/contracts/examples/multisig/src/multisig_propose.rs
+++ b/contracts/examples/multisig/src/multisig_propose.rs
@@ -54,6 +54,11 @@ pub trait MultisigProposeModule: crate::multisig_state::MultisigStateModule {
         opt_function: OptionalValue<ManagedBuffer>,
         arguments: MultiValueEncoded<ManagedBuffer>,
     ) -> CallActionData<Self::Api> {
+        require!(
+            egld_amount > 0 || opt_function.is_some(),
+            "proposed action has no effect"
+        );
+
         let endpoint_name = match opt_function {
             OptionalValue::Some(data) => data,
             OptionalValue::None => ManagedBuffer::new(),

--- a/contracts/examples/multisig/tests/multisig_rust_test.rs
+++ b/contracts/examples/multisig/tests/multisig_rust_test.rs
@@ -215,6 +215,16 @@ fn transfer_execute_to_user_test() {
         &rust_biguint!(egld_amount),
     );
 
+    // failed attempt
+    let (_, tx_result) = ms_setup.call_propose(ActionRaw::SendTransferExecute(CallActionDataRaw {
+        to: user_addr.clone(),
+        egld_amount: rust_biguint!(0),
+        endpoint_name: BoxedBytes::empty(),
+        arguments: Vec::new(),
+    }));
+    tx_result.assert_user_error("proposed action has no effect");
+
+    // propose
     let (action_id, tx_result) =
         ms_setup.call_propose(ActionRaw::SendTransferExecute(CallActionDataRaw {
             to: user_addr.clone(),

--- a/contracts/examples/multisig/wasm/Cargo.lock
+++ b/contracts/examples/multisig/wasm/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "elrond-codec"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arrayvec",
  "elrond-codec-derive",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "elrond-codec-derive"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "hex",
  "proc-macro2",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "elrond-wasm"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "bitflags",
  "elrond-codec",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "elrond-wasm-derive"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "hex",
  "proc-macro2",
@@ -89,21 +89,21 @@ dependencies = [
 
 [[package]]
 name = "elrond-wasm-modules"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "elrond-wasm",
 ]
 
 [[package]]
 name = "elrond-wasm-node"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "elrond-wasm",
 ]
 
 [[package]]
 name = "elrond-wasm-output"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "elrond-wasm-node",
  "wee_alloc",

--- a/elrond-codec/src/multi_types/multi_value_optional.rs
+++ b/elrond-codec/src/multi_types/multi_value_optional.rs
@@ -33,6 +33,14 @@ impl<T> OptionalValue<T> {
             OptionalValue::None => None,
         }
     }
+
+    pub fn is_some(&self) -> bool {
+        matches!(self, OptionalValue::Some(_))
+    }
+
+    pub fn is_none(&self) -> bool {
+        !self.is_some()
+    }
 }
 
 impl<T> TopEncodeMulti for OptionalValue<T>

--- a/elrond-wasm/src/storage/mappers/user_mapper.rs
+++ b/elrond-wasm/src/storage/mappers/user_mapper.rs
@@ -149,15 +149,15 @@ where
     {
         let mut user_count = self.get_user_count();
         for address in address_iter {
-            let mut user_id = self.get_user_id(&address);
+            let user_id = self.get_user_id(&address);
             if user_id > 0 {
                 user_id_lambda(user_id, false);
             } else {
                 user_count += 1;
-                user_id = user_count;
-                self.set_user_id(&address, user_id);
-                self.set_user_address(user_id, &address);
-                user_id_lambda(user_id, true);
+                let new_user_id = user_count;
+                self.set_user_id(&address, new_user_id);
+                self.set_user_address(new_user_id, &address);
+                user_id_lambda(new_user_id, true);
             }
         }
         self.set_user_count(user_count);

--- a/elrond-wasm/src/storage/mappers/user_mapper.rs
+++ b/elrond-wasm/src/storage/mappers/user_mapper.rs
@@ -128,10 +128,9 @@ where
     pub fn get_or_create_user(&self, address: &ManagedAddress<SA>) -> usize {
         let mut user_id = self.get_user_id(address);
         if user_id == 0 {
-            let mut user_count = self.get_user_count();
-            user_count += 1;
-            self.set_user_count(user_count);
-            user_id = user_count;
+            let next_user_count = self.get_user_count() + 1;
+            self.set_user_count(next_user_count);
+            user_id = next_user_count;
             self.set_user_id(address, user_id);
             self.set_user_address(user_id, address);
         }


### PR DESCRIPTION
Short description of audit findings:

1. variable does not need to be mutable
Severity: Informative | Category: Code Quality
Description: user_count does not need to be mutable in UserMapper.get_or_create_user.
Recommendation: Change the code so that user_count is not mutable.
2. Issue: variable does not need to be mutable
Severity: Informative | Category: Code Quality
Description: user_id probably does not need to be mutable in UserMapper.get_or_create_users
Recommendation: Change the code so that user_id is not mutable.
3. Issue: Users added to storage when deleting
Severity: Low | Difficulty: High | Category: Improvement
Description: The multisig code identifies that a user is not known to the contract by checking whether his role is None. Besides that, usually the multisig code gets a user’s ID from the user’s address with a function that adds the user to the id <-> address double mapping if it’s not already there. The function that deletes a user does exactly this: First, it ensures that the user is in the id <-> address double mapping, adding it if it’s not already there, then it sets its role to None.
This means that, when removing a user that is not known to the contract, the user gets added to the id <-> address double mapping, which is weird. This is not a big issue since the board has to vote for this, and it would be weird to have a successful vote on removing a non-existing user. Also, the contract works just fine even if this happens.
Recommendation: Skip removing the user if it’s not in the id <-> address mapping
4. Issue: Check that amount>0 when proposing transfers
Severity: Low | Difficulty: Easy | Category: Functional Correctness
Description: Actions that involve transfers (SendTransferExecute and SendAsyncCall) fail when executing if the amount to transfer is 0.
Recommendation: Check whether the amount is 0 when proposing the actions.