### PR TITLE
Remove TypeInfo from codec

### DIFF
--- a/elrond-codec/src/impl_for_types/impl_array.rs
+++ b/elrond-codec/src/impl_for_types/impl_array.rs
@@ -1,7 +1,7 @@
 use crate::{
     top_decode_from_nested_or_handle_err, DecodeError, DecodeErrorHandler, EncodeErrorHandler,
     NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput,
-    TopEncode, TopEncodeOutput, TypeInfo,
+    TopEncode, TopEncodeOutput,
 };
 use alloc::boxed::Box;
 use arrayvec::ArrayVec;
@@ -63,18 +63,20 @@ impl<T: NestedDecode, const N: usize> TopDecode for [T; N] {
         I: TopDecodeInput,
         H: DecodeErrorHandler,
     {
-        if let TypeInfo::U8 = T::TYPE_INFO {
-            // transmute directly
-            let bs = input.into_boxed_slice_u8();
-            if bs.len() != N {
-                return Err(h.handle_error(DecodeError::ARRAY_DECODE_ERROR));
-            }
-            let raw = Box::into_raw(bs);
-            let array_box = unsafe { Box::<[T; N]>::from_raw(raw as *mut [T; N]) };
-            Ok(array_box)
-        } else {
-            Ok(Box::new(Self::top_decode_or_handle_err(input, h)?))
-        }
+        T::if_u8(
+            input,
+            |input| {
+                // transmute directly
+                let bs = input.into_boxed_slice_u8();
+                if bs.len() != N {
+                    return Err(h.handle_error(DecodeError::ARRAY_DECODE_ERROR));
+                }
+                let raw = Box::into_raw(bs);
+                let array_box = unsafe { Box::<[T; N]>::from_raw(raw as *mut [T; N]) };
+                Ok(array_box)
+            },
+            |input| Ok(Box::new(Self::top_decode_or_handle_err(input, h)?)),
+        )
     }
 }
 

--- a/elrond-codec/src/impl_for_types/impl_bool.rs
+++ b/elrond-codec/src/impl_for_types/impl_bool.rs
@@ -1,12 +1,10 @@
 use crate::{
     dep_encode_num_mimic, DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
     NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
-    TopEncodeOutput, TypeInfo,
+    TopEncodeOutput,
 };
 
 impl TopEncode for bool {
-    const TYPE_INFO: TypeInfo = TypeInfo::Bool;
-
     #[inline]
     fn top_encode_or_handle_err<O, H>(&self, output: O, _h: H) -> Result<(), H::HandledErr>
     where
@@ -23,8 +21,6 @@ impl TopEncode for bool {
 }
 
 impl TopDecode for bool {
-    const TYPE_INFO: TypeInfo = TypeInfo::Bool;
-
     fn top_decode_or_handle_err<I, H>(input: I, h: H) -> Result<Self, H::HandledErr>
     where
         I: TopDecodeInput,
@@ -38,11 +34,9 @@ impl TopDecode for bool {
     }
 }
 
-dep_encode_num_mimic! {bool, u8, TypeInfo::Bool}
+dep_encode_num_mimic! {bool, u8}
 
 impl NestedDecode for bool {
-    const TYPE_INFO: TypeInfo = TypeInfo::Bool;
-
     fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> Result<Self, H::HandledErr>
     where
         I: NestedDecodeInput,

--- a/elrond-codec/src/impl_for_types/impl_num_signed.rs
+++ b/elrond-codec/src/impl_for_types/impl_num_signed.rs
@@ -1,11 +1,11 @@
 use crate::{
     dep_encode_num_mimic, num_conv::universal_decode_number, DecodeError, DecodeErrorHandler,
     EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput,
-    TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput, TypeInfo,
+    TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
 };
 
 macro_rules! top_encode_num_signed {
-    ($num_type:ty, $size_in_bits:expr, $type_info:expr) => {
+    ($num_type:ty, $size_in_bits:expr) => {
         impl TopEncode for $num_type {
             #[inline]
             fn top_encode_or_handle_err<O, H>(&self, output: O, _h: H) -> Result<(), H::HandledErr>
@@ -20,23 +20,21 @@ macro_rules! top_encode_num_signed {
     };
 }
 
-top_encode_num_signed! {i64, 64, TypeInfo::I64}
-top_encode_num_signed! {i32, 32, TypeInfo::I32}
-top_encode_num_signed! {isize, 32, TypeInfo::ISIZE}
-top_encode_num_signed! {i16, 16, TypeInfo::I16}
-top_encode_num_signed! {i8, 8, TypeInfo::I8}
+top_encode_num_signed! {i64, 64}
+top_encode_num_signed! {i32, 32}
+top_encode_num_signed! {isize, 32}
+top_encode_num_signed! {i16, 16}
+top_encode_num_signed! {i8, 8}
 
-dep_encode_num_mimic! {i64, u64, TypeInfo::I64}
-dep_encode_num_mimic! {i32, u32, TypeInfo::I32}
-dep_encode_num_mimic! {isize, u32, TypeInfo::ISIZE}
-dep_encode_num_mimic! {i16, u16, TypeInfo::I16}
-dep_encode_num_mimic! {i8, u8, TypeInfo::I8}
+dep_encode_num_mimic! {i64, u64}
+dep_encode_num_mimic! {i32, u32}
+dep_encode_num_mimic! {isize, u32}
+dep_encode_num_mimic! {i16, u16}
+dep_encode_num_mimic! {i8, u8}
 
 macro_rules! dep_decode_num_signed {
-    ($ty:ty, $num_bytes:expr, $type_info:expr) => {
+    ($ty:ty, $num_bytes:expr) => {
         impl NestedDecode for $ty {
-            const TYPE_INFO: TypeInfo = $type_info;
-
             fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> Result<Self, H::HandledErr>
             where
                 I: NestedDecodeInput,
@@ -51,17 +49,15 @@ macro_rules! dep_decode_num_signed {
     };
 }
 
-dep_decode_num_signed!(i8, 1, TypeInfo::I8);
-dep_decode_num_signed!(i16, 2, TypeInfo::I16);
-dep_decode_num_signed!(i32, 4, TypeInfo::I32);
-dep_decode_num_signed!(isize, 4, TypeInfo::ISIZE);
-dep_decode_num_signed!(i64, 8, TypeInfo::I64);
+dep_decode_num_signed!(i8, 1);
+dep_decode_num_signed!(i16, 2);
+dep_decode_num_signed!(i32, 4);
+dep_decode_num_signed!(isize, 4);
+dep_decode_num_signed!(i64, 8);
 
 macro_rules! top_decode_num_signed {
-    ($ty:ty, $bounds_ty:ty, $type_info:expr) => {
+    ($ty:ty, $bounds_ty:ty) => {
         impl TopDecode for $ty {
-            const TYPE_INFO: TypeInfo = $type_info;
-
             fn top_decode_or_handle_err<I, H>(input: I, h: H) -> Result<Self, H::HandledErr>
             where
                 I: TopDecodeInput,
@@ -80,11 +76,11 @@ macro_rules! top_decode_num_signed {
     };
 }
 
-top_decode_num_signed!(i8, i8, TypeInfo::I8);
-top_decode_num_signed!(i16, i16, TypeInfo::I16);
-top_decode_num_signed!(i32, i32, TypeInfo::I32);
-top_decode_num_signed!(isize, i32, TypeInfo::ISIZE); // even if isize can be 64 bits on some platforms, we always deserialize as max 32 bits
-top_decode_num_signed!(i64, i64, TypeInfo::I64);
+top_decode_num_signed!(i8, i8);
+top_decode_num_signed!(i16, i16);
+top_decode_num_signed!(i32, i32);
+top_decode_num_signed!(isize, i32); // even if isize can be 64 bits on some platforms, we always deserialize as max 32 bits
+top_decode_num_signed!(i64, i64);
 
 #[cfg(test)]
 pub mod tests {

--- a/elrond-codec/src/impl_for_types/impl_num_unsigned.rs
+++ b/elrond-codec/src/impl_for_types/impl_num_unsigned.rs
@@ -17,6 +17,14 @@ impl NestedEncode for u8 {
         dest.push_byte(*self);
         Ok(())
     }
+
+    fn if_u8<Output, If, Else, R>(input: Output, if_branch: If, _else_branch: Else) -> R
+    where
+        If: FnOnce(Output) -> R,
+        Else: FnOnce(Output) -> R,
+    {
+        if_branch(input)
+    }
 }
 
 dep_encode_num_mimic! {usize, u32, TypeInfo::USIZE}
@@ -79,6 +87,14 @@ impl NestedDecode for u8 {
         H: DecodeErrorHandler,
     {
         input.read_byte(h)
+    }
+
+    fn if_u8<Input, If, Else, R>(input: Input, if_branch: If, _else_branch: Else) -> R
+    where
+        If: FnOnce(Input) -> R,
+        Else: FnOnce(Input) -> R,
+    {
+        if_branch(input)
     }
 }
 

--- a/elrond-codec/src/impl_for_types/impl_num_unsigned.rs
+++ b/elrond-codec/src/impl_for_types/impl_num_unsigned.rs
@@ -1,13 +1,11 @@
 use crate::{
     dep_encode_num_mimic, num_conv::universal_decode_number, DecodeError, DecodeErrorHandler,
     EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput,
-    TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput, TypeInfo,
+    TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
 };
 
 // No reversing needed for u8, because it is a single byte.
 impl NestedEncode for u8 {
-    const TYPE_INFO: TypeInfo = TypeInfo::U8;
-
     #[inline]
     fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, _h: H) -> Result<(), H::HandledErr>
     where
@@ -27,14 +25,12 @@ impl NestedEncode for u8 {
     }
 }
 
-dep_encode_num_mimic! {usize, u32, TypeInfo::USIZE}
+dep_encode_num_mimic! {usize, u32}
 
 // The main unsigned types need to be reversed before serializing.
 macro_rules! dep_encode_num_unsigned {
-    ($num_type:ty, $size_in_bits:expr, $type_info:expr) => {
+    ($num_type:ty, $size_in_bits:expr) => {
         impl NestedEncode for $num_type {
-            const TYPE_INFO: TypeInfo = $type_info;
-
             #[inline]
             fn dep_encode_or_handle_err<O, H>(
                 &self,
@@ -52,12 +48,12 @@ macro_rules! dep_encode_num_unsigned {
     };
 }
 
-dep_encode_num_unsigned! {u64, 64, TypeInfo::U64}
-dep_encode_num_unsigned! {u32, 32, TypeInfo::U32}
-dep_encode_num_unsigned! {u16, 16, TypeInfo::U16}
+dep_encode_num_unsigned! {u64, 64}
+dep_encode_num_unsigned! {u32, 32}
+dep_encode_num_unsigned! {u16, 16}
 
 macro_rules! top_encode_num_unsigned {
-    ($num_type:ty, $size_in_bits:expr, $type_info:expr) => {
+    ($num_type:ty, $size_in_bits:expr) => {
         impl TopEncode for $num_type {
             #[inline]
             fn top_encode_or_handle_err<O, H>(&self, output: O, _h: H) -> Result<(), H::HandledErr>
@@ -72,15 +68,13 @@ macro_rules! top_encode_num_unsigned {
     };
 }
 
-top_encode_num_unsigned! {u64, 64, TypeInfo::U64}
-top_encode_num_unsigned! {u32, 32, TypeInfo::U32}
-top_encode_num_unsigned! {usize, 32, TypeInfo::USIZE}
-top_encode_num_unsigned! {u16, 16, TypeInfo::U16}
-top_encode_num_unsigned! {u8, 8, TypeInfo::U8}
+top_encode_num_unsigned! {u64, 64}
+top_encode_num_unsigned! {u32, 32}
+top_encode_num_unsigned! {usize, 32}
+top_encode_num_unsigned! {u16, 16}
+top_encode_num_unsigned! {u8, 8}
 
 impl NestedDecode for u8 {
-    const TYPE_INFO: TypeInfo = TypeInfo::U8;
-
     fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> Result<Self, H::HandledErr>
     where
         I: NestedDecodeInput,
@@ -99,10 +93,8 @@ impl NestedDecode for u8 {
 }
 
 macro_rules! dep_decode_num_unsigned {
-    ($ty:ty, $num_bytes:expr, $type_info:expr) => {
+    ($ty:ty, $num_bytes:expr) => {
         impl NestedDecode for $ty {
-            const TYPE_INFO: TypeInfo = $type_info;
-
             fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> Result<Self, H::HandledErr>
             where
                 I: NestedDecodeInput,
@@ -117,16 +109,14 @@ macro_rules! dep_decode_num_unsigned {
     };
 }
 
-dep_decode_num_unsigned!(u16, 2, TypeInfo::U16);
-dep_decode_num_unsigned!(u32, 4, TypeInfo::U32);
-dep_decode_num_unsigned!(usize, 4, TypeInfo::USIZE);
-dep_decode_num_unsigned!(u64, 8, TypeInfo::U64);
+dep_decode_num_unsigned!(u16, 2);
+dep_decode_num_unsigned!(u32, 4);
+dep_decode_num_unsigned!(usize, 4);
+dep_decode_num_unsigned!(u64, 8);
 
 macro_rules! top_decode_num_unsigned {
-    ($ty:ty, $bounds_ty:ty, $type_info:expr) => {
+    ($ty:ty, $bounds_ty:ty) => {
         impl TopDecode for $ty {
-            const TYPE_INFO: TypeInfo = $type_info;
-
             fn top_decode_or_handle_err<I, H>(input: I, h: H) -> Result<Self, H::HandledErr>
             where
                 I: TopDecodeInput,
@@ -144,11 +134,11 @@ macro_rules! top_decode_num_unsigned {
     };
 }
 
-top_decode_num_unsigned!(u8, u8, TypeInfo::U8);
-top_decode_num_unsigned!(u16, u16, TypeInfo::U16);
-top_decode_num_unsigned!(u32, u32, TypeInfo::U32);
-top_decode_num_unsigned!(usize, u32, TypeInfo::USIZE); // even if usize can be 64 bits on some platforms, we always deserialize as max 32 bits
-top_decode_num_unsigned!(u64, u64, TypeInfo::U64);
+top_decode_num_unsigned!(u8, u8);
+top_decode_num_unsigned!(u16, u16);
+top_decode_num_unsigned!(u32, u32);
+top_decode_num_unsigned!(usize, u32); // even if usize can be 64 bits on some platforms, we always deserialize as max 32 bits
+top_decode_num_unsigned!(u64, u64);
 
 #[cfg(test)]
 pub mod tests {

--- a/elrond-codec/src/impl_for_types/impl_unit.rs
+++ b/elrond-codec/src/impl_for_types/impl_unit.rs
@@ -1,11 +1,9 @@
 use crate::{
     DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
-    NestedEncodeOutput, TypeInfo,
+    NestedEncodeOutput,
 };
 
 impl NestedEncode for () {
-    const TYPE_INFO: TypeInfo = TypeInfo::Unit;
-
     #[inline]
     fn dep_encode_or_handle_err<O, H>(&self, _: &mut O, _h: H) -> Result<(), H::HandledErr>
     where
@@ -17,8 +15,6 @@ impl NestedEncode for () {
 }
 
 impl NestedDecode for () {
-    const TYPE_INFO: TypeInfo = TypeInfo::Unit;
-
     fn dep_decode_or_handle_err<I, H>(_input: &mut I, _h: H) -> Result<Self, H::HandledErr>
     where
         I: NestedDecodeInput,

--- a/elrond-codec/src/impl_for_types/impl_vec.rs
+++ b/elrond-codec/src/impl_for_types/impl_vec.rs
@@ -1,7 +1,7 @@
 use crate::{
     boxed_slice_into_vec, DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
     NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
-    TopEncodeOutput, TypeInfo,
+    TopEncodeOutput,
 };
 use alloc::vec::Vec;
 
@@ -22,23 +22,26 @@ impl<T: NestedDecode> TopDecode for Vec<T> {
         I: TopDecodeInput,
         H: DecodeErrorHandler,
     {
-        // TODO: use specialized getter, get rid of TypeInfo
-        if let TypeInfo::U8 = T::TYPE_INFO {
-            let bytes = input.into_boxed_slice_u8();
-            let bytes_vec = boxed_slice_into_vec(bytes);
-            let cast_vec: Vec<T> = unsafe { core::mem::transmute(bytes_vec) };
-            Ok(cast_vec)
-        } else {
-            let mut result: Vec<T> = Vec::new();
-            let mut nested_buffer = input.into_nested_buffer();
-            while !nested_buffer.is_depleted() {
-                result.push(T::dep_decode_or_handle_err(&mut nested_buffer, h)?);
-            }
-            if !nested_buffer.is_depleted() {
-                return Err(h.handle_error(DecodeError::INPUT_TOO_LONG));
-            }
-            Ok(result)
-        }
+        T::if_u8(
+            input,
+            |input| {
+                let bytes = input.into_boxed_slice_u8();
+                let bytes_vec = boxed_slice_into_vec(bytes);
+                let cast_vec: Vec<T> = unsafe { core::mem::transmute(bytes_vec) };
+                Ok(cast_vec)
+            },
+            |input| {
+                let mut result: Vec<T> = Vec::new();
+                let mut nested_buffer = input.into_nested_buffer();
+                while !nested_buffer.is_depleted() {
+                    result.push(T::dep_decode_or_handle_err(&mut nested_buffer, h)?);
+                }
+                if !nested_buffer.is_depleted() {
+                    return Err(h.handle_error(DecodeError::INPUT_TOO_LONG));
+                }
+                Ok(result)
+            },
+        )
     }
 }
 
@@ -60,21 +63,22 @@ impl<T: NestedDecode> NestedDecode for Vec<T> {
         H: DecodeErrorHandler,
     {
         let size = usize::dep_decode_or_handle_err(input, h)?;
-        match T::TYPE_INFO {
-            TypeInfo::U8 => {
+        T::if_u8(
+            input,
+            |input| {
                 let mut vec_u8: Vec<u8> = alloc::vec![0; size];
                 input.read_into(vec_u8.as_mut_slice(), h)?;
                 let cast_vec: Vec<T> = unsafe { core::mem::transmute(vec_u8) };
                 Ok(cast_vec)
             },
-            _ => {
+            |input| {
                 let mut result: Vec<T> = Vec::with_capacity(size);
                 for _ in 0..size {
                     result.push(T::dep_decode_or_handle_err(input, h)?);
                 }
                 Ok(result)
             },
-        }
+        )
     }
 }
 

--- a/elrond-codec/src/impl_for_types/local_macro.rs
+++ b/elrond-codec/src/impl_for_types/local_macro.rs
@@ -1,10 +1,8 @@
 // Derive the implementation of the other types by casting.
 #[macro_export]
 macro_rules! dep_encode_num_mimic {
-    ($num_type:ty, $mimic_type:ident, $type_info:expr) => {
+    ($num_type:ty, $mimic_type:ident) => {
         impl NestedEncode for $num_type {
-            const TYPE_INFO: TypeInfo = $type_info;
-
             #[inline]
             fn dep_encode_or_handle_err<O, H>(
                 &self,

--- a/elrond-codec/src/lib.rs
+++ b/elrond-codec/src/lib.rs
@@ -50,26 +50,3 @@ pub use multi::*;
 pub use single::*;
 
 pub use transmute::{boxed_slice_into_vec, vec_into_boxed_slice};
-
-/// !INTERNAL USE ONLY!
-///
-/// This enum provides type information to optimize encoding/decoding by doing fake specialization.
-#[doc(hidden)]
-#[allow(clippy::upper_case_acronyms)]
-#[derive(PartialEq, Eq)]
-pub enum TypeInfo {
-    /// Default value of [`NestedEncode::TYPE_INFO`] to not require implementors to set this value in the trait.
-    Unknown,
-    U8,
-    I8,
-    U16,
-    I16,
-    U32,
-    I32,
-    USIZE,
-    ISIZE,
-    U64,
-    I64,
-    Bool,
-    Unit,
-}

--- a/elrond-codec/src/single/nested_de.rs
+++ b/elrond-codec/src/single/nested_de.rs
@@ -31,4 +31,19 @@ pub trait NestedDecode: Sized {
             Err(e) => Err(h.handle_error(e)),
         }
     }
+
+    /// Allows the framework to do monomorphisation of special cases where the data is of type `u8`.
+    ///
+    /// Especially useful for deserializing byte arrays.
+    ///
+    /// Working with this also involves transmuting low-level data. Only use if you really know what you are doing!
+    #[doc(hidden)]
+    #[allow(unused_variables)]
+    fn if_u8<Input, If, Else, R>(input: Input, if_branch: If, else_branch: Else) -> R
+    where
+        If: FnOnce(Input) -> R,
+        Else: FnOnce(Input) -> R,
+    {
+        else_branch(input)
+    }
 }

--- a/elrond-codec/src/single/nested_de.rs
+++ b/elrond-codec/src/single/nested_de.rs
@@ -1,16 +1,9 @@
 // use core::ops::Try;
 
-use crate::{
-    codec_err::DecodeError, DecodeErrorHandler, DefaultErrorHandler, NestedDecodeInput, TypeInfo,
-};
+use crate::{codec_err::DecodeError, DecodeErrorHandler, DefaultErrorHandler, NestedDecodeInput};
 
 /// Trait that allows zero-copy read of value-references from slices in LE format.
 pub trait NestedDecode: Sized {
-    // !INTERNAL USE ONLY!
-    // This const helps elrond-wasm to optimize the encoding/decoding by doing fake specialization.
-    #[doc(hidden)]
-    const TYPE_INFO: TypeInfo = TypeInfo::Unknown;
-
     /// Attempt to deserialise the value from input,
     /// using the format of an object nested inside another structure.
     /// In case of success returns the deserialized value and the number of bytes consumed during the operation.

--- a/elrond-codec/src/single/nested_en.rs
+++ b/elrond-codec/src/single/nested_en.rs
@@ -32,6 +32,21 @@ pub trait NestedEncode: Sized {
             Err(e) => Err(h.handle_error(e)),
         }
     }
+
+    /// Allows the framework to do monomorphisation of special cases where the data is of type `u8`.
+    ///
+    /// Especially useful for serializing byte arrays.
+    ///
+    /// Working with this also involves transmuting low-level data. Only use if you really know what you are doing!
+    #[doc(hidden)]
+    #[allow(unused_variables)]
+    fn if_u8<Output, If, Else, R>(output: Output, if_branch: If, else_branch: Else) -> R
+    where
+        If: FnOnce(Output) -> R,
+        Else: FnOnce(Output) -> R,
+    {
+        else_branch(output)
+    }
 }
 
 /// Convenience function for getting an object nested-encoded to a Vec<u8> directly.

--- a/elrond-codec/src/single/nested_en.rs
+++ b/elrond-codec/src/single/nested_en.rs
@@ -1,6 +1,4 @@
-use crate::{
-    codec_err::EncodeError, DefaultErrorHandler, EncodeErrorHandler, NestedEncodeOutput, TypeInfo,
-};
+use crate::{codec_err::EncodeError, DefaultErrorHandler, EncodeErrorHandler, NestedEncodeOutput};
 use alloc::vec::Vec;
 
 /// Trait that allows zero-copy write of value-references to slices in LE format.
@@ -8,11 +6,6 @@ use alloc::vec::Vec;
 /// Implementations should override `using_top_encoded` for value types and `dep_encode` and `size_hint` for allocating types.
 /// Wrapper types should override all methods.
 pub trait NestedEncode: Sized {
-    // !INTERNAL USE ONLY!
-    // This const helps SCALE to optimize the encoding/decoding by doing fake specialization.
-    #[doc(hidden)]
-    const TYPE_INFO: TypeInfo = TypeInfo::Unknown;
-
     /// NestedEncode to output, using the format of an object nested inside another structure.
     /// Does not provide compact version.
     fn dep_encode<O: NestedEncodeOutput>(&self, dest: &mut O) -> Result<(), EncodeError> {

--- a/elrond-codec/src/single/top_de.rs
+++ b/elrond-codec/src/single/top_de.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 
 use crate::{
     codec_err::DecodeError, DecodeErrorHandler, DefaultErrorHandler, NestedDecode,
-    NestedDecodeInput, TopDecodeInput, TypeInfo,
+    NestedDecodeInput, TopDecodeInput,
 };
 
 /// Trait that allows zero-copy read of values from an underlying API in big endian format.
@@ -19,9 +19,6 @@ use crate::{
 /// and would overly complicate the trait.
 ///
 pub trait TopDecode: Sized {
-    #[doc(hidden)]
-    const TYPE_INFO: TypeInfo = TypeInfo::Unknown;
-
     /// Attempt to deserialize the value from input.
     fn top_decode<I>(input: I) -> Result<Self, DecodeError>
     where

--- a/elrond-codec/src/single/top_en.rs
+++ b/elrond-codec/src/single/top_en.rs
@@ -1,14 +1,10 @@
 use crate::{
     codec_err::EncodeError, DefaultErrorHandler, EncodeErrorHandler, NestedEncode,
-    PanicErrorHandler, TopEncodeOutput, TypeInfo,
+    PanicErrorHandler, TopEncodeOutput,
 };
 use alloc::vec::Vec;
 
 pub trait TopEncode: Sized {
-    // !INTERNAL USE ONLY!
-    #[doc(hidden)]
-    const TYPE_INFO: TypeInfo = TypeInfo::Unknown;
-
     /// Attempt to serialize the value to ouput.
     fn top_encode<O>(&self, output: O) -> Result<(), EncodeError>
     where

--- a/elrond-wasm/src/formatter/formatter_impl_num.rs
+++ b/elrond-wasm/src/formatter/formatter_impl_num.rs
@@ -100,7 +100,7 @@ macro_rules! formatter_signed {
 }
 
 macro_rules! formatter_signed_hex {
-    ($num_ty:ty, $size_in_bits:expr, $type_info:expr) => {
+    ($num_ty:ty, $size_in_bits:expr) => {
         impl SCLowerHex for $num_ty {
             #[inline]
             fn fmt<F: super::FormatByteReceiver>(&self, f: &mut F) {
@@ -116,8 +116,8 @@ formatter_signed! {isize}
 formatter_signed! {i16}
 formatter_signed! {i8}
 
-formatter_signed_hex! {i64, 64, TypeInfo::I64}
-formatter_signed_hex! {i32, 32, TypeInfo::I32}
-formatter_signed_hex! {isize, 32, TypeInfo::ISIZE}
-formatter_signed_hex! {i16, 16, TypeInfo::I16}
-formatter_signed_hex! {i8, 8, TypeInfo::I8}
+formatter_signed_hex! {i64, 64}
+formatter_signed_hex! {i32, 32}
+formatter_signed_hex! {isize, 32}
+formatter_signed_hex! {i16, 16}
+formatter_signed_hex! {i8, 8}


### PR DESCRIPTION
There are better ways to do monomorphization. Also showcased here.

In short:
```
T::if_u8(
            input,
            |input| {
                ...
            },
            |input| {
                ...
            },
        )
```
is more specific and cleaner than
```
        if let TypeInfo::U8 = T::TYPE_INFO {
           ...
        } else {
            ...
        }
```
... even if they amount to pretty much the same result in the end.

With that out of the way, `TypeInfo` is a relic from the SCALE codec we initially took some inspiration from, and is ready to go! 