### PR TITLE
ContractCall - allow full ESDT payment obj as arg

### DIFF
--- a/contracts/examples/seed-nft-minter/src/distribution_module.rs
+++ b/contracts/examples/seed-nft-minter/src/distribution_module.rs
@@ -35,11 +35,7 @@ pub trait DistributionModule {
             }
             self.send()
                 .contract_call::<IgnoreValue>(distribution.address, distribution.endpoint)
-                .with_egld_or_single_esdt_token_transfer(
-                    token_id.clone(),
-                    token_nonce,
-                    payment_amount,
-                )
+                .with_egld_or_single_esdt_transfer((token_id.clone(), token_nonce, payment_amount))
                 .with_gas_limit(distribution.gas_limit)
                 .transfer_execute();
         }

--- a/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw.rs
@@ -43,7 +43,7 @@ pub trait ForwarderRaw {
     ) -> ContractCall<Self::Api, ()> {
         self.send()
             .contract_call(to, endpoint_name)
-            .with_egld_or_single_esdt_token_transfer(payment_token, 0, payment_amount)
+            .with_egld_or_single_esdt_transfer((payment_token, 0, payment_amount))
             .with_arguments_raw(args.to_arg_buffer())
     }
 

--- a/contracts/feature-tests/composability/forwarder/src/call_async.rs
+++ b/contracts/feature-tests/composability/forwarder/src/call_async.rs
@@ -56,11 +56,11 @@ pub trait ForwarderAsyncCallModule {
     #[endpoint]
     #[payable("*")]
     fn forward_async_accept_funds(&self, to: ManagedAddress) {
-        let (token, token_nonce, payment) = self.call_value().egld_or_single_esdt().into_tuple();
+        let payment = self.call_value().egld_or_single_esdt();
         self.vault_proxy()
             .contract(to)
             .accept_funds()
-            .with_egld_or_single_esdt_token_transfer(token, token_nonce, payment)
+            .with_egld_or_single_esdt_transfer(payment)
             .async_call()
             .call_and_exit()
     }
@@ -73,11 +73,11 @@ pub trait ForwarderAsyncCallModule {
         self.vault_proxy()
             .contract(to)
             .accept_funds()
-            .with_egld_or_single_esdt_token_transfer(
+            .with_egld_or_single_esdt_transfer((
                 payment.token_identifier,
                 payment.token_nonce,
                 half_payment,
-            )
+            ))
             .async_call()
             .call_and_exit()
     }
@@ -87,16 +87,16 @@ pub trait ForwarderAsyncCallModule {
     fn forward_async_accept_funds_with_fees(&self, to: ManagedAddress, percentage_fees: BigUint) {
         let payment = self.call_value().egld_or_single_esdt();
         let fees = &payment.amount * &percentage_fees / PERCENTAGE_TOTAL;
-        let amount_to_send = payment.amount - fees;
+        let amount_to_send = &payment.amount - &fees;
 
         self.vault_proxy()
             .contract(to)
             .accept_funds()
-            .with_egld_or_single_esdt_token_transfer(
+            .with_egld_or_single_esdt_transfer((
                 payment.token_identifier,
                 payment.token_nonce,
                 amount_to_send,
-            )
+            ))
             .async_call()
             .call_and_exit()
     }
@@ -149,7 +149,7 @@ pub trait ForwarderAsyncCallModule {
         self.vault_proxy()
             .contract(to.clone())
             .accept_funds()
-            .with_egld_or_single_esdt_token_transfer(token_identifier.clone(), 0, amount.clone())
+            .with_egld_or_single_esdt_transfer((token_identifier.clone(), 0, amount.clone()))
             .async_call()
             .with_callback(
                 self.callbacks()
@@ -168,7 +168,7 @@ pub trait ForwarderAsyncCallModule {
         self.vault_proxy()
             .contract(to.clone())
             .accept_funds()
-            .with_egld_or_single_esdt_token_transfer(token_identifier.clone(), 0, cb_amount.clone())
+            .with_egld_or_single_esdt_transfer((token_identifier.clone(), 0, cb_amount.clone()))
             .async_call()
             .call_and_exit()
     }

--- a/contracts/feature-tests/composability/forwarder/src/call_queue.rs
+++ b/contracts/feature-tests/composability/forwarder/src/call_queue.rs
@@ -66,11 +66,11 @@ pub trait ForwarderQueuedCallModule {
             let contract_call = self
                 .self_proxy(call.to)
                 .forward_queued_calls(max_call_depth - 1)
-                .with_egld_or_single_esdt_token_transfer(
+                .with_egld_or_single_esdt_transfer((
                     call.payment_token,
                     call.payment_nonce,
                     call.payment_amount,
-                );
+                ));
             match call.call_type {
                 QueuedCallType::Sync => {
                     contract_call.execute_on_dest_context::<()>();

--- a/contracts/feature-tests/composability/promises-features/src/call_promise_direct.rs
+++ b/contracts/feature-tests/composability/promises-features/src/call_promise_direct.rs
@@ -19,11 +19,7 @@ pub trait CallPromisesDirectModule {
         let payment = self.call_value().egld_or_single_esdt();
         self.send()
             .contract_call::<()>(to, endpoint_name)
-            .with_egld_or_single_esdt_token_transfer(
-                payment.token_identifier,
-                payment.token_nonce,
-                payment.amount,
-            )
+            .with_egld_or_single_esdt_transfer(payment)
             .with_arguments_raw(args.to_arg_buffer())
             .with_gas_limit(gas_limit)
             .async_call_promise()

--- a/contracts/feature-tests/composability/promises-features/src/call_promises.rs
+++ b/contracts/feature-tests/composability/promises-features/src/call_promises.rs
@@ -18,12 +18,12 @@ pub trait CallPromisesModule {
     #[endpoint]
     #[payable("*")]
     fn forward_promise_accept_funds(&self, to: ManagedAddress) {
-        let (token, token_nonce, payment) = self.call_value().egld_or_single_esdt().into_tuple();
+        let payment = self.call_value().egld_or_single_esdt();
         let gas_limit = self.blockchain().get_gas_left() / 2;
         self.vault_proxy()
             .contract(to)
             .accept_funds()
-            .with_egld_or_single_esdt_token_transfer(token, token_nonce, payment)
+            .with_egld_or_single_esdt_transfer(payment)
             .with_gas_limit(gas_limit)
             .async_call_promise()
             .register_promise()

--- a/contracts/feature-tests/composability/recursive-caller/src/recursive_caller.rs
+++ b/contracts/feature-tests/composability/recursive-caller/src/recursive_caller.rs
@@ -27,7 +27,7 @@ pub trait RecursiveCaller {
         self.vault_proxy()
             .contract(to.clone())
             .accept_funds()
-            .with_egld_or_single_esdt_token_transfer(token_identifier.clone(), 0, amount.clone())
+            .with_egld_or_single_esdt_transfer((token_identifier.clone(), 0, amount.clone()))
             .async_call()
             .with_callback(self.callbacks().recursive_send_funds_callback(
                 to,

--- a/contracts/feature-tests/use-module/src/contract_base_full_path_mod.rs
+++ b/contracts/feature-tests/use-module/src/contract_base_full_path_mod.rs
@@ -1,9 +1,7 @@
 elrond_wasm::imports!();
 
 #[elrond_wasm::module]
-pub trait ContractBaseFullPathTestModule:
-    elrond_wasm::contract_base::ContractBase
-{
+pub trait ContractBaseFullPathTestModule: elrond_wasm::contract_base::ContractBase {
     #[endpoint]
     fn call_contract_base_full_path_endpoint(&self) {}
 }

--- a/contracts/feature-tests/use-module/src/contract_base_mod.rs
+++ b/contracts/feature-tests/use-module/src/contract_base_mod.rs
@@ -1,9 +1,7 @@
 elrond_wasm::imports!();
 
 #[elrond_wasm::module]
-pub trait ContractBaseTestModule:
-    ContractBase
-{
+pub trait ContractBaseTestModule: ContractBase {
     #[endpoint]
     fn call_contract_base_endpoint(&self) {}
 }

--- a/contracts/feature-tests/use-module/src/use_module.rs
+++ b/contracts/feature-tests/use-module/src/use_module.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+mod contract_base_full_path_mod;
+mod contract_base_mod;
 mod internal_mod_a;
 mod internal_mod_b;
 mod internal_mod_c;
@@ -11,8 +13,6 @@ mod only_admin_mod;
 mod only_owner_derived_mod;
 mod only_owner_mod;
 pub mod token_merge_mod_impl;
-mod contract_base_full_path_mod;
-mod contract_base_mod;
 
 elrond_wasm::imports!();
 

--- a/elrond-wasm-derive/src/generate/proxy_gen.rs
+++ b/elrond-wasm-derive/src/generate/proxy_gen.rs
@@ -140,7 +140,7 @@ pub fn generate_proxy_endpoint(m: &Method, endpoint_name: String) -> proc_macro2
 
     let single_payment_snippet = if token_count > 0 || nonce_count > 0 || payment_count > 0 {
         quote! {
-            ___contract_call___ = ___contract_call___.with_egld_or_single_esdt_token_transfer(#token_expr, #nonce_expr, #payment_expr);
+            ___contract_call___ = ___contract_call___.with_egld_or_single_esdt_transfer((#token_expr, #nonce_expr, #payment_expr));
         }
     } else {
         quote! {}

--- a/elrond-wasm-derive/src/parse/contract_trait_parse.rs
+++ b/elrond-wasm-derive/src/parse/contract_trait_parse.rs
@@ -4,9 +4,8 @@ use super::{
 };
 use crate::{
     model::{ContractTrait, Method, Supertrait, TraitProperties},
-    parse::process_trait_arguments,
+    parse::{is_contract_base, process_trait_arguments},
 };
-use crate::parse::is_contract_base;
 
 pub fn parse_contract_trait(
     args: syn::AttributeArgs,

--- a/elrond-wasm-derive/src/parse/supertrait_parse.rs
+++ b/elrond-wasm-derive/src/parse/supertrait_parse.rs
@@ -2,9 +2,7 @@ use crate::{model::Supertrait, parse::split_path_last};
 
 pub fn is_contract_base(supertrait: &syn::TypeParamBound) -> bool {
     match supertrait {
-        syn::TypeParamBound::Trait(t) => {
-            t.path.segments.last().unwrap().ident == "ContractBase"
-        },
+        syn::TypeParamBound::Trait(t) => t.path.segments.last().unwrap().ident == "ContractBase",
         _ => false,
     }
 }

--- a/elrond-wasm/src/types/interaction/contract_call_deprecated.rs
+++ b/elrond-wasm/src/types/interaction/contract_call_deprecated.rs
@@ -1,0 +1,61 @@
+use crate::{
+    api::CallTypeApi,
+    contract_base::SendRawWrapper,
+    types::{BigUint, EgldOrEsdtTokenIdentifier, TokenIdentifier},
+};
+
+use super::ContractCall;
+
+impl<SA, OriginalResult> ContractCall<SA, OriginalResult>
+where
+    SA: CallTypeApi + 'static,
+{
+    #[deprecated(
+        since = "0.38.0",
+        note = "Replace by `contract_call.with_esdt_transfer((payment_token, payment_nonce, payment_amount))`. 
+        The tuple argument will get automatically converted to EsdtTokenPayment."
+    )]
+    pub fn add_esdt_token_transfer(
+        self,
+        payment_token: TokenIdentifier<SA>,
+        payment_nonce: u64,
+        payment_amount: BigUint<SA>,
+    ) -> Self {
+        self.with_esdt_transfer((payment_token, payment_nonce, payment_amount))
+    }
+
+    #[deprecated(
+        since = "0.38.0",
+        note = "Replace by `contract_call.with_egld_or_single_esdt_transfer((payment_token, payment_nonce, payment_amount))`. "
+    )]
+    pub fn with_egld_or_single_esdt_token_transfer(
+        self,
+        payment_token: EgldOrEsdtTokenIdentifier<SA>,
+        payment_nonce: u64,
+        payment_amount: BigUint<SA>,
+    ) -> Self {
+        self.with_egld_or_single_esdt_transfer((payment_token, payment_nonce, payment_amount))
+    }
+
+    /// Executes immediately, synchronously.
+    ///
+    /// The result (if any) is ignored.
+    ///
+    /// Deprecated and will be removed soon. Use `let _: IgnoreValue = contract_call.execute_on_dest_context(...)` instead.
+    #[deprecated(
+        since = "0.36.1",
+        note = "Redundant method, use `let _: IgnoreValue = contract_call.execute_on_dest_context(...)` instead"
+    )]
+    pub fn execute_on_dest_context_ignore_result(mut self) {
+        self = self.convert_to_esdt_transfer_call();
+        let _ = SendRawWrapper::<SA>::new().execute_on_dest_context_raw(
+            self.resolve_gas_limit(),
+            &self.to,
+            &self.egld_payment,
+            &self.endpoint_name,
+            &self.arg_buffer,
+        );
+
+        SendRawWrapper::<SA>::new().clean_return_data();
+    }
+}

--- a/elrond-wasm/src/types/interaction/mod.rs
+++ b/elrond-wasm/src/types/interaction/mod.rs
@@ -4,6 +4,7 @@ mod async_call_promises;
 mod callback_closure;
 mod callback_selector_result;
 mod contract_call;
+mod contract_call_deprecated;
 mod contract_deploy;
 
 pub use arg_buffer_managed::ManagedArgBuffer;

--- a/elrond-wasm/src/types/managed/wrapped/egld_or_esdt_token_payment.rs
+++ b/elrond-wasm/src/types/managed/wrapped/egld_or_esdt_token_payment.rs
@@ -48,6 +48,16 @@ impl<M: ManagedTypeApi> EgldOrEsdtTokenPayment<M> {
     }
 }
 
+impl<M: ManagedTypeApi> From<(EgldOrEsdtTokenIdentifier<M>, u64, BigUint<M>)>
+    for EgldOrEsdtTokenPayment<M>
+{
+    #[inline]
+    fn from(value: (EgldOrEsdtTokenIdentifier<M>, u64, BigUint<M>)) -> Self {
+        let (token_identifier, token_nonce, amount) = value;
+        Self::new(token_identifier, token_nonce, amount)
+    }
+}
+
 impl<M: ManagedTypeApi> From<EsdtTokenPayment<M>> for EgldOrEsdtTokenPayment<M> {
     fn from(esdt_payment: EsdtTokenPayment<M>) -> Self {
         EgldOrEsdtTokenPayment {

--- a/elrond-wasm/src/types/managed/wrapped/esdt_token_payment.rs
+++ b/elrond-wasm/src/types/managed/wrapped/esdt_token_payment.rs
@@ -18,6 +18,7 @@ pub struct EsdtTokenPayment<M: ManagedTypeApi> {
 }
 
 impl<M: ManagedTypeApi> EsdtTokenPayment<M> {
+    #[inline]
     pub fn new(token_identifier: TokenIdentifier<M>, token_nonce: u64, amount: BigUint<M>) -> Self {
         EsdtTokenPayment {
             token_identifier,
@@ -43,6 +44,14 @@ impl<M: ManagedTypeApi> EsdtTokenPayment<M> {
     #[inline]
     pub fn into_tuple(self) -> (TokenIdentifier<M>, u64, BigUint<M>) {
         (self.token_identifier, self.token_nonce, self.amount)
+    }
+}
+
+impl<M: ManagedTypeApi> From<(TokenIdentifier<M>, u64, BigUint<M>)> for EsdtTokenPayment<M> {
+    #[inline]
+    fn from(value: (TokenIdentifier<M>, u64, BigUint<M>)) -> Self {
+        let (token_identifier, token_nonce, amount) = value;
+        Self::new(token_identifier, token_nonce, amount)
     }
 }
 


### PR DESCRIPTION
ContractCall accepts payment info both as tuple and as payment object.

Deprecated the old methods.