### PR TITLE
removed TopEncodeNoErr and NestedEncodeNoErr

### DIFF
--- a/elrond-codec/src/impl_for_types/impl_bool.rs
+++ b/elrond-codec/src/impl_for_types/impl_bool.rs
@@ -1,7 +1,7 @@
 use crate::{
-    dep_encode_from_no_err, dep_encode_num_mimic, DecodeError, DecodeErrorHandler,
-    EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeNoErr,
-    NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput, TypeInfo,
+    dep_encode_num_mimic, DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
+    NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
+    TopEncodeOutput, TypeInfo,
 };
 
 impl TopEncode for bool {

--- a/elrond-codec/src/impl_for_types/impl_bool.rs
+++ b/elrond-codec/src/impl_for_types/impl_bool.rs
@@ -1,21 +1,26 @@
 use crate::{
-    dep_encode_from_no_err, dep_encode_num_mimic, top_encode_from_no_err, DecodeError,
-    DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
-    NestedEncodeNoErr, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeNoErr,
-    TopEncodeOutput, TypeInfo,
+    dep_encode_from_no_err, dep_encode_num_mimic, DecodeError, DecodeErrorHandler,
+    EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeNoErr,
+    NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput, TypeInfo,
 };
 
-impl TopEncodeNoErr for bool {
-    fn top_encode_no_err<O: TopEncodeOutput>(&self, output: O) {
+impl TopEncode for bool {
+    const TYPE_INFO: TypeInfo = TypeInfo::Bool;
+
+    #[inline]
+    fn top_encode_or_handle_err<O, H>(&self, output: O, _h: H) -> Result<(), H::HandledErr>
+    where
+        O: TopEncodeOutput,
+        H: EncodeErrorHandler,
+    {
         // only using signed because this one is implemented in Arwen, unsigned is not
         // TODO: change to set_u64
         // true -> 1i64
         // false -> 0i64
         output.set_i64(i64::from(*self));
+        Ok(())
     }
 }
-
-top_encode_from_no_err! {bool, TypeInfo::Bool}
 
 impl TopDecode for bool {
     const TYPE_INFO: TypeInfo = TypeInfo::Bool;

--- a/elrond-codec/src/impl_for_types/impl_num_signed.rs
+++ b/elrond-codec/src/impl_for_types/impl_num_signed.rs
@@ -1,8 +1,7 @@
 use crate::{
-    dep_encode_from_no_err, dep_encode_num_mimic, num_conv::universal_decode_number, DecodeError,
-    DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
-    NestedEncodeNoErr, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
-    TypeInfo,
+    dep_encode_num_mimic, num_conv::universal_decode_number, DecodeError, DecodeErrorHandler,
+    EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput,
+    TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput, TypeInfo,
 };
 
 macro_rules! top_encode_num_signed {

--- a/elrond-codec/src/impl_for_types/impl_num_signed.rs
+++ b/elrond-codec/src/impl_for_types/impl_num_signed.rs
@@ -1,20 +1,23 @@
 use crate::{
-    dep_encode_from_no_err, dep_encode_num_mimic, num_conv::universal_decode_number,
-    top_encode_from_no_err, DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
-    NestedDecodeInput, NestedEncode, NestedEncodeNoErr, NestedEncodeOutput, TopDecode,
-    TopDecodeInput, TopEncode, TopEncodeNoErr, TopEncodeOutput, TypeInfo,
+    dep_encode_from_no_err, dep_encode_num_mimic, num_conv::universal_decode_number, DecodeError,
+    DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
+    NestedEncodeNoErr, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
+    TypeInfo,
 };
 
 macro_rules! top_encode_num_signed {
     ($num_type:ty, $size_in_bits:expr, $type_info:expr) => {
-        impl TopEncodeNoErr for $num_type {
+        impl TopEncode for $num_type {
             #[inline]
-            fn top_encode_no_err<O: TopEncodeOutput>(&self, output: O) {
+            fn top_encode_or_handle_err<O, H>(&self, output: O, _h: H) -> Result<(), H::HandledErr>
+            where
+                O: TopEncodeOutput,
+                H: EncodeErrorHandler,
+            {
                 output.set_i64(*self as i64);
+                Ok(())
             }
         }
-
-        top_encode_from_no_err! {$num_type, $type_info}
     };
 }
 

--- a/elrond-codec/src/impl_for_types/impl_num_unsigned.rs
+++ b/elrond-codec/src/impl_for_types/impl_num_unsigned.rs
@@ -1,8 +1,8 @@
 use crate::{
-    dep_encode_from_no_err, dep_encode_num_mimic, num_conv::universal_decode_number,
-    top_encode_from_no_err, DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
-    NestedDecodeInput, NestedEncode, NestedEncodeNoErr, NestedEncodeOutput, TopDecode,
-    TopDecodeInput, TopEncode, TopEncodeNoErr, TopEncodeOutput, TypeInfo,
+    dep_encode_from_no_err, dep_encode_num_mimic, num_conv::universal_decode_number, DecodeError,
+    DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
+    NestedEncodeNoErr, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
+    TypeInfo,
 };
 
 // No reversing needed for u8, because it is a single byte.
@@ -34,13 +34,17 @@ dep_encode_num_unsigned! {u16, 16, TypeInfo::U16}
 
 macro_rules! top_encode_num_unsigned {
     ($num_type:ty, $size_in_bits:expr, $type_info:expr) => {
-        impl TopEncodeNoErr for $num_type {
+        impl TopEncode for $num_type {
             #[inline]
-            fn top_encode_no_err<O: TopEncodeOutput>(&self, output: O) {
+            fn top_encode_or_handle_err<O, H>(&self, output: O, _h: H) -> Result<(), H::HandledErr>
+            where
+                O: TopEncodeOutput,
+                H: EncodeErrorHandler,
+            {
                 output.set_u64(*self as u64);
+                Ok(())
             }
         }
-        top_encode_from_no_err! {$num_type, $type_info}
     };
 }
 

--- a/elrond-codec/src/impl_for_types/impl_unit.rs
+++ b/elrond-codec/src/impl_for_types/impl_unit.rs
@@ -1,13 +1,20 @@
 use crate::{
-    dep_encode_from_no_err, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
-    NestedDecodeInput, NestedEncode, NestedEncodeNoErr, NestedEncodeOutput, TypeInfo,
+    DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
+    NestedEncodeOutput, TypeInfo,
 };
 
-impl NestedEncodeNoErr for () {
-    fn dep_encode_no_err<O: NestedEncodeOutput>(&self, _: &mut O) {}
-}
+impl NestedEncode for () {
+    const TYPE_INFO: TypeInfo = TypeInfo::Unit;
 
-dep_encode_from_no_err! {(), TypeInfo::Unit}
+    #[inline]
+    fn dep_encode_or_handle_err<O, H>(&self, _: &mut O, _h: H) -> Result<(), H::HandledErr>
+    where
+        O: NestedEncodeOutput,
+        H: EncodeErrorHandler,
+    {
+        Ok(())
+    }
+}
 
 impl NestedDecode for () {
     const TYPE_INFO: TypeInfo = TypeInfo::Unit;

--- a/elrond-codec/src/impl_for_types/local_macro.rs
+++ b/elrond-codec/src/impl_for_types/local_macro.rs
@@ -35,22 +35,3 @@ macro_rules! dep_encode_from_no_err {
         }
     };
 }
-
-#[macro_export]
-macro_rules! top_encode_from_no_err {
-    ($type:ty, $type_info:expr) => {
-        impl TopEncode for $type {
-            const TYPE_INFO: TypeInfo = $type_info;
-
-            #[inline]
-            fn top_encode_or_handle_err<O, H>(&self, output: O, _h: H) -> Result<(), H::HandledErr>
-            where
-                O: TopEncodeOutput,
-                H: EncodeErrorHandler,
-            {
-                self.top_encode_no_err(output);
-                Ok(())
-            }
-        }
-    };
-}

--- a/elrond-codec/src/impl_for_types/local_macro.rs
+++ b/elrond-codec/src/impl_for_types/local_macro.rs
@@ -2,35 +2,20 @@
 #[macro_export]
 macro_rules! dep_encode_num_mimic {
     ($num_type:ty, $mimic_type:ident, $type_info:expr) => {
-        impl NestedEncodeNoErr for $num_type {
-            #[inline]
-            fn dep_encode_no_err<O: NestedEncodeOutput>(&self, dest: &mut O) {
-                (*self as $mimic_type).dep_encode_no_err(dest)
-            }
-        }
-
-        dep_encode_from_no_err! {$num_type, $type_info}
-    };
-}
-
-#[macro_export]
-macro_rules! dep_encode_from_no_err {
-    ($type:ty, $type_info:expr) => {
-        impl NestedEncode for $type {
+        impl NestedEncode for $num_type {
             const TYPE_INFO: TypeInfo = $type_info;
 
             #[inline]
             fn dep_encode_or_handle_err<O, H>(
                 &self,
                 dest: &mut O,
-                _h: H,
+                h: H,
             ) -> Result<(), H::HandledErr>
             where
                 O: NestedEncodeOutput,
                 H: EncodeErrorHandler,
             {
-                self.dep_encode_no_err(dest);
-                Ok(())
+                (*self as $mimic_type).dep_encode_or_handle_err(dest, h)
             }
         }
     };

--- a/elrond-codec/src/single/mod.rs
+++ b/elrond-codec/src/single/mod.rs
@@ -18,7 +18,6 @@ pub use nested_en_output::NestedEncodeOutput;
 pub use top_de::{top_decode_from_nested, top_decode_from_nested_or_handle_err, TopDecode};
 pub use top_de_input::TopDecodeInput;
 pub use top_en::{
-    top_encode_from_nested, top_encode_no_err, top_encode_to_vec_u8, top_encode_to_vec_u8_or_panic,
-    TopEncode, TopEncodeNoErr,
+    top_encode_from_nested, top_encode_to_vec_u8, top_encode_to_vec_u8_or_panic, TopEncode,
 };
 pub use top_en_output::TopEncodeOutput;

--- a/elrond-codec/src/single/mod.rs
+++ b/elrond-codec/src/single/mod.rs
@@ -13,7 +13,7 @@ pub use nested_de::NestedDecode;
 pub use nested_de_input::NestedDecodeInput;
 pub use nested_de_input_owned::OwnedBytesNestedDecodeInput;
 pub use nested_de_input_slice::dep_decode_from_byte_slice;
-pub use nested_en::{dep_encode_to_vec, NestedEncode, NestedEncodeNoErr};
+pub use nested_en::{dep_encode_to_vec, NestedEncode};
 pub use nested_en_output::NestedEncodeOutput;
 pub use top_de::{top_decode_from_nested, top_decode_from_nested_or_handle_err, TopDecode};
 pub use top_de_input::TopDecodeInput;

--- a/elrond-codec/src/single/nested_en.rs
+++ b/elrond-codec/src/single/nested_en.rs
@@ -3,13 +3,6 @@ use crate::{
 };
 use alloc::vec::Vec;
 
-/// Most types will be encoded without any possibility of error.
-/// The trait is used to provide these implementations.
-/// This is currently not a substitute for implementing a proper NestedEncode.
-pub trait NestedEncodeNoErr: Sized {
-    fn dep_encode_no_err<O: NestedEncodeOutput>(&self, dest: &mut O);
-}
-
 /// Trait that allows zero-copy write of value-references to slices in LE format.
 ///
 /// Implementations should override `using_top_encoded` for value types and `dep_encode` and `size_hint` for allocating types.

--- a/elrond-codec/src/single/top_en.rs
+++ b/elrond-codec/src/single/top_en.rs
@@ -4,20 +4,6 @@ use crate::{
 };
 use alloc::vec::Vec;
 
-/// Most types will be encoded without any possibility of error.
-/// The trait is used to provide these implementations.
-/// This is currently not a substitute for implementing a proper TopEncode.
-pub trait TopEncodeNoErr: Sized {
-    fn top_encode_no_err<O: TopEncodeOutput>(&self, output: O);
-}
-
-/// Quick encoding of a type that never fails on encoding.
-pub fn top_encode_no_err<T: TopEncodeNoErr>(obj: &T) -> Vec<u8> {
-    let mut bytes = Vec::<u8>::new();
-    obj.top_encode_no_err(&mut bytes);
-    bytes
-}
-
 pub trait TopEncode: Sized {
     // !INTERNAL USE ONLY!
     #[doc(hidden)]

--- a/elrond-codec/tests/derive_hygiene.rs
+++ b/elrond-codec/tests/derive_hygiene.rs
@@ -19,7 +19,6 @@ struct TopDecodeInput;
 struct TopEncodeOutput;
 struct NestedDecodeInput;
 struct NestedEncodeOutput;
-struct NestedEncodeNoErr;
 
 // Making sure derive explicitly only works with core::result::Result
 // and doesn't get tricked by other enums with the same name.

--- a/elrond-codec/tests/explicit_impl_enum.rs
+++ b/elrond-codec/tests/explicit_impl_enum.rs
@@ -1,8 +1,8 @@
 use elrond_codec::{
     test_util::{check_dep_encode_decode, check_top_encode_decode},
     top_decode_from_nested_or_handle_err, top_encode_from_nested, DecodeError, DecodeErrorHandler,
-    EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeNoErr,
-    NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
+    EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput,
+    TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
 };
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -13,37 +13,30 @@ pub enum E {
     Struct { a: u32 },
 }
 
-impl NestedEncodeNoErr for E {
-    fn dep_encode_no_err<O: NestedEncodeOutput>(&self, dest: &mut O) {
-        match self {
-            E::Unit => {
-                0u32.dep_encode_no_err(dest);
-            },
-            E::Newtype(arg1) => {
-                1u32.dep_encode_no_err(dest);
-                arg1.dep_encode_no_err(dest);
-            },
-            E::Tuple(arg1, arg2) => {
-                2u32.dep_encode_no_err(dest);
-                arg1.dep_encode_no_err(dest);
-                arg2.dep_encode_no_err(dest);
-            },
-            E::Struct { a } => {
-                3u32.dep_encode_no_err(dest);
-                a.dep_encode_no_err(dest);
-            },
-        }
-    }
-}
-
 impl NestedEncode for E {
-    #[inline]
-    fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, _h: H) -> Result<(), H::HandledErr>
+    fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, h: H) -> Result<(), H::HandledErr>
     where
         O: NestedEncodeOutput,
         H: EncodeErrorHandler,
     {
-        self.dep_encode_no_err(dest);
+        match self {
+            E::Unit => {
+                0u32.dep_encode_or_handle_err(dest, h)?;
+            },
+            E::Newtype(arg1) => {
+                1u32.dep_encode_or_handle_err(dest, h)?;
+                arg1.dep_encode_or_handle_err(dest, h)?;
+            },
+            E::Tuple(arg1, arg2) => {
+                2u32.dep_encode_or_handle_err(dest, h)?;
+                arg1.dep_encode_or_handle_err(dest, h)?;
+                arg2.dep_encode_or_handle_err(dest, h)?;
+            },
+            E::Struct { a } => {
+                3u32.dep_encode_or_handle_err(dest, h)?;
+                a.dep_encode_or_handle_err(dest, h)?;
+            },
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
They were introduced long ago for potential performance improvements and code reuse, but they are completely unnecessary now and can lead to confusion.