### PR TITLE
multisig async call callback

### DIFF
--- a/contracts/examples/multisig/mandos/sendEsdt.scen.json
+++ b/contracts/examples/multisig/mandos/sendEsdt.scen.json
@@ -226,6 +226,14 @@
                             "address:esdt-owner"
                         ],
                         "data": ""
+                    },
+                    {
+                        "address": "sc:multisig",
+                        "endpoint": "str:callBack",
+                        "topics": [
+                            "str:asyncCallSuccess"
+                        ],
+                        "data": ""
                     }
                 ],
                 "gas": "*",

--- a/contracts/examples/multisig/src/multisig_perform.rs
+++ b/contracts/examples/multisig/src/multisig_perform.rs
@@ -194,6 +194,7 @@ pub trait MultisigPerformModule:
                     .with_egld_transfer(call_data.egld_amount)
                     .with_arguments_raw(call_data.arguments.into())
                     .async_call()
+                    .with_callback(self.callbacks().perform_async_call_callback())
                     .call_and_exit()
             },
             Action::SCDeployFromSource {
@@ -249,4 +250,26 @@ pub trait MultisigPerformModule:
             },
         }
     }
+
+    /// Callback only performs logging.
+    #[callback]
+    fn perform_async_call_callback(
+        &self,
+        #[call_result] call_result: ManagedAsyncCallResult<MultiValueEncoded<ManagedBuffer>>,
+    ) {
+        match call_result {
+            ManagedAsyncCallResult::Ok(results) => {
+                self.async_call_success(results);
+            },
+            ManagedAsyncCallResult::Err(err) => {
+                self.async_call_error(err.err_code, err.err_msg);
+            },
+        }
+    }
+
+    #[event("asyncCallSuccess")]
+    fn async_call_success(&self, #[indexed] results: MultiValueEncoded<ManagedBuffer>);
+
+    #[event("asyncCallError")]
+    fn async_call_error(&self, #[indexed] err_code: u32, #[indexed] err_message: ManagedBuffer);
 }

--- a/contracts/examples/multisig/wasm-multisig-full/src/lib.rs
+++ b/contracts/examples/multisig/wasm-multisig-full/src/lib.rs
@@ -6,7 +6,7 @@
 
 // Init:                                 1
 // Endpoints:                           28
-// Async Callback (empty):               1
+// Async Callback:                       1
 // Total number of exported functions:  30
 
 #![no_std]
@@ -42,7 +42,6 @@ elrond_wasm_node::wasm_endpoints! {
         getActionSigners
         getActionSignerCount
         getActionValidSignerCount
+        callBack
     )
 }
-
-elrond_wasm_node::wasm_empty_callback! {}

--- a/contracts/examples/multisig/wasm/src/lib.rs
+++ b/contracts/examples/multisig/wasm/src/lib.rs
@@ -6,7 +6,7 @@
 
 // Init:                                 1
 // Endpoints:                           20
-// Async Callback (empty):               1
+// Async Callback:                       1
 // Total number of exported functions:  22
 
 #![no_std]
@@ -34,7 +34,6 @@ elrond_wasm_node::wasm_endpoints! {
         quorumReached
         performAction
         dnsRegister
+        callBack
     )
 }
-
-elrond_wasm_node::wasm_empty_callback! {}

--- a/contracts/feature-tests/composability/promises-features/src/call_promise_direct.rs
+++ b/contracts/feature-tests/composability/promises-features/src/call_promise_direct.rs
@@ -58,13 +58,20 @@ pub trait CallPromisesDirectModule {
     }
 
     #[promises_callback]
-    fn the_one_callback(&self, #[call_result] result: MultiValueEncoded<ManagedBuffer>, arg1: usize, arg2: usize) {
+    fn the_one_callback(
+        &self,
+        #[call_result] result: MultiValueEncoded<ManagedBuffer>,
+        arg1: usize,
+        arg2: usize,
+    ) {
         self.async_call_event_callback(arg1, arg2, &result.into_vec_of_buffers());
     }
 
     #[event("async_call_event_callback")]
-    fn async_call_event_callback(&self, 
-        #[indexed] arg1: usize, 
+    fn async_call_event_callback(
+        &self,
+        #[indexed] arg1: usize,
         #[indexed] arg2: usize,
-        arguments: &ManagedVec<Self::Api, ManagedBuffer>);
+        arguments: &ManagedVec<Self::Api, ManagedBuffer>,
+    );
 }

--- a/elrond-wasm-debug/src/meta/output_contract/output_contract_model.rs
+++ b/elrond-wasm-debug/src/meta/output_contract/output_contract_model.rs
@@ -159,6 +159,18 @@ impl OutputContract {
             .map(|endpoint| endpoint.name.to_string())
             .collect()
     }
+
+    /// Yields "init" + all endpoint names + "callBack" (if it exists).
+    ///
+    /// Should correspond to all wasm exported functions.
+    pub fn all_exported_function_names(&self) -> Vec<String> {
+        let mut result = vec!["init".to_string()];
+        result.append(&mut self.endpoint_names());
+        if self.abi.has_callback {
+            result.push("callBack".to_string());
+        }
+        result
+    }
 }
 
 impl std::fmt::Debug for OutputContract {

--- a/elrond-wasm-debug/src/world_mock/blockchain_mock_init.rs
+++ b/elrond-wasm-debug/src/world_mock/blockchain_mock_init.rs
@@ -98,7 +98,10 @@ impl BlockchainMock {
 
         self.register_contract_container(
             expression,
-            ContractContainer::new(contract_obj, Some(sub_contract.endpoint_names())),
+            ContractContainer::new(
+                contract_obj,
+                Some(sub_contract.all_exported_function_names()),
+            ),
         );
     }
 }

--- a/elrond-wasm-debug/src/world_mock/contract_container.rs
+++ b/elrond-wasm-debug/src/world_mock/contract_container.rs
@@ -6,38 +6,33 @@ use elrond_wasm::contract_base::CallableContract;
 /// It can optionally also contain an allowed endpoint whitelist, to simulate multi-contract.
 pub struct ContractContainer {
     callable: Box<dyn CallableContract>,
-    endpoint_whitelist: Option<Vec<String>>,
+    function_whitelist: Option<Vec<String>>,
 }
 
 impl ContractContainer {
     pub fn new(
         callable: Box<dyn CallableContract>,
-        endpoint_whitelist: Option<Vec<String>>,
+        function_whitelist: Option<Vec<String>>,
     ) -> Self {
         ContractContainer {
             callable,
-            endpoint_whitelist,
+            function_whitelist,
         }
     }
 
-    fn validate_endpoint(&self, endpoint_name: &[u8]) -> bool {
-        if let Some(endpoint_filter) = &self.endpoint_whitelist {
-            if endpoint_name == &b"init"[..] {
-                // init is not in the endpoint list, yet all contract have it
-                return true;
-            }
-
-            endpoint_filter
+    fn validate_function_name(&self, function_name: &[u8]) -> bool {
+        if let Some(function_whitelist) = &self.function_whitelist {
+            function_whitelist
                 .iter()
-                .any(|whitelisted_endpoint| whitelisted_endpoint.as_bytes() == endpoint_name)
+                .any(|whitelisted_endpoint| whitelisted_endpoint.as_bytes() == function_name)
         } else {
             true
         }
     }
 
-    pub fn call(&self, endpoint_name: &[u8]) -> bool {
-        if self.validate_endpoint(endpoint_name) {
-            self.callable.call(endpoint_name)
+    pub fn call(&self, function_name: &[u8]) -> bool {
+        if self.validate_function_name(function_name) {
+            self.callable.call(function_name)
         } else {
             false
         }


### PR DESCRIPTION
A simple callback to log async results. Useful for interacting with the contract.

Also found a bug in the multi-contract debugger (the callback was not properly functional).