### PR TITLE
`elrond-wasm-node` back into the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "elrond-wasm",
   "elrond-wasm-debug",
   "elrond-wasm-derive",
+  "elrond-wasm-node",
   "elrond-wasm-modules",
   "mandos",
   "elrond-codec",
@@ -150,6 +151,5 @@ members = [
 ]
 
 exclude = [
-  "elrond-wasm-node",
   "elrond-wasm-output",
 ]

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 
 export CARGO_INCREMENTAL=0
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Coverflow-checks=off -Zpanic_abort_tests"
 export RUSTDOCFLAGS="-Cpanic=abort"
 
 cargo build
 cargo test
 
 grcov ./target/debug/ -s . -t html --llvm --branch -o ./target/debug/coverage/ \
+	--ignore elrond-wasm-node \
 	--ignore-not-existing \
 	--ignore *abi/src* \
 	--ignore *meta/src* \

--- a/elrond-wasm-node/src/api/managed_types/managed_buffer_api_node.rs
+++ b/elrond-wasm-node/src/api/managed_types/managed_buffer_api_node.rs
@@ -53,7 +53,7 @@ impl ManagedBufferApi for crate::VmApiImpl {
 
     #[inline]
     fn mb_len(&self, handle: Self::ManagedBufferHandle) -> usize {
-        unsafe { mBufferGetLength(handle as i32) as usize }
+        unsafe { mBufferGetLength(handle) as usize }
     }
 
     fn mb_to_boxed_bytes(&self, handle: Self::ManagedBufferHandle) -> BoxedBytes {
@@ -131,7 +131,7 @@ impl ManagedBufferApi for crate::VmApiImpl {
     #[inline]
     fn mb_overwrite(&self, handle: Self::ManagedBufferHandle, bytes: &[u8]) {
         unsafe {
-            let _ = mBufferSetBytes(handle as i32, bytes.as_ptr(), bytes.len() as i32);
+            let _ = mBufferSetBytes(handle, bytes.as_ptr(), bytes.len() as i32);
         }
     }
 
@@ -160,7 +160,7 @@ impl ManagedBufferApi for crate::VmApiImpl {
     #[inline]
     fn mb_set_random(&self, dest_handle: Self::ManagedBufferHandle, length: usize) {
         unsafe {
-            let _ = mBufferSetRandom(dest_handle as i32, length as i32);
+            let _ = mBufferSetRandom(dest_handle, length as i32);
         }
     }
 
@@ -171,7 +171,7 @@ impl ManagedBufferApi for crate::VmApiImpl {
         data_handle: Self::ManagedBufferHandle,
     ) {
         unsafe {
-            let _ = mBufferAppend(accumulator_handle as i32, data_handle as i32);
+            let _ = mBufferAppend(accumulator_handle, data_handle);
         }
     }
 
@@ -179,7 +179,7 @@ impl ManagedBufferApi for crate::VmApiImpl {
     fn mb_append_bytes(&self, accumulator_handle: Self::ManagedBufferHandle, bytes: &[u8]) {
         unsafe {
             let _ = mBufferAppendBytes(
-                accumulator_handle as i32,
+                accumulator_handle,
                 bytes.as_ptr(),
                 bytes.len() as i32,
             );

--- a/elrond-wasm-node/src/api/managed_types/managed_buffer_api_node.rs
+++ b/elrond-wasm-node/src/api/managed_types/managed_buffer_api_node.rs
@@ -178,11 +178,7 @@ impl ManagedBufferApi for crate::VmApiImpl {
     #[inline]
     fn mb_append_bytes(&self, accumulator_handle: Self::ManagedBufferHandle, bytes: &[u8]) {
         unsafe {
-            let _ = mBufferAppendBytes(
-                accumulator_handle,
-                bytes.as_ptr(),
-                bytes.len() as i32,
-            );
+            let _ = mBufferAppendBytes(accumulator_handle, bytes.as_ptr(), bytes.len() as i32);
         }
     }
 


### PR DESCRIPTION
After playing around, accomplished the following:

- Included `elrond-wasm-node` in workspace
- Coverage script fix - this was the reason `elrond-wasm-node` was out. This problem seems fixed now.
- Perk: we now have build checks, clippy and fmt for `elrond-wasm-node`.