### PR TITLE
Release elrond-wasm 0.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ There are several crates in this repo, this changelog will keep track of all of 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Unreleased
+#### (Next release must be minor and include elrond-codec)
+- elrond-codec refactor: removed `TopEncodeNoErr`, `NestedEncodeNoErr` and `TypeInfo`
+
+## [elrond-wasm 0.36.1] - 2022-11-01
+- Deprecated `ContractCall` `execute_on_dest_context_ignore_result` method, since it is currently redundant.
+
 ## [elrond-wasm 0.36.0, elrond-codec 0.14.0] - 2022-10-13
 - `EsdtTokenPayment` legacy decode: objects encoded by older versions of the framework can now also be decoded, if flag `esdt-token-payment-legacy-decode` is active.
 - Codec `NestedDecodeInput` new  `peek_into` method.

--- a/contracts/benchmarks/mappers/benchmark-common/Cargo.toml
+++ b/contracts/benchmarks/mappers/benchmark-common/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/linked-list-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/linked-list-repeat/Cargo.toml
@@ -13,9 +13,9 @@ path = "../benchmark-common"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/linked-list-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/linked-list-repeat/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/linked-list-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/mappers/linked-list-repeat/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/benchmarks/mappers/map-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/map-repeat/Cargo.toml
@@ -13,9 +13,9 @@ path = "../benchmark-common"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/map-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/map-repeat/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/map-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/mappers/map-repeat/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/benchmarks/mappers/queue-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/queue-repeat/Cargo.toml
@@ -13,9 +13,9 @@ path = "../benchmark-common"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/queue-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/queue-repeat/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/queue-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/mappers/queue-repeat/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/benchmarks/mappers/set-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/set-repeat/Cargo.toml
@@ -13,9 +13,9 @@ path = "../benchmark-common"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/set-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/set-repeat/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/set-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/mappers/set-repeat/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/benchmarks/mappers/single-value-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/single-value-repeat/Cargo.toml
@@ -13,9 +13,9 @@ path = "../benchmark-common"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/single-value-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/single-value-repeat/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/single-value-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/mappers/single-value-repeat/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/benchmarks/mappers/vec-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/vec-repeat/Cargo.toml
@@ -13,9 +13,9 @@ path = "../benchmark-common"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/vec-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/vec-repeat/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/mappers/vec-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/mappers/vec-repeat/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/benchmarks/send-tx-repeat/Cargo.toml
+++ b/contracts/benchmarks/send-tx-repeat/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 path = "src/send_tx_repeat.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 features = ["alloc"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/benchmarks/send-tx-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/send-tx-repeat/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/send-tx-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/send-tx-repeat/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/benchmarks/str-repeat/Cargo.toml
+++ b/contracts/benchmarks/str-repeat/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 path = "src/str_repeat.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 features = ["alloc"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/benchmarks/str-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/str-repeat/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/benchmarks/str-repeat/wasm/Cargo.toml
+++ b/contracts/benchmarks/str-repeat/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/core/price-aggregator/Cargo.toml
+++ b/contracts/core/price-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-sc-price-aggregator"
-version = "0.36.0"
+version = "0.36.1"
 authors = [
     "Claudiu-Marcel Bruda <claudiu.bruda@elrond.com>",
     "Elrond Network <contact@elrond.com>",
@@ -19,15 +19,15 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-modules"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dependencies]

--- a/contracts/core/price-aggregator/meta/Cargo.toml
+++ b/contracts/core/price-aggregator/meta/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/core/price-aggregator/wasm/Cargo.toml
+++ b/contracts/core/price-aggregator/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/core/wegld-swap/Cargo.toml
+++ b/contracts/core/wegld-swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-sc-wegld-swap"
-version = "0.36.0"
+version = "0.36.1"
 
 authors = [
     "Dorin Iancu <dorin.iancu@elrond.com>",
@@ -20,13 +20,13 @@ edition = "2018"
 path = "src/wegld.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-modules"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/core/wegld-swap/meta/Cargo.toml
+++ b/contracts/core/wegld-swap/meta/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/core/wegld-swap/wasm/Cargo.toml
+++ b/contracts/core/wegld-swap/wasm/Cargo.toml
@@ -24,10 +24,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/examples/adder/Cargo.toml
+++ b/contracts/examples/adder/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/adder.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/adder/meta/Cargo.toml
+++ b/contracts/examples/adder/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/adder/wasm/Cargo.toml
+++ b/contracts/examples/adder/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/bonding-curve-contract/Cargo.toml
+++ b/contracts/examples/bonding-curve-contract/Cargo.toml
@@ -9,14 +9,14 @@ publish = false
 path = "src/bonding_curve_contract.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-modules"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 

--- a/contracts/examples/bonding-curve-contract/meta/Cargo.toml
+++ b/contracts/examples/bonding-curve-contract/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/bonding-curve-contract/wasm/Cargo.toml
+++ b/contracts/examples/bonding-curve-contract/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/crowdfunding-esdt/Cargo.toml
+++ b/contracts/examples/crowdfunding-esdt/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 path = "src/crowdfunding_esdt.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dev-dependencies]

--- a/contracts/examples/crowdfunding-esdt/meta/Cargo.toml
+++ b/contracts/examples/crowdfunding-esdt/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/crowdfunding-esdt/wasm/Cargo.toml
+++ b/contracts/examples/crowdfunding-esdt/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/crypto-bubbles/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/crypto_bubbles.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-bubbles/meta/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-bubbles/wasm/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/crypto-kitties/common/kitty/Cargo.toml
+++ b/contracts/examples/crypto-kitties/common/kitty/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm"
 
 [dependencies.random]

--- a/contracts/examples/crypto-kitties/common/random/Cargo.toml
+++ b/contracts/examples/crypto-kitties/common/random/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm"

--- a/contracts/examples/crypto-kitties/kitty-auction/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-auction/Cargo.toml
@@ -17,9 +17,9 @@ version = "0.0.0"
 path = "../kitty-ownership"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-kitties/kitty-auction/meta/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-auction/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-kitties/kitty-auction/wasm/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-auction/wasm/Cargo.toml
@@ -21,10 +21,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/Cargo.toml
@@ -18,9 +18,9 @@ version = "0.0.0"
 path = "../common/random"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/meta/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/Cargo.toml
@@ -21,10 +21,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/examples/crypto-kitties/kitty-ownership/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-ownership/Cargo.toml
@@ -21,9 +21,9 @@ version = "0.0.0"
 path = "../kitty-genetic-alg"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-kitties/kitty-ownership/meta/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-ownership/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/examples/crypto-kitties/kitty-ownership/wasm/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-ownership/wasm/Cargo.toml
@@ -21,10 +21,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/examples/digital-cash/Cargo.toml
+++ b/contracts/examples/digital-cash/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/digital_cash.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/digital-cash/meta/Cargo.toml
+++ b/contracts/examples/digital-cash/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/digital-cash/wasm/Cargo.toml
+++ b/contracts/examples/digital-cash/wasm/Cargo.toml
@@ -24,10 +24,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 features = ["wasm-output-mode"]
 path = "../../../../elrond-wasm-output"

--- a/contracts/examples/empty/Cargo.toml
+++ b/contracts/examples/empty/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 path = "src/empty.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dev-dependencies]

--- a/contracts/examples/empty/meta/Cargo.toml
+++ b/contracts/examples/empty/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/empty/wasm/Cargo.toml
+++ b/contracts/examples/empty/wasm/Cargo.toml
@@ -18,11 +18,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/esdt-transfer-with-fee/Cargo.toml
+++ b/contracts/examples/esdt-transfer-with-fee/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/esdt_transfer_with_fee.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/esdt-transfer-with-fee/meta/Cargo.toml
+++ b/contracts/examples/esdt-transfer-with-fee/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/esdt-transfer-with-fee/wasm/Cargo.toml
+++ b/contracts/examples/esdt-transfer-with-fee/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/factorial/Cargo.toml
+++ b/contracts/examples/factorial/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/factorial.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/factorial/meta/Cargo.toml
+++ b/contracts/examples/factorial/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/factorial/wasm/Cargo.toml
+++ b/contracts/examples/factorial/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/lottery-esdt/Cargo.toml
+++ b/contracts/examples/lottery-esdt/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/lottery.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/lottery-esdt/meta/Cargo.toml
+++ b/contracts/examples/lottery-esdt/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/lottery-esdt/wasm/Cargo.toml
+++ b/contracts/examples/lottery-esdt/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/multisig/Cargo.toml
+++ b/contracts/examples/multisig/Cargo.toml
@@ -9,15 +9,15 @@ publish = false
 path = "src/multisig.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-modules"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dev-dependencies.adder]

--- a/contracts/examples/multisig/interact-rs/Cargo.toml
+++ b/contracts/examples/multisig/interact-rs/Cargo.toml
@@ -13,9 +13,9 @@ path = "src/multisig_interact.rs"
 path = ".."
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-modules"
 
 [dependencies.elrond-interact-snippets]
-version = "0.1.0"
+version = "0.36.1"
 path = "../../../../elrond-interact-snippets"

--- a/contracts/examples/multisig/meta/Cargo.toml
+++ b/contracts/examples/multisig/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/multisig/wasm-view/Cargo.toml
+++ b/contracts/examples/multisig/wasm-view/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/multisig/wasm/Cargo.toml
+++ b/contracts/examples/multisig/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/nft-minter/Cargo.toml
+++ b/contracts/examples/nft-minter/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/nft-minter/meta/Cargo.toml
+++ b/contracts/examples/nft-minter/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/nft-minter/wasm/Cargo.toml
+++ b/contracts/examples/nft-minter/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/examples/nft-storage-prepay/Cargo.toml
+++ b/contracts/examples/nft-storage-prepay/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/nft_storage_prepay.rs"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/examples/nft-storage-prepay/meta/Cargo.toml
+++ b/contracts/examples/nft-storage-prepay/meta/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/nft-storage-prepay/wasm/Cargo.toml
+++ b/contracts/examples/nft-storage-prepay/wasm/Cargo.toml
@@ -24,10 +24,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/examples/order-book/factory/Cargo.toml
+++ b/contracts/examples/order-book/factory/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"
 

--- a/contracts/examples/order-book/factory/meta/Cargo.toml
+++ b/contracts/examples/order-book/factory/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/examples/order-book/factory/wasm/Cargo.toml
+++ b/contracts/examples/order-book/factory/wasm/Cargo.toml
@@ -23,10 +23,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/examples/order-book/pair/Cargo.toml
+++ b/contracts/examples/order-book/pair/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 features = ["alloc"]

--- a/contracts/examples/order-book/pair/meta/Cargo.toml
+++ b/contracts/examples/order-book/pair/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/examples/order-book/pair/wasm/Cargo.toml
+++ b/contracts/examples/order-book/pair/wasm/Cargo.toml
@@ -23,10 +23,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/examples/ping-pong-egld/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 path = "src/ping_pong.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 

--- a/contracts/examples/ping-pong-egld/meta/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/ping-pong-egld/wasm/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/wasm/Cargo.toml
@@ -21,10 +21,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/examples/proxy-pause/Cargo.toml
+++ b/contracts/examples/proxy-pause/Cargo.toml
@@ -9,15 +9,15 @@ publish = false
 path = "src/proxy_pause.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-modules"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dev-dependencies.use-module]

--- a/contracts/examples/proxy-pause/meta/Cargo.toml
+++ b/contracts/examples/proxy-pause/meta/Cargo.toml
@@ -11,5 +11,5 @@ authors = [ "you",]
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/examples/proxy-pause/wasm/Cargo.toml
+++ b/contracts/examples/proxy-pause/wasm/Cargo.toml
@@ -24,10 +24,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = [ "wasm-output-mode",]

--- a/contracts/examples/token-release/Cargo.toml
+++ b/contracts/examples/token-release/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 path = "src/token_release.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 

--- a/contracts/examples/token-release/meta/Cargo.toml
+++ b/contracts/examples/token-release/meta/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"
 

--- a/contracts/examples/token-release/wasm/Cargo.toml
+++ b/contracts/examples/token-release/wasm/Cargo.toml
@@ -21,10 +21,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = [ "wasm-output-mode",]

--- a/contracts/experimental/multisig-external-view/Cargo.toml
+++ b/contracts/experimental/multisig-external-view/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 path = "src/multisig_external_view.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dev-dependencies.adder]

--- a/contracts/experimental/multisig-external-view/meta/Cargo.toml
+++ b/contracts/experimental/multisig-external-view/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/experimental/multisig-external-view/wasm-view/Cargo.toml
+++ b/contracts/experimental/multisig-external-view/wasm-view/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/experimental/multisig-external-view/wasm/Cargo.toml
+++ b/contracts/experimental/multisig-external-view/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/abi-tester/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 path = "src/abi_tester.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 features = ["alloc"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/abi-tester/abi_tester_expected_main.abi.json
+++ b/contracts/feature-tests/abi-tester/abi_tester_expected_main.abi.json
@@ -14,7 +14,7 @@
         },
         "framework": {
             "name": "elrond-wasm",
-            "version": "0.36.0"
+            "version": "0.36.1"
         }
     },
     "docs": [

--- a/contracts/feature-tests/abi-tester/abi_tester_expected_view.abi.json
+++ b/contracts/feature-tests/abi-tester/abi_tester_expected_view.abi.json
@@ -14,7 +14,7 @@
         },
         "framework": {
             "name": "elrond-wasm",
-            "version": "0.36.0"
+            "version": "0.36.1"
         }
     },
     "docs": [

--- a/contracts/feature-tests/abi-tester/meta/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/abi-tester/wasm-view/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/wasm-view/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/abi-tester/wasm/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/alloc-features/Cargo.toml
+++ b/contracts/feature-tests/alloc-features/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 path = "src/alloc_features_main.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 features = ["alloc"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-modules"
 
 [dev-dependencies.esdt-system-sc-mock]

--- a/contracts/feature-tests/alloc-features/meta/Cargo.toml
+++ b/contracts/feature-tests/alloc-features/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/alloc-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/alloc-features/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/basic-features/Cargo.toml
+++ b/contracts/feature-tests/basic-features/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 path = "src/basic_features_main.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 features = ["ei-1-2"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-modules"
 
 [dev-dependencies.esdt-system-sc-mock]

--- a/contracts/feature-tests/basic-features/meta/Cargo.toml
+++ b/contracts/feature-tests/basic-features/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/basic-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/basic-features/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/big-float-features/Cargo.toml
+++ b/contracts/feature-tests/big-float-features/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 path = "src/big_float_main.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 features = ["big-float"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-modules"
 
 [dev-dependencies.esdt-system-sc-mock]

--- a/contracts/feature-tests/big-float-features/meta/Cargo.toml
+++ b/contracts/feature-tests/big-float-features/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/big-float-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/big-float-features/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/Cargo.toml
+++ b/contracts/feature-tests/composability/Cargo.toml
@@ -27,9 +27,9 @@ path = "recursive-caller"
 path = "vault"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/esdt-contract-pair/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/Cargo.toml
@@ -16,9 +16,9 @@ path = "first-contract"
 path = "second-contract"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/Cargo.toml
@@ -10,10 +10,10 @@ path = "src/lib.rs"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"
 

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/meta/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/Cargo.toml
@@ -10,10 +10,10 @@ path = "src/lib.rs"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"
 

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/meta/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/Cargo.toml
@@ -16,9 +16,9 @@ path = "parent"
 path = "child"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/lib.rs"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/meta/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/Cargo.toml
@@ -13,10 +13,10 @@ path = "src/lib.rs"
 path = "../child"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"
 

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/meta/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
@@ -40,11 +40,12 @@ pub trait Parent {
     ) {
         let issue_cost = self.call_value().egld_value();
         let child_contract_adress = self.child_contract_address().get();
-        self.child_proxy(child_contract_adress)
+        let _: IgnoreValue = self
+            .child_proxy(child_contract_adress)
             .issue_wrapped_egld(token_display_name, token_ticker, initial_supply)
             .with_egld_transfer(issue_cost)
             .with_gas_limit(ISSUE_EXPECTED_GAS_COST)
-            .execute_on_dest_context_ignore_result();
+            .execute_on_dest_context();
     }
 
     // storage

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/forwarder-raw/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-raw/Cargo.toml
@@ -12,14 +12,14 @@ path = "src/forwarder_raw.rs"
 ei-unmanaged = ["elrond-wasm/ei-unmanaged"]
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/forwarder-raw/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-raw/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/forwarder-raw/wasm-no-managed-ei/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm-no-managed-ei/Cargo.toml
@@ -20,12 +20,12 @@ path = ".."
 features = ["ei-unmanaged"]
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 features = ["ei-unmanaged-node"]
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/forwarder-raw/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/forwarder/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder/Cargo.toml
@@ -15,11 +15,11 @@ ei-unmanaged = ["elrond-wasm/ei-unmanaged"]
 path = "../vault"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 features = ["ei-1-2"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"
 

--- a/contracts/feature-tests/composability/forwarder/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/forwarder/wasm-no-managed-ei/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder/wasm-no-managed-ei/Cargo.toml
@@ -20,12 +20,12 @@ path = ".."
 features = ["ei-unmanaged"]
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 features = ["ei-unmanaged-node"]
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/forwarder/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/local-esdt-and-nft/Cargo.toml
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/lib.rs"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/local-esdt-and-nft/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/local-esdt-and-nft/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/promises-features/Cargo.toml
+++ b/contracts/feature-tests/composability/promises-features/Cargo.toml
@@ -12,15 +12,15 @@ path = "src/promises_features.rs"
 path = "../vault"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 features = ["promises"]
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/promises-features/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/promises-features/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/promises-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/promises-features/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/proxy-test-first/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-first/Cargo.toml
@@ -15,15 +15,15 @@ ei-unmanaged = ["elrond-wasm/ei-unmanaged"]
 hex-literal = "0.3.1"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 features = ["alloc"]
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/proxy-test-first/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-first/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/proxy-test-first/wasm-no-managed-ei/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm-no-managed-ei/Cargo.toml
@@ -20,12 +20,12 @@ path = ".."
 features = ["ei-unmanaged"]
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 features = ["ei-unmanaged-node"]
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/proxy-test-first/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/proxy-test-second/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-second/Cargo.toml
@@ -12,10 +12,10 @@ path = "src/proxy-test-second.rs"
 ei-unmanaged = ["elrond-wasm/ei-unmanaged"]
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 features = ["alloc"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/proxy-test-second/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-second/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/proxy-test-second/wasm-no-managed-ei/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm-no-managed-ei/Cargo.toml
@@ -20,12 +20,12 @@ path = ".."
 features = ["ei-unmanaged"]
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 features = ["ei-unmanaged-node"]
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/proxy-test-second/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/recursive-caller/Cargo.toml
+++ b/contracts/feature-tests/composability/recursive-caller/Cargo.toml
@@ -15,14 +15,14 @@ ei-unmanaged = ["elrond-wasm/ei-unmanaged"]
 path = "../vault"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/recursive-caller/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/recursive-caller/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/recursive-caller/wasm-no-managed-ei/Cargo.toml
+++ b/contracts/feature-tests/composability/recursive-caller/wasm-no-managed-ei/Cargo.toml
@@ -20,12 +20,12 @@ path = ".."
 features = ["ei-unmanaged"]
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 features = ["ei-unmanaged-node"]
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/recursive-caller/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/recursive-caller/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/transfer-role-features/Cargo.toml
+++ b/contracts/feature-tests/composability/transfer-role-features/Cargo.toml
@@ -12,13 +12,13 @@ path = "src/lib.rs"
 path = "../vault"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-modules"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/transfer-role-features/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/transfer-role-features/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/transfer-role-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/transfer-role-features/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/composability/vault/Cargo.toml
+++ b/contracts/feature-tests/composability/vault/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/vault.rs"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/vault/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/vault/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/composability/vault/wasm/Cargo.toml
+++ b/contracts/feature-tests/composability/vault/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/Cargo.toml
@@ -12,10 +12,10 @@ path = "src/crowdfunding_erc20.rs"
 path = "../erc20"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"
 

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/wasm/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/Cargo.toml
@@ -13,9 +13,9 @@ path = "src/lib.rs"
 path = "../erc1155"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 features = ["alloc"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"
 

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/wasm/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/erc-style-contracts/erc1155/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/Cargo.toml
@@ -12,9 +12,9 @@ path = "src/erc1155.rs"
 path="../erc1155-user-mock"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/erc1155/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/erc1155/wasm/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/erc-style-contracts/erc20/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc20/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/erc20.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/erc20/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc20/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/erc20/wasm/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc20/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/erc-style-contracts/erc721/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc721/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/erc721.rs"
 
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/erc721/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc721/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/erc721/wasm/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc721/wasm/Cargo.toml
@@ -21,10 +21,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/Cargo.toml
@@ -12,15 +12,15 @@ path = "src/lottery.rs"
 path = "../erc20"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 features = ["alloc"]
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/Cargo.toml
@@ -22,10 +22,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]

--- a/contracts/feature-tests/esdt-system-sc-mock/Cargo.toml
+++ b/contracts/feature-tests/esdt-system-sc-mock/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/esdt_system_sc_mock.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/esdt-system-sc-mock/meta/Cargo.toml
+++ b/contracts/feature-tests/esdt-system-sc-mock/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/esdt-system-sc-mock/wasm/Cargo.toml
+++ b/contracts/feature-tests/esdt-system-sc-mock/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/formatted-message-features/Cargo.toml
+++ b/contracts/feature-tests/formatted-message-features/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 path = "src/formatted_message_features.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 features = ["ei-1-2"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/formatted-message-features/meta/Cargo.toml
+++ b/contracts/feature-tests/formatted-message-features/meta/Cargo.toml
@@ -11,5 +11,5 @@ authors = [ "you",]
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/formatted-message-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/formatted-message-features/wasm/Cargo.toml
@@ -24,10 +24,10 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = [ "wasm-output-mode",]

--- a/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/Cargo.toml
+++ b/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 path = "src/crypto_bubbles_legacy.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 features = ["alloc"]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/meta/Cargo.toml
+++ b/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/wasm/Cargo.toml
+++ b/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/multi-contract-features/Cargo.toml
+++ b/contracts/feature-tests/multi-contract-features/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/multi_contract_features.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/multi-contract-features/meta/Cargo.toml
+++ b/contracts/feature-tests/multi-contract-features/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/multi-contract-features/wasm-view/Cargo.toml
+++ b/contracts/feature-tests/multi-contract-features/wasm-view/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/multi-contract-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/multi-contract-features/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/panic-message-features/Cargo.toml
+++ b/contracts/feature-tests/panic-message-features/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/panic_features.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/panic-message-features/meta/Cargo.toml
+++ b/contracts/feature-tests/panic-message-features/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/panic-message-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/panic-message-features/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode", "panic-message"] # <- to get panic messages
 

--- a/contracts/feature-tests/payable-features/Cargo.toml
+++ b/contracts/feature-tests/payable-features/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = "src/payable_features.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/payable-features/meta/Cargo.toml
+++ b/contracts/feature-tests/payable-features/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/payable-features/wasm/Cargo.toml
+++ b/contracts/feature-tests/payable-features/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/rust-testing-framework-tester/Cargo.toml
+++ b/contracts/feature-tests/rust-testing-framework-tester/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 features = [ "alloc" ]
 
@@ -17,7 +17,7 @@ path = "../../examples/adder"
 path = "../../feature-tests/basic-features"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"
 
 [dev-dependencies]

--- a/contracts/feature-tests/rust-testing-framework-tester/meta/Cargo.toml
+++ b/contracts/feature-tests/rust-testing-framework-tester/meta/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/rust-testing-framework-tester/wasm/Cargo.toml
+++ b/contracts/feature-tests/rust-testing-framework-tester/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features = ["wasm-output-mode"]
 

--- a/contracts/feature-tests/use-module/Cargo.toml
+++ b/contracts/feature-tests/use-module/Cargo.toml
@@ -9,14 +9,14 @@ publish = false
 path = "src/use_module.rs"
 
 [dependencies.elrond-wasm-modules]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-modules"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm"
 features = [ "alloc" ]
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../elrond-wasm-debug"

--- a/contracts/feature-tests/use-module/meta/Cargo.toml
+++ b/contracts/feature-tests/use-module/meta/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/use-module/meta/abi/Cargo.toml
+++ b/contracts/feature-tests/use-module/meta/abi/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-debug"

--- a/contracts/feature-tests/use-module/use_module_expected_main.abi.json
+++ b/contracts/feature-tests/use-module/use_module_expected_main.abi.json
@@ -14,7 +14,7 @@
         },
         "framework": {
             "name": "elrond-wasm",
-            "version": "0.36.0"
+            "version": "0.36.1"
         }
     },
     "docs": [

--- a/contracts/feature-tests/use-module/use_module_expected_view.abi.json
+++ b/contracts/feature-tests/use-module/use_module_expected_view.abi.json
@@ -14,7 +14,7 @@
         },
         "framework": {
             "name": "elrond-wasm",
-            "version": "0.36.0"
+            "version": "0.36.1"
         }
     },
     "docs": [

--- a/contracts/feature-tests/use-module/wasm-view/Cargo.toml
+++ b/contracts/feature-tests/use-module/wasm-view/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/contracts/feature-tests/use-module/wasm/Cargo.toml
+++ b/contracts/feature-tests/use-module/wasm/Cargo.toml
@@ -19,11 +19,11 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-node"
 
 [dependencies.elrond-wasm-output]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../../../elrond-wasm-output"
 features=["wasm-output-mode"]
 

--- a/elrond-interact-snippets/Cargo.toml
+++ b/elrond-interact-snippets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-interact-snippets"
-version = "0.1.0"
+version = "0.36.1"
 edition = "2018"
 
 authors = [
@@ -25,6 +25,6 @@ log = "0.4.17"
 env_logger = "0.8.4"
 
 [dependencies.elrond-wasm-debug]
-version = "=0.36.0"
+version = "=0.36.1"
 path = "../elrond-wasm-debug"
 

--- a/elrond-wasm-debug/Cargo.toml
+++ b/elrond-wasm-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-debug"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2018"
 
 authors = [
@@ -39,7 +39,7 @@ bech32 = "0.9.0"
 mandos-go-tests = []
 
 [dependencies.elrond-wasm]
-version = "=0.36.0"
+version = "=0.36.1"
 path = "../elrond-wasm"
 features = ["alloc", "num-bigint", "promises", "big-float"]
 

--- a/elrond-wasm-derive/Cargo.toml
+++ b/elrond-wasm-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-derive"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]

--- a/elrond-wasm-modules/Cargo.toml
+++ b/elrond-wasm-modules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-modules"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2018"
 
 authors = ["Elrond Network <contact@elrond.com>"]
@@ -17,5 +17,5 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies"]
 alloc = ["elrond-wasm/alloc"]
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../elrond-wasm"

--- a/elrond-wasm-node/Cargo.toml
+++ b/elrond-wasm-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-node"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
@@ -19,5 +19,5 @@ vm-esdt-local-roles = []
 ei-unmanaged-node = []
 
 [dependencies.elrond-wasm]
-version = "=0.36.0"
+version = "=0.36.1"
 path = "../elrond-wasm"

--- a/elrond-wasm-output/Cargo.toml
+++ b/elrond-wasm-output/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm-output"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
@@ -27,5 +27,5 @@ panic-message = []
 wee_alloc = "0.4"
 
 [dependencies.elrond-wasm-node]
-version = "=0.36.0"
+version = "=0.36.1"
 path = "../elrond-wasm-node"

--- a/elrond-wasm/Cargo.toml
+++ b/elrond-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elrond-wasm"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2018"
 
 authors = ["Andrei Marinica <andrei.marinica@elrond.com>", "Elrond Network <contact@elrond.com>"]
@@ -34,7 +34,7 @@ version = "0.2"
 default-features = false
 
 [dependencies.elrond-wasm-derive]
-version = "=0.36.0"
+version = "=0.36.1"
 path = "../elrond-wasm-derive"
 
 [dependencies.elrond-codec]

--- a/elrond-wasm/src/types/interaction/contract_call.rs
+++ b/elrond-wasm/src/types/interaction/contract_call.rs
@@ -422,7 +422,11 @@ where
     ///
     /// The result (if any) is ignored.
     ///
-    /// Only works if the target contract is in the same shard.
+    /// Deprecated and will be removed soon. Use `let _: IgnoreValue = contract_call.execute_on_dest_context(...)` instead.
+    #[deprecated(
+        since = "0.36.1",
+        note = "Redundant method, use `let _: IgnoreValue = contract_call.execute_on_dest_context(...)` instead"
+    )]
     pub fn execute_on_dest_context_ignore_result(mut self) {
         self = self.convert_to_esdt_transfer_call();
         let _ = SendRawWrapper::<SA>::new().execute_on_dest_context_raw(

--- a/tools/erdpy-snippet-generator/Cargo.toml
+++ b/tools/erdpy-snippet-generator/Cargo.toml
@@ -9,11 +9,11 @@ name = "erdpy-snippet-generator"
 path = "src/erdpy_snippet_generator.rs"
 
 [dependencies.elrond-wasm]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../elrond-wasm"
 
 [dependencies.elrond-wasm-debug]
-version = "0.36.0"
+version = "0.36.1"
 path = "../../elrond-wasm-debug"
 
 [dependencies]


### PR DESCRIPTION
Deprecated `ContractCall` `execute_on_dest_context_ignore_result` method, since it is currently redundant. Made a hotfix release out of it.

Branch started directly from tag `v0.36.0`. Latest codec refactor **not** included in hotfix.