### PR TITLE
reexport rename: `mx_sc::codec`

### DIFF
--- a/contracts/examples/multisig/interact-rs/src/multisig_interact.rs
+++ b/contracts/examples/multisig/interact-rs/src/multisig_interact.rs
@@ -8,7 +8,7 @@ use mx_sc_snippets::{
     dns_address_for_name, env_logger,
     erdrs::interactors::wallet::Wallet,
     mx_sc::{
-        mx_sc_codec::multi_types::MultiValueVec,
+        codec::multi_types::MultiValueVec,
         storage::mappers::SingleValue,
         types::{Address, CodeMetadata},
     },

--- a/contracts/examples/multisig/interact-rs/src/multisig_interact_nfts.rs
+++ b/contracts/examples/multisig/interact-rs/src/multisig_interact_nfts.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use mx_sc_snippets::mx_sc::mx_sc_codec::test_util::top_encode_to_vec_u8_or_panic;
+use mx_sc_snippets::mx_sc::codec::test_util::top_encode_to_vec_u8_or_panic;
 
 use super::*;
 

--- a/contracts/examples/multisig/tests/multisig_rust_test_setup/mod.rs
+++ b/contracts/examples/multisig/tests/multisig_rust_test_setup/mod.rs
@@ -4,7 +4,7 @@ use multisig::{
 };
 use mx_sc::{
     api::ManagedTypeApi,
-    mx_sc_codec::multi_types::OptionalValue,
+    codec::multi_types::OptionalValue,
     types::{Address, BigUint, BoxedBytes, CodeMetadata, ManagedBuffer, ManagedVec},
 };
 use mx_sc_debug::{

--- a/contracts/examples/multisig/tests/multisig_rust_test_v2.rs
+++ b/contracts/examples/multisig/tests/multisig_rust_test_v2.rs
@@ -6,7 +6,7 @@ use multisig::{
 };
 
 use mx_sc::{
-    mx_sc_codec::multi_types::{MultiValueVec, OptionalValue},
+    codec::multi_types::{MultiValueVec, OptionalValue},
     storage::mappers::SingleValue,
     types::{Address, CodeMetadata},
 };

--- a/contracts/examples/rewards-distribution/tests/test_raffle_and_claim.rs
+++ b/contracts/examples/rewards-distribution/tests/test_raffle_and_claim.rs
@@ -1,5 +1,5 @@
 use mx_sc::{
-    mx_sc_codec::multi_types::MultiValue2,
+    codec::multi_types::MultiValue2,
     types::{BigUint, EgldOrEsdtTokenIdentifier, MultiValueEncoded, OperationCompletionStatus},
 };
 use mx_sc_debug::{

--- a/contracts/feature-tests/basic-features/src/types/codec_err_test_type.rs
+++ b/contracts/feature-tests/basic-features/src/types/codec_err_test_type.rs
@@ -1,6 +1,6 @@
 use mx_sc::{
     derive::TypeAbi,
-    mx_sc_codec::{
+    codec::{
         DecodeError, DecodeErrorHandler, EncodeError, EncodeErrorHandler, NestedDecode,
         NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
         TopEncodeOutput,

--- a/contracts/feature-tests/basic-features/src/types/codec_err_test_type.rs
+++ b/contracts/feature-tests/basic-features/src/types/codec_err_test_type.rs
@@ -1,10 +1,10 @@
 use mx_sc::{
-    derive::TypeAbi,
     codec::{
         DecodeError, DecodeErrorHandler, EncodeError, EncodeErrorHandler, NestedDecode,
         NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
         TopEncodeOutput,
     },
+    derive::TypeAbi,
 };
 
 /// Helper type to explore encode/decode errors.

--- a/contracts/feature-tests/composability/vault/src/vault.rs
+++ b/contracts/feature-tests/composability/vault/src/vault.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![allow(clippy::type_complexity)]
 
-use mx_sc::mx_sc_codec::Empty;
+use mx_sc::codec::Empty;
 
 mx_sc::imports!();
 

--- a/contracts/feature-tests/rust-testing-framework-tester/tests/rust_mandos_v1_test.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/tests/rust_mandos_v1_test.rs
@@ -4,7 +4,7 @@ use num_traits::ToPrimitive;
 
 use basic_features::BasicFeatures;
 use mx_sc::{
-    mx_sc_codec::Empty,
+    codec::Empty,
     types::{Address, BigUint, EsdtLocalRole, EsdtTokenPayment, ManagedVec, TokenIdentifier},
 };
 use mx_sc_debug::{

--- a/contracts/feature-tests/use-module/tests/token_merge_module_test.rs
+++ b/contracts/feature-tests/use-module/tests/token_merge_module_test.rs
@@ -1,7 +1,7 @@
 use mx_sc::{
     arrayvec::ArrayVec,
     contract_base::ContractBase,
-    mx_sc_codec::Empty,
+    codec::Empty,
     storage::mappers::StorageTokenWrapper,
     types::{EsdtLocalRole, EsdtTokenPayment, ManagedVec},
 };

--- a/contracts/feature-tests/use-module/tests/token_merge_module_test.rs
+++ b/contracts/feature-tests/use-module/tests/token_merge_module_test.rs
@@ -1,7 +1,7 @@
 use mx_sc::{
     arrayvec::ArrayVec,
-    contract_base::ContractBase,
     codec::Empty,
+    contract_base::ContractBase,
     storage::mappers::StorageTokenWrapper,
     types::{EsdtLocalRole, EsdtTokenPayment, ManagedVec},
 };

--- a/contracts/modules/src/features.rs
+++ b/contracts/modules/src/features.rs
@@ -42,7 +42,7 @@ pub struct FeatureName<M>(ManagedBuffer<M>)
 where
     M: ManagedTypeApi;
 
-use mx_sc::mx_sc_codec::*;
+use mx_sc::codec::*;
 impl<M> NestedEncode for FeatureName<M>
 where
     M: ManagedTypeApi,

--- a/contracts/modules/src/token_merge/custom_merged_token_attributes.rs
+++ b/contracts/modules/src/token_merge/custom_merged_token_attributes.rs
@@ -2,7 +2,7 @@ mx_sc::imports!();
 
 use core::marker::PhantomData;
 
-use mx_sc::mx_sc_codec::Empty;
+use mx_sc::codec::Empty;
 
 use super::merged_token_instances::MergedTokenInstances;
 

--- a/contracts/modules/src/transfer_role_proxy.rs
+++ b/contracts/modules/src/transfer_role_proxy.rs
@@ -1,4 +1,4 @@
-use mx_sc::mx_sc_codec::TopEncodeMulti;
+use mx_sc::codec::TopEncodeMulti;
 
 mx_sc::imports!();
 

--- a/framework/base/src/abi/type_abi_impl_codec_multi.rs
+++ b/framework/base/src/abi/type_abi_impl_codec_multi.rs
@@ -1,5 +1,7 @@
-use crate::abi::{OutputAbis, TypeAbi, TypeDescriptionContainer, TypeName};
-use crate::codec::multi_types::{IgnoreValue, OptionalValue};
+use crate::{
+    abi::{OutputAbis, TypeAbi, TypeDescriptionContainer, TypeName},
+    codec::multi_types::{IgnoreValue, OptionalValue},
+};
 
 #[cfg(feature = "alloc")]
 impl<T: TypeAbi> TypeAbi for crate::codec::multi_types::MultiValueVec<T> {

--- a/framework/base/src/abi/type_abi_impl_codec_multi.rs
+++ b/framework/base/src/abi/type_abi_impl_codec_multi.rs
@@ -1,8 +1,8 @@
 use crate::abi::{OutputAbis, TypeAbi, TypeDescriptionContainer, TypeName};
-use mx_sc_codec::multi_types::{IgnoreValue, OptionalValue};
+use crate::codec::multi_types::{IgnoreValue, OptionalValue};
 
 #[cfg(feature = "alloc")]
-impl<T: TypeAbi> TypeAbi for mx_sc_codec::multi_types::MultiValueVec<T> {
+impl<T: TypeAbi> TypeAbi for crate::codec::multi_types::MultiValueVec<T> {
     fn type_name() -> TypeName {
         super::type_name_variadic::<T>()
     }
@@ -43,7 +43,7 @@ impl<T: TypeAbi> TypeAbi for OptionalValue<T> {
 macro_rules! multi_arg_impls {
     ($(($mval_struct:ident $($n:tt $name:ident)+) )+) => {
         $(
-            impl<$($name),+ > TypeAbi for mx_sc_codec::multi_types::$mval_struct<$($name,)+>
+            impl<$($name),+ > TypeAbi for crate::codec::multi_types::$mval_struct<$($name,)+>
             where
                 $($name: TypeAbi,)+
             {

--- a/framework/base/src/api/managed_types/handles.rs
+++ b/framework/base/src/api/managed_types/handles.rs
@@ -7,7 +7,7 @@ pub trait HandleTypeInfo {
     type EllipticCurveHandle: HandleConstraints;
 }
 
-use mx_sc_codec::TryStaticCast;
+use crate::codec::TryStaticCast;
 
 use crate::{
     api::{ErrorApi, ErrorApiImpl},

--- a/framework/base/src/api/uncallable/mod.rs
+++ b/framework/base/src/api/uncallable/mod.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::TryStaticCast;
+use crate::codec::TryStaticCast;
 
 mod big_float_api_uncallable;
 mod big_int_api_uncallable;

--- a/framework/base/src/contract_base/wrappers/blockchain_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/blockchain_wrapper.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::TopDecode;
+use crate::codec::TopDecode;
 
 use crate::{
     api::{

--- a/framework/base/src/contract_base/wrappers/error_helper.rs
+++ b/framework/base/src/contract_base/wrappers/error_helper.rs
@@ -1,6 +1,6 @@
 use core::{borrow::Borrow, marker::PhantomData};
 
-use mx_sc_codec::{DecodeError, EncodeError};
+use crate::codec::{DecodeError, EncodeError};
 
 use crate::{
     api::{ErrorApiImpl, ManagedTypeApi},

--- a/framework/base/src/contract_base/wrappers/send_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/send_wrapper.rs
@@ -1,8 +1,9 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::Empty;
+use crate::codec::Empty;
 
 use crate::{
+    codec,
     api::{
         BlockchainApi, BlockchainApiImpl, CallTypeApi, StorageReadApi,
         CHANGE_OWNER_BUILTIN_FUNC_NAME, CLAIM_DEVELOPER_REWARDS_FUNC_NAME,
@@ -334,7 +335,7 @@ where
     /// Must have ESDTNftCreate role set, or this will fail with "action is not allowed".
     /// Returns the nonce of the newly created NFT.
     #[allow(clippy::too_many_arguments)]
-    pub fn esdt_nft_create<T: mx_sc_codec::TopEncode>(
+    pub fn esdt_nft_create<T: codec::TopEncode>(
         &self,
         token: &TokenIdentifier<A>,
         amount: &BigUint<A>,
@@ -354,7 +355,7 @@ where
 
         if uris.is_empty() {
             // at least one URI is required, so we push an empty one
-            arg_buffer.push_arg(mx_sc_codec::Empty);
+            arg_buffer.push_arg(codec::Empty);
         } else {
             // The API function has the last argument as variadic,
             // so we top-encode each and send as separate argument
@@ -377,7 +378,7 @@ where
     }
 
     #[inline]
-    pub fn esdt_nft_create_compact<T: mx_sc_codec::TopEncode>(
+    pub fn esdt_nft_create_compact<T: codec::TopEncode>(
         &self,
         token: &TokenIdentifier<A>,
         amount: &BigUint<A>,
@@ -386,7 +387,7 @@ where
         self.esdt_nft_create_compact_named(token, amount, &ManagedBuffer::new(), attributes)
     }
 
-    pub fn esdt_nft_create_compact_named<T: mx_sc_codec::TopEncode>(
+    pub fn esdt_nft_create_compact_named<T: codec::TopEncode>(
         &self,
         token: &TokenIdentifier<A>,
         amount: &BigUint<A>,
@@ -486,7 +487,7 @@ where
         );
     }
 
-    pub fn nft_update_attributes<T: mx_sc_codec::TopEncode>(
+    pub fn nft_update_attributes<T: codec::TopEncode>(
         &self,
         token_id: &TokenIdentifier<A>,
         nft_nonce: u64,

--- a/framework/base/src/contract_base/wrappers/send_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/send_wrapper.rs
@@ -3,7 +3,6 @@ use core::marker::PhantomData;
 use crate::codec::Empty;
 
 use crate::{
-    codec,
     api::{
         BlockchainApi, BlockchainApiImpl, CallTypeApi, StorageReadApi,
         CHANGE_OWNER_BUILTIN_FUNC_NAME, CLAIM_DEVELOPER_REWARDS_FUNC_NAME,
@@ -11,6 +10,7 @@ use crate::{
         ESDT_NFT_ADD_URI_FUNC_NAME, ESDT_NFT_BURN_FUNC_NAME, ESDT_NFT_CREATE_FUNC_NAME,
         ESDT_NFT_UPDATE_ATTRIBUTES_FUNC_NAME,
     },
+    codec,
     esdt::ESDTSystemSmartContractProxy,
     types::{
         BigUint, ContractCall, ContractCallNoPayment, EgldOrEsdtTokenIdentifier, EsdtTokenPayment,

--- a/framework/base/src/contract_base/wrappers/serializer.rs
+++ b/framework/base/src/contract_base/wrappers/serializer.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{
+use crate::codec::{
     DecodeError, DecodeErrorHandler, EncodeError, EncodeErrorHandler, TopDecode, TopEncode,
 };
 

--- a/framework/base/src/contract_base/wrappers/storage_raw_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/storage_raw_wrapper.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{TopDecode, TopEncode};
+use crate::codec::{TopDecode, TopEncode};
 
 use crate::{
     api::{

--- a/framework/base/src/formatter/formatter_traits.rs
+++ b/framework/base/src/formatter/formatter_traits.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::TopEncode;
+use crate::codec::TopEncode;
 
 use crate::{
     api::ManagedTypeApi, contract_base::ExitCodecErrorHandler, err_msg, types::ManagedBuffer,

--- a/framework/base/src/hex_call_data/cd_de.rs
+++ b/framework/base/src/hex_call_data/cd_de.rs
@@ -1,7 +1,7 @@
 use super::SEPARATOR;
 use crate::{err_msg, formatter::hex_util::hex_digits_to_byte};
 use alloc::{boxed::Box, vec::Vec};
-use mx_sc_codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
+use crate::codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
 
 /// Deserializes from Elrond's smart contract call format.
 ///

--- a/framework/base/src/hex_call_data/cd_de.rs
+++ b/framework/base/src/hex_call_data/cd_de.rs
@@ -1,7 +1,10 @@
 use super::SEPARATOR;
-use crate::{err_msg, formatter::hex_util::hex_digits_to_byte};
+use crate::{
+    codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput},
+    err_msg,
+    formatter::hex_util::hex_digits_to_byte,
+};
 use alloc::{boxed::Box, vec::Vec};
-use crate::codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
 
 /// Deserializes from Elrond's smart contract call format.
 ///

--- a/framework/base/src/io/arg_de_input.rs
+++ b/framework/base/src/io/arg_de_input.rs
@@ -6,7 +6,7 @@ use crate::{
         heap::Box, BigInt, BigUint, ManagedBuffer, ManagedBufferNestedDecodeInput, ManagedType,
     },
 };
-use mx_sc_codec::{
+use crate::codec::{
     try_execute_then_cast, DecodeError, DecodeErrorHandler, TopDecodeInput, TryStaticCast,
 };
 

--- a/framework/base/src/io/arg_de_input.rs
+++ b/framework/base/src/io/arg_de_input.rs
@@ -2,12 +2,12 @@ use core::marker::PhantomData;
 
 use crate::{
     api::{EndpointArgumentApi, EndpointArgumentApiImpl, ManagedTypeApi, StaticVarApiImpl},
+    codec::{
+        try_execute_then_cast, DecodeError, DecodeErrorHandler, TopDecodeInput, TryStaticCast,
+    },
     types::{
         heap::Box, BigInt, BigUint, ManagedBuffer, ManagedBufferNestedDecodeInput, ManagedType,
     },
-};
-use crate::codec::{
-    try_execute_then_cast, DecodeError, DecodeErrorHandler, TopDecodeInput, TryStaticCast,
 };
 
 /// Adapter from the API to the TopDecodeInput trait.

--- a/framework/base/src/io/arg_error_handler.rs
+++ b/framework/base/src/io/arg_error_handler.rs
@@ -2,9 +2,9 @@ use core::marker::PhantomData;
 
 use crate::{
     api::{ErrorApi, ManagedTypeApi},
+    codec::*,
     io::{signal_arg_de_error, ArgId},
 };
-use crate::codec::*;
 
 #[derive(Clone)]
 pub struct ArgErrorHandler<M>

--- a/framework/base/src/io/arg_error_handler.rs
+++ b/framework/base/src/io/arg_error_handler.rs
@@ -4,7 +4,7 @@ use crate::{
     api::{ErrorApi, ManagedTypeApi},
     io::{signal_arg_de_error, ArgId},
 };
-use mx_sc_codec::*;
+use crate::codec::*;
 
 #[derive(Clone)]
 pub struct ArgErrorHandler<M>

--- a/framework/base/src/io/arg_loader_multi.rs
+++ b/framework/base/src/io/arg_loader_multi.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
+use crate::codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
 
 use crate::{
     api::{EndpointArgumentApi, ErrorApi, ManagedTypeApi, StaticVarApiImpl},

--- a/framework/base/src/io/arg_loader_single.rs
+++ b/framework/base/src/io/arg_loader_single.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{DecodeErrorHandler, TopDecodeMultiInput};
+use crate::codec::{DecodeErrorHandler, TopDecodeMultiInput};
 
 use crate::{
     api::{EndpointArgumentApi, ErrorApi, ManagedTypeApi},

--- a/framework/base/src/io/arg_nested_tuple.rs
+++ b/framework/base/src/io/arg_nested_tuple.rs
@@ -8,7 +8,7 @@ use crate::{
     err_msg,
     io::{ArgErrorHandler, ArgId},
 };
-use mx_sc_codec::{DecodeError, TopDecodeMulti, TopDecodeMultiInput};
+use crate::codec::{DecodeError, TopDecodeMulti, TopDecodeMultiInput};
 
 /// Argument count cannot change during execution, and it can get queried multiple times,
 /// so it makes sense to save it statically.

--- a/framework/base/src/io/arg_nested_tuple.rs
+++ b/framework/base/src/io/arg_nested_tuple.rs
@@ -4,11 +4,11 @@ use crate::{
         EndpointArgumentApi, EndpointArgumentApiImpl, ErrorApi, ErrorApiImpl, ManagedTypeApi,
         StaticVarApiImpl, VMApi,
     },
+    codec::{DecodeError, TopDecodeMulti, TopDecodeMultiInput},
     contract_base::CallbackArgApiWrapper,
     err_msg,
     io::{ArgErrorHandler, ArgId},
 };
-use crate::codec::{DecodeError, TopDecodeMulti, TopDecodeMultiInput};
 
 /// Argument count cannot change during execution, and it can get queried multiple times,
 /// so it makes sense to save it statically.

--- a/framework/base/src/io/bytes_arg_loader.rs
+++ b/framework/base/src/io/bytes_arg_loader.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use alloc::{boxed::Box, vec::Vec};
-use mx_sc_codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
+use crate::codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
 
 use crate::{
     api::{ErrorApi, ManagedTypeApi},

--- a/framework/base/src/io/bytes_arg_loader.rs
+++ b/framework/base/src/io/bytes_arg_loader.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
-use alloc::{boxed::Box, vec::Vec};
 use crate::codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
+use alloc::{boxed::Box, vec::Vec};
 
 use crate::{
     api::{ErrorApi, ManagedTypeApi},

--- a/framework/base/src/io/finish.rs
+++ b/framework/base/src/io/finish.rs
@@ -4,8 +4,8 @@ use crate::codec::{EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput, Try
 
 use crate::{
     api::{EndpointFinishApi, EndpointFinishApiImpl, ManagedTypeApi},
-    contract_base::ExitCodecErrorHandler,
     codec::{EncodeError, TopEncode, TopEncodeOutput},
+    contract_base::ExitCodecErrorHandler,
     err_msg,
     types::{
         BigInt, BigUint, ManagedBuffer, ManagedBufferCachedBuilder, ManagedSCError, ManagedType,

--- a/framework/base/src/io/finish.rs
+++ b/framework/base/src/io/finish.rs
@@ -1,12 +1,12 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput, TryStaticCast};
+use crate::codec::{EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput, TryStaticCast};
 
 use crate::{
     api::{EndpointFinishApi, EndpointFinishApiImpl, ManagedTypeApi},
     contract_base::ExitCodecErrorHandler,
+    codec::{EncodeError, TopEncode, TopEncodeOutput},
     err_msg,
-    mx_sc_codec::{EncodeError, TopEncode, TopEncodeOutput},
     types::{
         BigInt, BigUint, ManagedBuffer, ManagedBufferCachedBuilder, ManagedSCError, ManagedType,
         SCError, StaticSCError,

--- a/framework/base/src/io/managed_result_arg_loader.rs
+++ b/framework/base/src/io/managed_result_arg_loader.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
+use crate::codec::{DecodeError, DecodeErrorHandler, TopDecodeMultiInput};
 
 use crate::{
     api::{ErrorApi, ManagedTypeApi},

--- a/framework/base/src/io/signal_error.rs
+++ b/framework/base/src/io/signal_error.rs
@@ -4,7 +4,7 @@ use crate::{
     err_msg,
     types::{ManagedBuffer, ManagedType},
 };
-use mx_sc_codec::DecodeError;
+use crate::codec::DecodeError;
 
 pub fn signal_arg_de_error<EA>(arg_id: ArgId, decode_err: DecodeError) -> !
 where

--- a/framework/base/src/io/signal_error.rs
+++ b/framework/base/src/io/signal_error.rs
@@ -1,10 +1,10 @@
 use super::ArgId;
 use crate::{
     api::{ErrorApi, ErrorApiImpl, ManagedTypeApi},
+    codec::DecodeError,
     err_msg,
     types::{ManagedBuffer, ManagedType},
 };
-use crate::codec::DecodeError;
 
 pub fn signal_arg_de_error<EA>(arg_id: ArgId, decode_err: DecodeError) -> !
 where

--- a/framework/base/src/lib.rs
+++ b/framework/base/src/lib.rs
@@ -14,10 +14,11 @@ pub use mx_sc_derive::{self as derive, contract, module, proxy};
 // re-export basic heap types
 extern crate alloc;
 
-/// Reexported for convenience.
-pub use mx_sc_codec::arrayvec;
+/// The current version of `mx_sc_codec`, re-exported.
+pub use mx_sc_codec as codec;
 
-pub use mx_sc_codec;
+/// Reexported for convenience.
+pub use crate::codec::arrayvec;
 
 pub mod abi;
 pub mod api;

--- a/framework/base/src/log_util.rs
+++ b/framework/base/src/log_util.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{TopEncode, TopEncodeMulti};
+use crate::codec::{TopEncode, TopEncodeMulti};
 
 use crate::{
     api::{ErrorApi, LogApi, LogApiImpl, ManagedTypeApi},

--- a/framework/base/src/macros.rs
+++ b/framework/base/src/macros.rs
@@ -23,7 +23,7 @@ macro_rules! imports {
             err_msg,
             esdt::*,
             io::*,
-            mx_sc_codec::{
+            codec::{
                 multi_types::*, DecodeError, IntoMultiValue, NestedDecode, NestedEncode, TopDecode,
                 TopEncode,
             },
@@ -45,8 +45,8 @@ macro_rules! derive_imports {
     () => {
         use mx_sc::{
             derive::{ManagedVecItem, TypeAbi},
-            mx_sc_codec,
-            mx_sc_codec::mx_sc_codec_derive::{
+            codec,
+            codec::mx_sc_codec_derive::{
                 NestedDecode, NestedEncode, TopDecode, TopDecodeOrDefault, TopEncode,
                 TopEncodeOrDefault,
             },

--- a/framework/base/src/macros.rs
+++ b/framework/base/src/macros.rs
@@ -19,14 +19,14 @@ macro_rules! imports {
                 SendApiImpl,
             },
             arrayvec::ArrayVec,
-            contract_base::{ContractBase, ProxyObjBase},
-            err_msg,
-            esdt::*,
-            io::*,
             codec::{
                 multi_types::*, DecodeError, IntoMultiValue, NestedDecode, NestedEncode, TopDecode,
                 TopEncode,
             },
+            contract_base::{ContractBase, ProxyObjBase},
+            err_msg,
+            esdt::*,
+            io::*,
             non_zero_usize,
             non_zero_util::*,
             require, require_old, sc_error, sc_format, sc_panic, sc_print,
@@ -44,12 +44,12 @@ macro_rules! imports {
 macro_rules! derive_imports {
     () => {
         use mx_sc::{
-            derive::{ManagedVecItem, TypeAbi},
             codec,
             codec::mx_sc_codec_derive::{
                 NestedDecode, NestedEncode, TopDecode, TopDecodeOrDefault, TopEncode,
                 TopEncodeOrDefault,
             },
+            derive::{ManagedVecItem, TypeAbi},
         };
     };
 }

--- a/framework/base/src/storage/mappers/bi_di_mapper.rs
+++ b/framework/base/src/storage/mappers/bi_di_mapper.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{
+use crate::codec::{
     multi_encode_iter_or_handle_err, multi_types::MultiValue2, CodecFrom, EncodeErrorHandler,
     NestedDecode, NestedEncode, TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
 };

--- a/framework/base/src/storage/mappers/fungible_token_mapper.rs
+++ b/framework/base/src/storage/mappers/fungible_token_mapper.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{CodecFrom, EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput};
+use crate::codec::{CodecFrom, EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput};
 
 use super::{
     token_mapper::{

--- a/framework/base/src/storage/mappers/linked_list_mapper.rs
+++ b/framework/base/src/storage/mappers/linked_list_mapper.rs
@@ -4,17 +4,19 @@ use super::{StorageClearable, StorageMapper};
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::StorageMapperApi,
+    codec::{
+        self,
+        mx_sc_codec_derive::{
+            NestedDecode, NestedEncode, TopDecode, TopDecodeOrDefault, TopEncode,
+            TopEncodeOrDefault,
+        },
+        CodecFrom, DecodeDefault, EncodeDefault, EncodeErrorHandler, NestedDecode, NestedEncode,
+        TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
+    },
     storage::{storage_get, storage_set, StorageKey},
     types::{heap::BoxedBytes, ManagedType, MultiValueEncoded},
 };
 use alloc::vec::Vec;
-use crate::codec::{ self,
-    mx_sc_codec_derive::{
-        NestedDecode, NestedEncode, TopDecode, TopDecodeOrDefault, TopEncode, TopEncodeOrDefault,
-    },
-    CodecFrom, DecodeDefault, EncodeDefault, EncodeErrorHandler, NestedDecode, NestedEncode,
-    TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
-};
 use storage_get::storage_get_len;
 
 const NULL_ENTRY: u32 = 0;

--- a/framework/base/src/storage/mappers/linked_list_mapper.rs
+++ b/framework/base/src/storage/mappers/linked_list_mapper.rs
@@ -8,7 +8,7 @@ use crate::{
     types::{heap::BoxedBytes, ManagedType, MultiValueEncoded},
 };
 use alloc::vec::Vec;
-use mx_sc_codec::{
+use crate::codec::{ self,
     mx_sc_codec_derive::{
         NestedDecode, NestedEncode, TopDecode, TopDecodeOrDefault, TopEncode, TopEncodeOrDefault,
     },

--- a/framework/base/src/storage/mappers/map_mapper.rs
+++ b/framework/base/src/storage/mappers/map_mapper.rs
@@ -4,12 +4,12 @@ use super::{set_mapper, SetMapper, StorageClearable, StorageMapper};
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::StorageMapperApi,
+    codec::{
+        multi_encode_iter_or_handle_err, multi_types::MultiValue2, CodecFrom, EncodeErrorHandler,
+        NestedDecode, NestedEncode, TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
+    },
     storage::{storage_clear, storage_get, storage_set, StorageKey},
     types::{ManagedType, MultiValueEncoded},
-};
-use crate::codec::{
-    multi_encode_iter_or_handle_err, multi_types::MultiValue2, CodecFrom, EncodeErrorHandler,
-    NestedDecode, NestedEncode, TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
 };
 
 const MAPPED_VALUE_IDENTIFIER: &[u8] = b".mapped";

--- a/framework/base/src/storage/mappers/map_mapper.rs
+++ b/framework/base/src/storage/mappers/map_mapper.rs
@@ -7,7 +7,7 @@ use crate::{
     storage::{storage_clear, storage_get, storage_set, StorageKey},
     types::{ManagedType, MultiValueEncoded},
 };
-use mx_sc_codec::{
+use crate::codec::{
     multi_encode_iter_or_handle_err, multi_types::MultiValue2, CodecFrom, EncodeErrorHandler,
     NestedDecode, NestedEncode, TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
 };

--- a/framework/base/src/storage/mappers/map_storage_mapper.rs
+++ b/framework/base/src/storage/mappers/map_storage_mapper.rs
@@ -3,9 +3,9 @@ use core::marker::PhantomData;
 use super::{set_mapper, SetMapper, StorageClearable, StorageMapper};
 use crate::{
     api::StorageMapperApi,
+    codec::{NestedDecode, NestedEncode, TopDecode, TopEncode},
     storage::{self, StorageKey},
 };
-use crate::codec::{NestedDecode, NestedEncode, TopDecode, TopEncode};
 
 const MAPPED_STORAGE_VALUE_IDENTIFIER: &[u8] = b".storage";
 type Keys<'a, SA, T> = set_mapper::Iter<'a, SA, T>;

--- a/framework/base/src/storage/mappers/map_storage_mapper.rs
+++ b/framework/base/src/storage/mappers/map_storage_mapper.rs
@@ -5,7 +5,7 @@ use crate::{
     api::StorageMapperApi,
     storage::{self, StorageKey},
 };
-use mx_sc_codec::{NestedDecode, NestedEncode, TopDecode, TopEncode};
+use crate::codec::{NestedDecode, NestedEncode, TopDecode, TopEncode};
 
 const MAPPED_STORAGE_VALUE_IDENTIFIER: &[u8] = b".storage";
 type Keys<'a, SA, T> = set_mapper::Iter<'a, SA, T>;

--- a/framework/base/src/storage/mappers/non_fungible_token_mapper.rs
+++ b/framework/base/src/storage/mappers/non_fungible_token_mapper.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{
+use crate::codec::{
     CodecFrom, EncodeErrorHandler, TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
 };
 

--- a/framework/base/src/storage/mappers/queue_mapper.rs
+++ b/framework/base/src/storage/mappers/queue_mapper.rs
@@ -4,17 +4,16 @@ use super::{StorageClearable, StorageMapper};
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::StorageMapperApi,
+    codec::{
+        self, multi_encode_iter_or_handle_err,
+        mx_sc_codec_derive::{TopDecode, TopDecodeOrDefault, TopEncode, TopEncodeOrDefault},
+        CodecFrom, DecodeDefault, EncodeDefault, EncodeErrorHandler, TopDecode, TopEncode,
+        TopEncodeMulti, TopEncodeMultiOutput,
+    },
     storage::{storage_get, storage_set, StorageKey},
     types::{ManagedType, MultiValueEncoded},
 };
 use alloc::vec::Vec;
-use crate::codec::{
-    self,
-    multi_encode_iter_or_handle_err,
-    mx_sc_codec_derive::{TopDecode, TopDecodeOrDefault, TopEncode, TopEncodeOrDefault},
-    CodecFrom, DecodeDefault, EncodeDefault, EncodeErrorHandler, TopDecode, TopEncode,
-    TopEncodeMulti, TopEncodeMultiOutput,
-};
 
 const NULL_ENTRY: u32 = 0;
 const INFO_IDENTIFIER: &[u8] = b".info";

--- a/framework/base/src/storage/mappers/queue_mapper.rs
+++ b/framework/base/src/storage/mappers/queue_mapper.rs
@@ -8,7 +8,8 @@ use crate::{
     types::{ManagedType, MultiValueEncoded},
 };
 use alloc::vec::Vec;
-use mx_sc_codec::{
+use crate::codec::{
+    self,
     multi_encode_iter_or_handle_err,
     mx_sc_codec_derive::{TopDecode, TopDecodeOrDefault, TopEncode, TopEncodeOrDefault},
     CodecFrom, DecodeDefault, EncodeDefault, EncodeErrorHandler, TopDecode, TopEncode,
@@ -149,7 +150,7 @@ where
         storage_set(
             self.build_node_id_named_key(NODE_IDENTIFIER, node_id)
                 .as_ref(),
-            &mx_sc_codec::Empty,
+            &codec::Empty,
         );
     }
 
@@ -179,7 +180,7 @@ where
         storage_set(
             self.build_node_id_named_key(VALUE_IDENTIFIER, node_id)
                 .as_ref(),
-            &mx_sc_codec::Empty,
+            &codec::Empty,
         )
     }
 

--- a/framework/base/src/storage/mappers/set_mapper.rs
+++ b/framework/base/src/storage/mappers/set_mapper.rs
@@ -8,7 +8,7 @@ use crate::{
     storage::{storage_get, storage_set, StorageKey},
     types::{ManagedType, MultiValueEncoded},
 };
-use mx_sc_codec::{
+use crate::codec::{ self,
     multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, NestedDecode, NestedEncode,
     TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
 };
@@ -84,7 +84,7 @@ where
         storage_set(
             self.build_named_value_key(NODE_ID_IDENTIFIER, value)
                 .as_ref(),
-            &mx_sc_codec::Empty,
+            &codec::Empty,
         );
     }
 

--- a/framework/base/src/storage/mappers/set_mapper.rs
+++ b/framework/base/src/storage/mappers/set_mapper.rs
@@ -5,12 +5,12 @@ use super::{QueueMapper, StorageClearable, StorageMapper};
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::StorageMapperApi,
+    codec::{
+        self, multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, NestedDecode,
+        NestedEncode, TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
+    },
     storage::{storage_get, storage_set, StorageKey},
     types::{ManagedType, MultiValueEncoded},
-};
-use crate::codec::{ self,
-    multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, NestedDecode, NestedEncode,
-    TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
 };
 
 const NULL_ENTRY: u32 = 0;

--- a/framework/base/src/storage/mappers/single_value_mapper.rs
+++ b/framework/base/src/storage/mappers/single_value_mapper.rs
@@ -4,16 +4,16 @@ use super::StorageMapper;
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::StorageMapperApi,
+    codec::{
+        multi_types::PlaceholderOutput, CodecFrom, CodecFromSelf, DecodeErrorHandler,
+        EncodeErrorHandler, TopDecode, TopDecodeInput, TopEncode, TopEncodeMulti,
+        TopEncodeMultiOutput, TopEncodeOutput,
+    },
     storage::{
         storage_clear, storage_get, storage_get_from_address, storage_get_len, storage_set,
         StorageKey,
     },
     types::{ManagedAddress, ManagedType},
-};
-use crate::codec::{
-    multi_types::PlaceholderOutput, CodecFrom, CodecFromSelf, DecodeErrorHandler,
-    EncodeErrorHandler, TopDecode, TopDecodeInput, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
-    TopEncodeOutput,
 };
 use storage_get_from_address::storage_get_len_from_address;
 

--- a/framework/base/src/storage/mappers/single_value_mapper.rs
+++ b/framework/base/src/storage/mappers/single_value_mapper.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     types::{ManagedAddress, ManagedType},
 };
-use mx_sc_codec::{
+use crate::codec::{
     multi_types::PlaceholderOutput, CodecFrom, CodecFromSelf, DecodeErrorHandler,
     EncodeErrorHandler, TopDecode, TopDecodeInput, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
     TopEncodeOutput,

--- a/framework/base/src/storage/mappers/token_attributes_mapper.rs
+++ b/framework/base/src/storage/mappers/token_attributes_mapper.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{NestedDecode, NestedEncode, TopDecode, TopEncode};
+use crate::codec::{NestedDecode, NestedEncode, TopDecode, TopEncode};
 
 use super::StorageMapper;
 use crate::{

--- a/framework/base/src/storage/mappers/unique_id_mapper.rs
+++ b/framework/base/src/storage/mappers/unique_id_mapper.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{
+use crate::codec::{
     multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, TopEncodeMulti,
     TopEncodeMultiOutput,
 };

--- a/framework/base/src/storage/mappers/unordered_set_mapper.rs
+++ b/framework/base/src/storage/mappers/unordered_set_mapper.rs
@@ -9,7 +9,7 @@ use crate::{
     storage_clear, storage_get, storage_set,
     types::{ManagedAddress, ManagedType, MultiValueEncoded},
 };
-use mx_sc_codec::{
+use crate::codec::{
     multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, NestedDecode, NestedEncode,
     TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
 };

--- a/framework/base/src/storage/mappers/unordered_set_mapper.rs
+++ b/framework/base/src/storage/mappers/unordered_set_mapper.rs
@@ -5,13 +5,13 @@ use super::{StorageClearable, StorageMapper, VecMapper};
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::StorageMapperApi,
+    codec::{
+        multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, NestedDecode, NestedEncode,
+        TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
+    },
     storage::{storage_get_from_address, StorageKey},
     storage_clear, storage_get, storage_set,
     types::{ManagedAddress, ManagedType, MultiValueEncoded},
-};
-use crate::codec::{
-    multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, NestedDecode, NestedEncode,
-    TopDecode, TopEncode, TopEncodeMulti, TopEncodeMultiOutput,
 };
 
 const ITEM_INDEX: &[u8] = b".index";

--- a/framework/base/src/storage/mappers/user_mapper.rs
+++ b/framework/base/src/storage/mappers/user_mapper.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{
+use crate::codec::{
     multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, TopEncodeMulti,
     TopEncodeMultiOutput,
 };

--- a/framework/base/src/storage/mappers/vec_mapper.rs
+++ b/framework/base/src/storage/mappers/vec_mapper.rs
@@ -2,6 +2,10 @@ use super::{StorageClearable, StorageMapper};
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::{ErrorApiImpl, StorageMapperApi},
+    codec::{
+        multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, TopDecode, TopEncode,
+        TopEncodeMulti, TopEncodeMultiOutput,
+    },
     storage::{
         storage_clear, storage_get, storage_get_from_address, storage_get_len, storage_set,
         StorageKey,
@@ -9,10 +13,6 @@ use crate::{
     types::{ManagedAddress, ManagedType, MultiValueEncoded},
 };
 use core::{marker::PhantomData, usize};
-use crate::codec::{
-    multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, TopDecode, TopEncode,
-    TopEncodeMulti, TopEncodeMultiOutput,
-};
 use storage_get_from_address::storage_get_len_from_address;
 
 const ITEM_SUFFIX: &[u8] = b".item";

--- a/framework/base/src/storage/mappers/vec_mapper.rs
+++ b/framework/base/src/storage/mappers/vec_mapper.rs
@@ -9,7 +9,7 @@ use crate::{
     types::{ManagedAddress, ManagedType, MultiValueEncoded},
 };
 use core::{marker::PhantomData, usize};
-use mx_sc_codec::{
+use crate::codec::{
     multi_encode_iter_or_handle_err, CodecFrom, EncodeErrorHandler, TopDecode, TopEncode,
     TopEncodeMulti, TopEncodeMultiOutput,
 };

--- a/framework/base/src/storage/mappers/whitelist_mapper.rs
+++ b/framework/base/src/storage/mappers/whitelist_mapper.rs
@@ -6,7 +6,7 @@ use crate::{
     storage::StorageKey,
     types::ManagedAddress,
 };
-use mx_sc_codec::NestedEncode;
+use crate::codec::NestedEncode;
 
 type FlagMapper<SA> = SingleValueMapper<SA, bool>;
 

--- a/framework/base/src/storage/mappers/whitelist_mapper.rs
+++ b/framework/base/src/storage/mappers/whitelist_mapper.rs
@@ -3,10 +3,10 @@ use core::marker::PhantomData;
 use super::{SingleValueMapper, StorageMapper};
 use crate::{
     api::{ErrorApiImpl, StorageMapperApi},
+    codec::NestedEncode,
     storage::StorageKey,
     types::ManagedAddress,
 };
-use crate::codec::NestedEncode;
 
 type FlagMapper<SA> = SingleValueMapper<SA, bool>;
 

--- a/framework/base/src/storage/storage_get.rs
+++ b/framework/base/src/storage/storage_get.rs
@@ -5,13 +5,13 @@ use crate::{
         const_handles, use_raw_handle, ErrorApi, ErrorApiImpl, ManagedBufferApi, ManagedTypeApi,
         StaticVarApiImpl, StorageReadApi, StorageReadApiImpl,
     },
+    codec::*,
     err_msg,
     types::{
         BigInt, BigUint, ManagedBuffer, ManagedBufferNestedDecodeInput, ManagedRef, ManagedType,
     },
 };
 use alloc::boxed::Box;
-use crate::codec::*;
 
 use super::StorageKey;
 

--- a/framework/base/src/storage/storage_get.rs
+++ b/framework/base/src/storage/storage_get.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use alloc::boxed::Box;
-use mx_sc_codec::*;
+use crate::codec::*;
 
 use super::StorageKey;
 

--- a/framework/base/src/storage/storage_get_from_address.rs
+++ b/framework/base/src/storage/storage_get_from_address.rs
@@ -3,13 +3,13 @@ use crate::{
         const_handles, use_raw_handle, ErrorApi, ManagedBufferApi, ManagedTypeApi,
         StaticVarApiImpl, StorageReadApi, StorageReadApiImpl,
     },
+    codec::*,
     types::{
         BigInt, BigUint, ManagedAddress, ManagedBuffer, ManagedBufferNestedDecodeInput, ManagedRef,
         ManagedType,
     },
 };
 use alloc::boxed::Box;
-use crate::codec::*;
 
 use super::{StorageGetErrorHandler, StorageKey};
 

--- a/framework/base/src/storage/storage_get_from_address.rs
+++ b/framework/base/src/storage/storage_get_from_address.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 use alloc::boxed::Box;
-use mx_sc_codec::*;
+use crate::codec::*;
 
 use super::{StorageGetErrorHandler, StorageKey};
 

--- a/framework/base/src/storage/storage_key.rs
+++ b/framework/base/src/storage/storage_key.rs
@@ -4,7 +4,7 @@ use crate::{
     types::{heap::BoxedBytes, ManagedBuffer, ManagedByteArray, ManagedType},
     *,
 };
-use mx_sc_codec::*;
+use crate::codec::*;
 
 pub struct StorageKey<A>
 where

--- a/framework/base/src/storage/storage_key.rs
+++ b/framework/base/src/storage/storage_key.rs
@@ -1,10 +1,10 @@
 use crate::{
     api::{ErrorApi, ManagedTypeApi},
+    codec::*,
     contract_base::ExitCodecErrorHandler,
     types::{heap::BoxedBytes, ManagedBuffer, ManagedByteArray, ManagedType},
     *,
 };
-use crate::codec::*;
 
 pub struct StorageKey<A>
 where

--- a/framework/base/src/storage/storage_set.rs
+++ b/framework/base/src/storage/storage_set.rs
@@ -1,10 +1,10 @@
 use crate::{
     api::{ErrorApi, ManagedTypeApi, StorageWriteApi, StorageWriteApiImpl},
+    codec::*,
     contract_base::ExitCodecErrorHandler,
     err_msg,
     types::{BigInt, BigUint, ManagedBuffer, ManagedBufferCachedBuilder, ManagedRef, ManagedType},
 };
-use crate::codec::*;
 
 use super::StorageKey;
 

--- a/framework/base/src/storage/storage_set.rs
+++ b/framework/base/src/storage/storage_set.rs
@@ -4,7 +4,7 @@ use crate::{
     err_msg,
     types::{BigInt, BigUint, ManagedBuffer, ManagedBufferCachedBuilder, ManagedRef, ManagedType},
 };
-use mx_sc_codec::*;
+use crate::codec::*;
 
 use super::StorageKey;
 

--- a/framework/base/src/types/crypto/message_hash_type.rs
+++ b/framework/base/src/types/crypto/message_hash_type.rs
@@ -1,5 +1,8 @@
-use crate::abi::{TypeAbi, TypeName};
-use mx_sc_codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode};
+use crate::{
+    abi::{TypeAbi, TypeName},
+    codec,
+    codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
+};
 
 /// Message hash type for the `verifyCustomSecp256k1` CryptoApi function
 #[derive(TopDecode, TopEncode, NestedDecode, NestedEncode, Clone, PartialEq, Eq, Debug)]

--- a/framework/base/src/types/flags/code_metadata.rs
+++ b/framework/base/src/types/flags/code_metadata.rs
@@ -1,9 +1,9 @@
 use crate::{
     abi::{TypeAbi, TypeName},
+    codec::*,
     formatter::{hex_util, FormatByteReceiver, SCBinary, SCDisplay, SCLowerHex},
 };
 use bitflags::bitflags;
-use crate::codec::*;
 
 const UPGRADEABLE_STRING: &[u8] = b"Upgradeable";
 const READABLE_STRING: &[u8] = b"Readable";

--- a/framework/base/src/types/flags/code_metadata.rs
+++ b/framework/base/src/types/flags/code_metadata.rs
@@ -3,7 +3,7 @@ use crate::{
     formatter::{hex_util, FormatByteReceiver, SCBinary, SCDisplay, SCLowerHex},
 };
 use bitflags::bitflags;
-use mx_sc_codec::*;
+use crate::codec::*;
 
 const UPGRADEABLE_STRING: &[u8] = b"Upgradeable";
 const READABLE_STRING: &[u8] = b"Readable";

--- a/framework/base/src/types/flags/esdt_local_role.rs
+++ b/framework/base/src/types/flags/esdt_local_role.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode};
+use crate::codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode};use crate::codec;
 
 use super::EsdtLocalRoleFlags;
 use crate as mx_sc;

--- a/framework/base/src/types/flags/esdt_local_role.rs
+++ b/framework/base/src/types/flags/esdt_local_role.rs
@@ -1,4 +1,7 @@
-use crate::codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode};use crate::codec;
+use crate::{
+    codec,
+    codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
+};
 
 use super::EsdtLocalRoleFlags;
 use crate as mx_sc;

--- a/framework/base/src/types/flags/esdt_token_type.rs
+++ b/framework/base/src/types/flags/esdt_token_type.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::*;
+use crate::codec::*;
 
 const ESDT_TYPE_FUNGIBLE: &[u8] = b"FungibleESDT";
 const ESDT_TYPE_NON_FUNGIBLE: &[u8] = b"NonFungibleESDT";

--- a/framework/base/src/types/heap/arg_buffer.rs
+++ b/framework/base/src/types/heap/arg_buffer.rs
@@ -1,9 +1,9 @@
 use crate::{
     api::ManagedTypeApi,
+    codec::TopEncodeOutput,
     types::{heap::BoxedBytes, ManagedArgBuffer},
 };
 use alloc::vec::Vec;
-use crate::codec::TopEncodeOutput;
 
 /// Helper structure for providing arguments to all SC call functions other than async_call_raw.
 /// It keeps argument lengths separately from the argument data itself.

--- a/framework/base/src/types/heap/arg_buffer.rs
+++ b/framework/base/src/types/heap/arg_buffer.rs
@@ -3,7 +3,7 @@ use crate::{
     types::{heap::BoxedBytes, ManagedArgBuffer},
 };
 use alloc::vec::Vec;
-use mx_sc_codec::TopEncodeOutput;
+use crate::codec::TopEncodeOutput;
 
 /// Helper structure for providing arguments to all SC call functions other than async_call_raw.
 /// It keeps argument lengths separately from the argument data itself.

--- a/framework/base/src/types/heap/async_call_result.rs
+++ b/framework/base/src/types/heap/async_call_result.rs
@@ -2,7 +2,7 @@ use crate::{
     abi::{TypeAbi, TypeName},
     types::heap::BoxedBytes,
 };
-use mx_sc_codec::{
+use crate::codec::{
     DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput, TopEncodeMulti,
     TopEncodeMultiOutput,
 };

--- a/framework/base/src/types/heap/async_call_result.rs
+++ b/framework/base/src/types/heap/async_call_result.rs
@@ -1,10 +1,10 @@
 use crate::{
     abi::{TypeAbi, TypeName},
+    codec::{
+        DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput,
+        TopEncodeMulti, TopEncodeMultiOutput,
+    },
     types::heap::BoxedBytes,
-};
-use crate::codec::{
-    DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput, TopEncodeMulti,
-    TopEncodeMultiOutput,
 };
 
 pub struct AsyncCallError {

--- a/framework/base/src/types/heap/boxed_bytes.rs
+++ b/framework/base/src/types/heap/boxed_bytes.rs
@@ -4,7 +4,7 @@ use alloc::{
     boxed::Box,
     vec::Vec,
 };
-use mx_sc_codec::*;
+use crate::codec::*;
 
 /// Simple wrapper around a boxed byte slice,
 /// but with a lot of optimized methods for manipulating it.

--- a/framework/base/src/types/heap/boxed_bytes.rs
+++ b/framework/base/src/types/heap/boxed_bytes.rs
@@ -1,10 +1,12 @@
-use crate::abi::{TypeAbi, TypeName};
+use crate::{
+    abi::{TypeAbi, TypeName},
+    codec::*,
+};
 use alloc::{
     alloc::{alloc, alloc_zeroed, realloc, Layout},
     boxed::Box,
     vec::Vec,
 };
-use crate::codec::*;
 
 /// Simple wrapper around a boxed byte slice,
 /// but with a lot of optimized methods for manipulating it.

--- a/framework/base/src/types/heap/h256.rs
+++ b/framework/base/src/types/heap/h256.rs
@@ -233,8 +233,8 @@ impl TypeAbi for H256 {
 #[cfg(test)]
 mod h256_tests {
     use super::*;
-    use alloc::vec::Vec;
     use crate::codec::test_util::{check_top_encode, check_top_encode_decode};
+    use alloc::vec::Vec;
 
     #[test]
     fn test_h256_from_array() {

--- a/framework/base/src/types/heap/h256.rs
+++ b/framework/base/src/types/heap/h256.rs
@@ -157,7 +157,7 @@ impl H256 {
     }
 }
 
-use mx_sc_codec::*;
+use crate::codec::*;
 
 impl NestedEncode for H256 {
     fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, _h: H) -> Result<(), H::HandledErr>
@@ -234,7 +234,7 @@ impl TypeAbi for H256 {
 mod h256_tests {
     use super::*;
     use alloc::vec::Vec;
-    use mx_sc_codec::test_util::{check_top_encode, check_top_encode_decode};
+    use crate::codec::test_util::{check_top_encode, check_top_encode_decode};
 
     #[test]
     fn test_h256_from_array() {

--- a/framework/base/src/types/heap/h256_address.rs
+++ b/framework/base/src/types/heap/h256_address.rs
@@ -151,7 +151,7 @@ impl Address {
     }
 }
 
-use mx_sc_codec::*;
+use crate::codec::*;
 
 impl NestedEncode for Address {
     fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, h: H) -> Result<(), H::HandledErr>
@@ -203,7 +203,7 @@ impl TypeAbi for Address {
 mod address_tests {
     use super::*;
     use alloc::vec::Vec;
-    use mx_sc_codec::test_util::{check_top_encode, check_top_encode_decode};
+    use crate::codec::test_util::{check_top_encode, check_top_encode_decode};
 
     #[test]
     fn test_address() {

--- a/framework/base/src/types/heap/h256_address.rs
+++ b/framework/base/src/types/heap/h256_address.rs
@@ -202,8 +202,8 @@ impl TypeAbi for Address {
 #[cfg(test)]
 mod address_tests {
     use super::*;
-    use alloc::vec::Vec;
     use crate::codec::test_util::{check_top_encode, check_top_encode_decode};
+    use alloc::vec::Vec;
 
     #[test]
     fn test_address() {

--- a/framework/base/src/types/heap/queue.rs
+++ b/framework/base/src/types/heap/queue.rs
@@ -1,6 +1,6 @@
 use crate::abi::{TypeAbi, TypeName};
 use alloc::vec::Vec;
-use mx_sc_codec::*;
+use crate::codec::*;
 
 /// A simple queue struct that is able to push and pop without moving elements.
 /// New items are pushed at the end, just like for a regular Vec.

--- a/framework/base/src/types/heap/queue.rs
+++ b/framework/base/src/types/heap/queue.rs
@@ -1,6 +1,8 @@
-use crate::abi::{TypeAbi, TypeName};
+use crate::{
+    abi::{TypeAbi, TypeName},
+    codec::*,
+};
 use alloc::vec::Vec;
-use crate::codec::*;
 
 /// A simple queue struct that is able to push and pop without moving elements.
 /// New items are pushed at the end, just like for a regular Vec.

--- a/framework/base/src/types/interaction/arg_buffer_managed.rs
+++ b/framework/base/src/types/interaction/arg_buffer_managed.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use alloc::vec::Vec;
-use mx_sc_codec::{
+use crate::codec::{
     DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
     NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeMultiOutput,
     TopEncodeOutput,

--- a/framework/base/src/types/interaction/arg_buffer_managed.rs
+++ b/framework/base/src/types/interaction/arg_buffer_managed.rs
@@ -1,5 +1,10 @@
 use crate::{
     api::{ErrorApi, ManagedTypeApi},
+    codec::{
+        DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
+        NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeMultiOutput,
+        TopEncodeOutput,
+    },
     contract_base::ExitCodecErrorHandler,
     err_msg,
     types::{
@@ -8,11 +13,6 @@ use crate::{
     },
 };
 use alloc::vec::Vec;
-use crate::codec::{
-    DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
-    NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeMultiOutput,
-    TopEncodeOutput,
-};
 
 #[derive(Debug, Default)]
 #[repr(transparent)]

--- a/framework/base/src/types/interaction/callback_closure.rs
+++ b/framework/base/src/types/interaction/callback_closure.rs
@@ -1,15 +1,16 @@
 use crate::{
     api::{BlockchainApi, ErrorApi, ManagedTypeApi, StorageReadApi, StorageWriteApi},
+    codec::{
+        self,
+        mx_sc_codec_derive::{TopDecode, TopEncode},
+        TopEncodeMulti,
+    },
     contract_base::{BlockchainWrapper, ExitCodecErrorHandler, ManagedSerializer},
     err_msg,
     io::ManagedResultArgLoader,
     storage::StorageKey,
     storage_clear, storage_get, storage_set,
     types::{ManagedBuffer, ManagedType},
-};
-use crate::codec::{ self,
-    mx_sc_codec_derive::{TopDecode, TopEncode},
-    TopEncodeMulti,
 };
 
 use super::ManagedArgBuffer;

--- a/framework/base/src/types/interaction/callback_closure.rs
+++ b/framework/base/src/types/interaction/callback_closure.rs
@@ -7,7 +7,7 @@ use crate::{
     storage_clear, storage_get, storage_set,
     types::{ManagedBuffer, ManagedType},
 };
-use mx_sc_codec::{
+use crate::codec::{ self,
     mx_sc_codec_derive::{TopDecode, TopEncode},
     TopEncodeMulti,
 };

--- a/framework/base/src/types/interaction/contract_call_exec.rs
+++ b/framework/base/src/types/interaction/contract_call_exec.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::TopDecodeMulti;
+use crate::codec::TopDecodeMulti;
 
 use crate::{
     api::{BlockchainApiImpl, CallTypeApi},

--- a/framework/base/src/types/interaction/contract_call_no_payment.rs
+++ b/framework/base/src/types/interaction/contract_call_no_payment.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::TopEncodeMulti;
+use crate::codec::TopEncodeMulti;
 
 use crate::{
     api::CallTypeApi,

--- a/framework/base/src/types/interaction/contract_call_trait.rs
+++ b/framework/base/src/types/interaction/contract_call_trait.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{multi_types::IgnoreValue, TopDecodeMulti, TopEncodeMulti};
+use crate::codec::{multi_types::IgnoreValue, TopDecodeMulti, TopEncodeMulti};
 
 use crate::{
     api::CallTypeApi, contract_base::ExitCodecErrorHandler, err_msg, types::ManagedBuffer,

--- a/framework/base/src/types/interaction/contract_call_with_egld.rs
+++ b/framework/base/src/types/interaction/contract_call_with_egld.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::TopEncodeMulti;
+use crate::codec::TopEncodeMulti;
 
 use crate::{
     api::CallTypeApi,

--- a/framework/base/src/types/interaction/contract_call_with_egld_or_single_esdt.rs
+++ b/framework/base/src/types/interaction/contract_call_with_egld_or_single_esdt.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::TopEncodeMulti;
+use crate::codec::TopEncodeMulti;
 
 use crate::{
     api::CallTypeApi,

--- a/framework/base/src/types/interaction/contract_call_with_multi_esdt.rs
+++ b/framework/base/src/types/interaction/contract_call_with_multi_esdt.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::TopEncodeMulti;
+use crate::codec::TopEncodeMulti;
 
 use crate::{
     api::CallTypeApi,

--- a/framework/base/src/types/interaction/contract_deploy.rs
+++ b/framework/base/src/types/interaction/contract_deploy.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{CodecFrom, TopEncodeMulti};
+use crate::codec::{CodecFrom, TopEncodeMulti};
 
 use crate::{
     api::{BlockchainApiImpl, CallTypeApi},

--- a/framework/base/src/types/io/codec_multi_value_aliases.rs
+++ b/framework/base/src/types/io/codec_multi_value_aliases.rs
@@ -1,4 +1,5 @@
-use mx_sc_codec::multi_types::{IgnoreValue, OptionalValue};
+use crate::codec::multi_types::{IgnoreValue, OptionalValue};
+use crate::codec;
 
 /// Structure that allows taking a variable number of arguments
 /// or returning a variable number of results in a smart contract endpoint.
@@ -7,7 +8,7 @@ use mx_sc_codec::multi_types::{IgnoreValue, OptionalValue};
     note = "Alias kept for backwards compatibility. Replace with `MultiValueVec`"
 )]
 #[cfg(feature = "alloc")]
-pub type MultiArgVec<T> = mx_sc_codec::multi_types::MultiValueVec<T>;
+pub type MultiArgVec<T> = codec::multi_types::MultiValueVec<T>;
 
 /// Used for taking a variable number of arguments in an endpoint,
 /// it is synonymous with `MultiResultVec`/`MultiArgVec`.
@@ -16,7 +17,7 @@ pub type MultiArgVec<T> = mx_sc_codec::multi_types::MultiValueVec<T>;
     note = "Alias kept for backwards compatibility. Replace with `MultiValueVec`"
 )]
 #[cfg(feature = "alloc")]
-pub type VarArgs<T> = mx_sc_codec::multi_types::MultiValueVec<T>;
+pub type VarArgs<T> = codec::multi_types::MultiValueVec<T>;
 
 /// Used for returning a variable number of results from an endpoint,
 /// it is synonymous with `MultiResult`.
@@ -25,7 +26,7 @@ pub type VarArgs<T> = mx_sc_codec::multi_types::MultiValueVec<T>;
     note = "Alias kept for backwards compatibility. Replace with `MultiValueVec`"
 )]
 #[cfg(feature = "alloc")]
-pub type MultiResultVec<T> = mx_sc_codec::multi_types::MultiValueVec<T>;
+pub type MultiResultVec<T> = codec::multi_types::MultiValueVec<T>;
 
 /// Structure that allows taking a variable number of arguments,
 /// but does nothing with them, not even deserialization.
@@ -64,13 +65,13 @@ macro_rules! multi_arg_impls {
                 since = "0.29.0",
                 note = "Alias kept for backwards compatibility. Replace with `MultiValue*`"
             )]
-            pub type $marg_struct<$($name,)+> = mx_sc_codec::multi_types::$mval_struct<$($name,)+>;
+            pub type $marg_struct<$($name,)+> = codec::multi_types::$mval_struct<$($name,)+>;
 
             #[deprecated(
                 since = "0.29.0",
                 note = "Alias kept for backwards compatibility. Replace with `MultiValue*`"
             )]
-            pub type $mres_struct<$($name,)+> = mx_sc_codec::multi_types::$mval_struct<$($name,)+>;
+            pub type $mres_struct<$($name,)+> = codec::multi_types::$mval_struct<$($name,)+>;
         )+
     }
 }

--- a/framework/base/src/types/io/codec_multi_value_aliases.rs
+++ b/framework/base/src/types/io/codec_multi_value_aliases.rs
@@ -1,5 +1,7 @@
-use crate::codec::multi_types::{IgnoreValue, OptionalValue};
-use crate::codec;
+use crate::{
+    codec,
+    codec::multi_types::{IgnoreValue, OptionalValue},
+};
 
 /// Structure that allows taking a variable number of arguments
 /// or returning a variable number of results in a smart contract endpoint.

--- a/framework/base/src/types/io/operation_completion_status.rs
+++ b/framework/base/src/types/io/operation_completion_status.rs
@@ -1,9 +1,9 @@
 use crate::{
     abi::{TypeAbi, TypeName},
     api::ManagedTypeApi,
+    codec::{CodecFrom, EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput},
     types::ManagedBuffer,
 };
-use crate::codec::{CodecFrom, EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput};
 
 /// Standard way of signalling that an operation was interrupted early, before running out of gas.
 /// An endpoint that performs a longer operation can check from time to time if it is running low

--- a/framework/base/src/types/io/operation_completion_status.rs
+++ b/framework/base/src/types/io/operation_completion_status.rs
@@ -3,7 +3,7 @@ use crate::{
     api::ManagedTypeApi,
     types::ManagedBuffer,
 };
-use mx_sc_codec::{CodecFrom, EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput};
+use crate::codec::{CodecFrom, EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput};
 
 /// Standard way of signalling that an operation was interrupted early, before running out of gas.
 /// An endpoint that performs a longer operation can check from time to time if it is running low

--- a/framework/base/src/types/io/sc_error_managed.rs
+++ b/framework/base/src/types/io/sc_error_managed.rs
@@ -1,5 +1,5 @@
-use alloc::{string::String, vec::Vec};
 use crate::codec::{EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput, TryStaticCast};
+use alloc::{string::String, vec::Vec};
 
 use crate::{
     api::{EndpointFinishApi, ErrorApi, ErrorApiImpl, ManagedTypeApi},

--- a/framework/base/src/types/io/sc_error_managed.rs
+++ b/framework/base/src/types/io/sc_error_managed.rs
@@ -1,5 +1,5 @@
 use alloc::{string::String, vec::Vec};
-use mx_sc_codec::{EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput, TryStaticCast};
+use crate::codec::{EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput, TryStaticCast};
 
 use crate::{
     api::{EndpointFinishApi, ErrorApi, ErrorApiImpl, ManagedTypeApi},

--- a/framework/base/src/types/io/sc_error_static.rs
+++ b/framework/base/src/types/io/sc_error_static.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{DecodeError, EncodeError, TopEncodeMulti, TryStaticCast};
+use crate::codec::{self, DecodeError, EncodeError, TopEncodeMulti, TryStaticCast};
 
 use crate::api::{EndpointFinishApi, ErrorApiImpl};
 
@@ -63,8 +63,8 @@ impl From<!> for StaticSCError {
 impl TopEncodeMulti for StaticSCError {
     fn multi_encode_or_handle_err<O, H>(&self, output: &mut O, h: H) -> Result<(), H::HandledErr>
     where
-        O: mx_sc_codec::TopEncodeMultiOutput,
-        H: mx_sc_codec::EncodeErrorHandler,
+        O: codec::TopEncodeMultiOutput,
+        H: codec::EncodeErrorHandler,
     {
         output.push_multi_specialized(self, h)
     }

--- a/framework/base/src/types/io/sc_result.rs
+++ b/framework/base/src/types/io/sc_result.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput};
+use crate::codec::{EncodeErrorHandler, TopEncodeMulti, TopEncodeMultiOutput};
 
 use crate::{
     abi::{OutputAbis, TypeAbi, TypeDescriptionContainer, TypeName},
@@ -173,7 +173,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use mx_sc_codec::DecodeError;
+    use crate::codec::DecodeError;
 
     use super::*;
 

--- a/framework/base/src/types/managed/basic/big_float.rs
+++ b/framework/base/src/types/managed/basic/big_float.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloc::string::String;
 
-use mx_sc_codec::{
+use crate::codec::{
     CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput,
     NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
     TryStaticCast,

--- a/framework/base/src/types/managed/basic/big_int.rs
+++ b/framework/base/src/types/managed/basic/big_int.rs
@@ -9,7 +9,8 @@ use crate::{
     formatter::{hex_util::encode_bytes_as_hex, FormatByteReceiver, SCDisplay},
     types::{heap::BoxedBytes, BigUint, ManagedBuffer, ManagedOption, ManagedType, Sign},
 };
-use mx_sc_codec::{
+use crate::codec::{
+    self,
     CodecFrom, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
     NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
     TopEncodeOutput, TryStaticCast,
@@ -113,19 +114,19 @@ big_int_conv_num! {i8}
 impl<M> CodecFromSelf for BigInt<M> where M: ManagedTypeApi {}
 
 #[cfg(feature = "num-bigint")]
-impl<M: ManagedTypeApi> CodecFrom<mx_sc_codec::num_bigint::BigInt> for BigInt<M> {}
+impl<M: ManagedTypeApi> CodecFrom<codec::num_bigint::BigInt> for BigInt<M> {}
 #[cfg(feature = "num-bigint")]
-impl<M: ManagedTypeApi> CodecFrom<BigInt<M>> for mx_sc_codec::num_bigint::BigInt {}
+impl<M: ManagedTypeApi> CodecFrom<BigInt<M>> for codec::num_bigint::BigInt {}
 
 #[cfg(feature = "num-bigint")]
-impl<M: ManagedTypeApi> From<&mx_sc_codec::num_bigint::BigInt> for BigInt<M> {
-    fn from(alloc_big_int: &mx_sc_codec::num_bigint::BigInt) -> Self {
+impl<M: ManagedTypeApi> From<&codec::num_bigint::BigInt> for BigInt<M> {
+    fn from(alloc_big_int: &codec::num_bigint::BigInt) -> Self {
         BigInt::from_signed_bytes_be(alloc_big_int.to_signed_bytes_be().as_slice())
     }
 }
 #[cfg(feature = "num-bigint")]
-impl<M: ManagedTypeApi> From<mx_sc_codec::num_bigint::BigInt> for BigInt<M> {
-    fn from(alloc_big_int: mx_sc_codec::num_bigint::BigInt) -> Self {
+impl<M: ManagedTypeApi> From<codec::num_bigint::BigInt> for BigInt<M> {
+    fn from(alloc_big_int: codec::num_bigint::BigInt) -> Self {
         BigInt::from(&alloc_big_int)
     }
 }

--- a/framework/base/src/types/managed/basic/big_int.rs
+++ b/framework/base/src/types/managed/basic/big_int.rs
@@ -6,14 +6,13 @@ use crate::{
         const_handles, use_raw_handle, BigIntApi, HandleConstraints, ManagedTypeApi,
         ManagedTypeApiImpl, RawHandle, StaticVarApiImpl,
     },
+    codec::{
+        self, CodecFrom, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
+        NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
+        TopEncodeOutput, TryStaticCast,
+    },
     formatter::{hex_util::encode_bytes_as_hex, FormatByteReceiver, SCDisplay},
     types::{heap::BoxedBytes, BigUint, ManagedBuffer, ManagedOption, ManagedType, Sign},
-};
-use crate::codec::{
-    self,
-    CodecFrom, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
-    NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
-    TopEncodeOutput, TryStaticCast,
 };
 
 use super::cast_to_i64::cast_to_i64;

--- a/framework/base/src/types/managed/basic/big_int_sign.rs
+++ b/framework/base/src/types/managed/basic/big_int_sign.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{
+use crate::codec::{
     DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
     NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
 };

--- a/framework/base/src/types/managed/basic/big_uint.rs
+++ b/framework/base/src/types/managed/basic/big_uint.rs
@@ -9,7 +9,8 @@ use crate::{
     formatter::{hex_util::encode_bytes_as_hex, FormatByteReceiver, SCDisplay},
     types::{heap::BoxedBytes, ManagedBuffer, ManagedType},
 };
-use mx_sc_codec::{
+use crate::codec::{
+    self,
     CodecFrom, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
     NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
     TopEncodeOutput, TryStaticCast,
@@ -94,26 +95,26 @@ big_uint_conv_num! {u8}
 impl<M> CodecFromSelf for BigUint<M> where M: ManagedTypeApi {}
 
 #[cfg(feature = "num-bigint")]
-impl<M: ManagedTypeApi> CodecFrom<mx_sc_codec::num_bigint::BigUint> for BigUint<M> {}
+impl<M: ManagedTypeApi> CodecFrom<codec::num_bigint::BigUint> for BigUint<M> {}
 #[cfg(feature = "num-bigint")]
-impl<M: ManagedTypeApi> CodecFrom<BigUint<M>> for mx_sc_codec::num_bigint::BigUint {}
+impl<M: ManagedTypeApi> CodecFrom<BigUint<M>> for codec::num_bigint::BigUint {}
 
 #[cfg(feature = "num-bigint")]
-impl<M: ManagedTypeApi> From<&mx_sc_codec::num_bigint::BigUint> for BigUint<M> {
-    fn from(alloc_big_uint: &mx_sc_codec::num_bigint::BigUint) -> Self {
+impl<M: ManagedTypeApi> From<&codec::num_bigint::BigUint> for BigUint<M> {
+    fn from(alloc_big_uint: &codec::num_bigint::BigUint) -> Self {
         BigUint::from_bytes_be(alloc_big_uint.to_bytes_be().as_slice())
     }
 }
 #[cfg(feature = "num-bigint")]
-impl<M: ManagedTypeApi> From<mx_sc_codec::num_bigint::BigUint> for BigUint<M> {
-    fn from(alloc_big_uint: mx_sc_codec::num_bigint::BigUint) -> Self {
+impl<M: ManagedTypeApi> From<codec::num_bigint::BigUint> for BigUint<M> {
+    fn from(alloc_big_uint: codec::num_bigint::BigUint) -> Self {
         BigUint::from(&alloc_big_uint)
     }
 }
 #[cfg(feature = "num-bigint")]
 impl<M: ManagedTypeApi> BigUint<M> {
-    pub fn to_alloc(&self) -> mx_sc_codec::num_bigint::BigUint {
-        mx_sc_codec::num_bigint::BigUint::from_bytes_be(self.to_bytes_be().as_slice())
+    pub fn to_alloc(&self) -> codec::num_bigint::BigUint {
+        codec::num_bigint::BigUint::from_bytes_be(self.to_bytes_be().as_slice())
     }
 }
 

--- a/framework/base/src/types/managed/basic/big_uint.rs
+++ b/framework/base/src/types/managed/basic/big_uint.rs
@@ -6,14 +6,13 @@ use crate::{
         const_handles, use_raw_handle, BigIntApi, HandleConstraints, ManagedBufferApi,
         ManagedTypeApi, ManagedTypeApiImpl, RawHandle, StaticVarApiImpl,
     },
+    codec::{
+        self, CodecFrom, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
+        NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
+        TopEncodeOutput, TryStaticCast,
+    },
     formatter::{hex_util::encode_bytes_as_hex, FormatByteReceiver, SCDisplay},
     types::{heap::BoxedBytes, ManagedBuffer, ManagedType},
-};
-use crate::codec::{
-    self,
-    CodecFrom, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
-    NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
-    TopEncodeOutput, TryStaticCast,
 };
 
 use super::cast_to_i64::cast_to_i64;

--- a/framework/base/src/types/managed/basic/elliptic_curve.rs
+++ b/framework/base/src/types/managed/basic/elliptic_curve.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use crate::{api::StaticVarApiImpl, types::ManagedBuffer};
 
-use mx_sc_codec::*;
+use crate::codec::*;
 
 pub const ELLIPTIC_CURVE_P224_INT: u32 = 224;
 pub const ELLIPTIC_CURVE_P224_NAME: &str = "p224";

--- a/framework/base/src/types/managed/basic/managed_buffer.rs
+++ b/framework/base/src/types/managed/basic/managed_buffer.rs
@@ -4,15 +4,15 @@ use crate::{
         use_raw_handle, ErrorApiImpl, HandleConstraints, InvalidSliceError, ManagedBufferApi,
         ManagedTypeApi, StaticVarApiImpl,
     },
+    codec::{
+        CodecFrom, CodecFromSelf, DecodeErrorHandler, Empty, EncodeErrorHandler, NestedDecode,
+        NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
+        TopEncodeOutput, TryStaticCast,
+    },
     formatter::{
         hex_util::encode_bytes_as_hex, FormatByteReceiver, SCBinary, SCDisplay, SCLowerHex,
     },
     types::{heap::BoxedBytes, ManagedType},
-};
-use crate::codec::{
-    CodecFrom, CodecFromSelf, DecodeErrorHandler, Empty, EncodeErrorHandler, NestedDecode,
-    NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
-    TopEncodeOutput, TryStaticCast,
 };
 
 /// A byte buffer managed by an external API.

--- a/framework/base/src/types/managed/basic/managed_buffer.rs
+++ b/framework/base/src/types/managed/basic/managed_buffer.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     types::{heap::BoxedBytes, ManagedType},
 };
-use mx_sc_codec::{
+use crate::codec::{
     CodecFrom, CodecFromSelf, DecodeErrorHandler, Empty, EncodeErrorHandler, NestedDecode,
     NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
     TopEncodeOutput, TryStaticCast,

--- a/framework/base/src/types/managed/codec_util/managed_buffer_nested_de_input.rs
+++ b/framework/base/src/types/managed/codec_util/managed_buffer_nested_de_input.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{
+use crate::codec::{
     try_execute_then_cast, DecodeError, DecodeErrorHandler, NestedDecode, NestedDecodeInput,
     TryStaticCast,
 };

--- a/framework/base/src/types/managed/codec_util/managed_buffer_nested_en_output.rs
+++ b/framework/base/src/types/managed/codec_util/managed_buffer_nested_en_output.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{EncodeError, EncodeErrorHandler, NestedEncodeOutput, TryStaticCast};
+use crate::codec::{EncodeError, EncodeErrorHandler, NestedEncodeOutput, TryStaticCast};
 
 use crate::{
     api::ManagedTypeApi,

--- a/framework/base/src/types/managed/codec_util/managed_buffer_top_de_input.rs
+++ b/framework/base/src/types/managed/codec_util/managed_buffer_top_de_input.rs
@@ -1,5 +1,5 @@
 use alloc::boxed::Box;
-use mx_sc_codec::{
+use crate::codec::{
     try_execute_then_cast, DecodeError, DecodeErrorHandler, TopDecodeInput, TryStaticCast,
 };
 

--- a/framework/base/src/types/managed/codec_util/managed_buffer_top_de_input.rs
+++ b/framework/base/src/types/managed/codec_util/managed_buffer_top_de_input.rs
@@ -1,7 +1,7 @@
-use alloc::boxed::Box;
 use crate::codec::{
     try_execute_then_cast, DecodeError, DecodeErrorHandler, TopDecodeInput, TryStaticCast,
 };
+use alloc::boxed::Box;
 
 use crate::{
     api::ManagedTypeApi,

--- a/framework/base/src/types/managed/codec_util/managed_buffer_top_en_output.rs
+++ b/framework/base/src/types/managed/codec_util/managed_buffer_top_en_output.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{EncodeError, EncodeErrorHandler, TopEncodeOutput, TryStaticCast};
+use crate::codec::{EncodeError, EncodeErrorHandler, TopEncodeOutput, TryStaticCast};
 
 use crate::{
     api::ManagedTypeApi,

--- a/framework/base/src/types/managed/multi_value/async_call_result_managed.rs
+++ b/framework/base/src/types/managed/multi_value/async_call_result_managed.rs
@@ -3,7 +3,7 @@ use crate::{
     api::ManagedTypeApi,
     types::ManagedBuffer,
 };
-use mx_sc_codec::{
+use crate::codec::{
     DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput, TopEncodeMulti,
     TopEncodeMultiOutput,
 };

--- a/framework/base/src/types/managed/multi_value/async_call_result_managed.rs
+++ b/framework/base/src/types/managed/multi_value/async_call_result_managed.rs
@@ -1,11 +1,11 @@
 use crate::{
     abi::{TypeAbi, TypeName},
     api::ManagedTypeApi,
+    codec::{
+        DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput,
+        TopEncodeMulti, TopEncodeMultiOutput,
+    },
     types::ManagedBuffer,
-};
-use crate::codec::{
-    DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput, TopEncodeMulti,
-    TopEncodeMultiOutput,
 };
 
 const SAME_SHARD_SUCCESS_CODE: u32 = 0;

--- a/framework/base/src/types/managed/multi_value/esdt_token_payment_multi_arg.rs
+++ b/framework/base/src/types/managed/multi_value/esdt_token_payment_multi_arg.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{
+use crate::codec::{
     multi_types::MultiValue3, DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti,
     TopDecodeMultiInput, TopDecodeMultiLength, TopEncodeMulti, TopEncodeMultiOutput,
 };

--- a/framework/base/src/types/managed/multi_value/multi_value_encoded.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_encoded.rs
@@ -6,7 +6,7 @@ use crate::{
     types::{ManagedArgBuffer, ManagedBuffer, ManagedType, ManagedVec, ManagedVecItem},
 };
 use core::{iter::FromIterator, marker::PhantomData};
-use mx_sc_codec::{
+use crate::codec::{
     try_cast_execute_or_else, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, TopDecode,
     TopDecodeMulti, TopDecodeMultiInput, TopDecodeMultiLength, TopEncode, TopEncodeMulti,
     TopEncodeMultiOutput,
@@ -243,7 +243,7 @@ where
 impl<M, T> CodecFromSelf for MultiValueEncoded<M, T> where M: ManagedTypeApi {}
 
 #[cfg(feature = "alloc")]
-use mx_sc_codec::{multi_types::MultiValueVec, CodecFrom};
+use crate::codec::{multi_types::MultiValueVec, CodecFrom};
 
 #[cfg(feature = "alloc")]
 impl<M, T, U> CodecFrom<MultiValueVec<T>> for MultiValueEncoded<M, U>

--- a/framework/base/src/types/managed/multi_value/multi_value_encoded.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_encoded.rs
@@ -1,16 +1,16 @@
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::{ErrorApi, ManagedTypeApi},
+    codec::{
+        try_cast_execute_or_else, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, TopDecode,
+        TopDecodeMulti, TopDecodeMultiInput, TopDecodeMultiLength, TopEncode, TopEncodeMulti,
+        TopEncodeMultiOutput,
+    },
     contract_base::{ExitCodecErrorHandler, ManagedSerializer},
     err_msg,
     types::{ManagedArgBuffer, ManagedBuffer, ManagedType, ManagedVec, ManagedVecItem},
 };
 use core::{iter::FromIterator, marker::PhantomData};
-use crate::codec::{
-    try_cast_execute_or_else, CodecFromSelf, DecodeErrorHandler, EncodeErrorHandler, TopDecode,
-    TopDecodeMulti, TopDecodeMultiInput, TopDecodeMultiLength, TopEncode, TopEncodeMulti,
-    TopEncodeMultiOutput,
-};
 
 /// A multi-value container, that keeps raw values as ManagedBuffer
 /// It allows encoding and decoding of multi-values.

--- a/framework/base/src/types/managed/multi_value/multi_value_encoded_iter.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_encoded_iter.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{TopDecodeMulti, TopDecodeMultiInput};
+use crate::codec::{TopDecodeMulti, TopDecodeMultiInput};
 
 use crate::{
     api::{ErrorApi, ManagedTypeApi},

--- a/framework/base/src/types/managed/multi_value/multi_value_managed_vec.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_managed_vec.rs
@@ -1,11 +1,11 @@
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::ManagedTypeApi,
+    codec::{
+        DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput,
+        TopEncodeMulti, TopEncodeMultiOutput, Vec,
+    },
     types::ManagedType,
-};
-use crate::codec::{
-    DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput, TopEncodeMulti,
-    TopEncodeMultiOutput, Vec,
 };
 
 use crate::types::{ManagedVec, ManagedVecItem, ManagedVecRefIterator};

--- a/framework/base/src/types/managed/multi_value/multi_value_managed_vec.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_managed_vec.rs
@@ -3,7 +3,7 @@ use crate::{
     api::ManagedTypeApi,
     types::ManagedType,
 };
-use mx_sc_codec::{
+use crate::codec::{
     DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput, TopEncodeMulti,
     TopEncodeMultiOutput, Vec,
 };

--- a/framework/base/src/types/managed/multi_value/multi_value_managed_vec_counted.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_managed_vec_counted.rs
@@ -1,11 +1,11 @@
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::ManagedTypeApi,
+    codec::{
+        DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput,
+        TopEncodeMulti, TopEncodeMultiOutput,
+    },
     types::{ManagedVec, ManagedVecItem},
-};
-use crate::codec::{
-    DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput, TopEncodeMulti,
-    TopEncodeMultiOutput,
 };
 
 /// Argument or result that is made up of the argument count, followed by the arguments themselves.

--- a/framework/base/src/types/managed/multi_value/multi_value_managed_vec_counted.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_managed_vec_counted.rs
@@ -3,7 +3,7 @@ use crate::{
     api::ManagedTypeApi,
     types::{ManagedVec, ManagedVecItem},
 };
-use mx_sc_codec::{
+use crate::codec::{
     DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput, TopEncodeMulti,
     TopEncodeMultiOutput,
 };

--- a/framework/base/src/types/managed/wrapped/egld_or_esdt_token_identifier.rs
+++ b/framework/base/src/types/managed/wrapped/egld_or_esdt_token_identifier.rs
@@ -1,11 +1,11 @@
 use crate::{
     abi::{TypeAbi, TypeName},
     api::{HandleConstraints, ManagedTypeApi},
+    codec::*,
     derive::ManagedVecItem,
     formatter::{FormatByteReceiver, SCDisplay, SCLowerHex},
     types::{ManagedBuffer, ManagedOption, ManagedRef, ManagedType, TokenIdentifier},
 };
-use crate::codec::*;
 
 use crate as mx_sc; // required by the ManagedVecItem derive
 

--- a/framework/base/src/types/managed/wrapped/egld_or_esdt_token_identifier.rs
+++ b/framework/base/src/types/managed/wrapped/egld_or_esdt_token_identifier.rs
@@ -5,7 +5,7 @@ use crate::{
     formatter::{FormatByteReceiver, SCDisplay, SCLowerHex},
     types::{ManagedBuffer, ManagedOption, ManagedRef, ManagedType, TokenIdentifier},
 };
-use mx_sc_codec::*;
+use crate::codec::*;
 
 use crate as mx_sc; // required by the ManagedVecItem derive
 

--- a/framework/base/src/types/managed/wrapped/egld_or_esdt_token_payment.rs
+++ b/framework/base/src/types/managed/wrapped/egld_or_esdt_token_payment.rs
@@ -3,7 +3,7 @@ use crate::{
     types::{BigUint, EgldOrEsdtTokenIdentifier},
 };
 
-use mx_sc_codec::{
+use crate::codec::{ self,
     mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
     CodecFrom, CodecFromSelf,
 };

--- a/framework/base/src/types/managed/wrapped/egld_or_esdt_token_payment.rs
+++ b/framework/base/src/types/managed/wrapped/egld_or_esdt_token_payment.rs
@@ -3,7 +3,8 @@ use crate::{
     types::{BigUint, EgldOrEsdtTokenIdentifier},
 };
 
-use crate::codec::{ self,
+use crate::codec::{
+    self,
     mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
     CodecFrom, CodecFromSelf,
 };

--- a/framework/base/src/types/managed/wrapped/esdt_token_data.rs
+++ b/framework/base/src/types/managed/wrapped/esdt_token_data.rs
@@ -1,11 +1,13 @@
 use crate::{
     api::ManagedTypeApi,
+    codec,
+    codec::{
+        mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
+        *,
+    },
     contract_base::ExitCodecErrorHandler,
     types::{BigUint, EsdtTokenType, ManagedAddress, ManagedBuffer, ManagedVec},
 };
-use crate::codec::*;
-use crate::codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode};
-use crate::codec;
 
 use crate as mx_sc; // needed by the TypeAbi generated code
 use crate::derive::TypeAbi;

--- a/framework/base/src/types/managed/wrapped/esdt_token_data.rs
+++ b/framework/base/src/types/managed/wrapped/esdt_token_data.rs
@@ -3,9 +3,9 @@ use crate::{
     contract_base::ExitCodecErrorHandler,
     types::{BigUint, EsdtTokenType, ManagedAddress, ManagedBuffer, ManagedVec},
 };
-use mx_sc_codec::*;
-
-use mx_sc_codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode};
+use crate::codec::*;
+use crate::codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode};
+use crate::codec;
 
 use crate as mx_sc; // needed by the TypeAbi generated code
 use crate::derive::TypeAbi;

--- a/framework/base/src/types/managed/wrapped/esdt_token_payment.rs
+++ b/framework/base/src/types/managed/wrapped/esdt_token_payment.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use crate as mx_sc; // needed by the codec and TypeAbi generated code
 use crate::derive::TypeAbi;
-use mx_sc_codec::{
+use crate::codec::{ self,
     mx_sc_codec_derive::{NestedEncode, TopEncode},
     IntoMultiValue, NestedDecode, TopDecode,
 };
@@ -58,13 +58,13 @@ impl<M: ManagedTypeApi> From<(TokenIdentifier<M>, u64, BigUint<M>)> for EsdtToke
 impl<M: ManagedTypeApi> TopDecode for EsdtTokenPayment<M> {
     fn top_decode_or_handle_err<I, H>(top_input: I, h: H) -> Result<Self, H::HandledErr>
     where
-        I: mx_sc_codec::TopDecodeInput,
-        H: mx_sc_codec::DecodeErrorHandler,
+        I: codec::TopDecodeInput,
+        H: codec::DecodeErrorHandler,
     {
         let mut nested_buffer = top_input.into_nested_buffer();
         let result = Self::dep_decode_or_handle_err(&mut nested_buffer, h)?;
-        if !mx_sc_codec::NestedDecodeInput::is_depleted(&nested_buffer) {
-            return Err(h.handle_error(mx_sc_codec::DecodeError::INPUT_TOO_LONG));
+        if !codec::NestedDecodeInput::is_depleted(&nested_buffer) {
+            return Err(h.handle_error(codec::DecodeError::INPUT_TOO_LONG));
         }
         Ok(result)
     }
@@ -74,8 +74,8 @@ impl<M: ManagedTypeApi> NestedDecode for EsdtTokenPayment<M> {
     #[cfg(not(feature = "esdt-token-payment-legacy-decode"))]
     fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> Result<Self, H::HandledErr>
     where
-        I: mx_sc_codec::NestedDecodeInput,
-        H: mx_sc_codec::DecodeErrorHandler,
+        I: codec::NestedDecodeInput,
+        H: codec::DecodeErrorHandler,
     {
         Self::regular_dep_decode_or_handle_err(input, h)
     }
@@ -83,8 +83,8 @@ impl<M: ManagedTypeApi> NestedDecode for EsdtTokenPayment<M> {
     #[cfg(feature = "esdt-token-payment-legacy-decode")]
     fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> Result<Self, H::HandledErr>
     where
-        I: mx_sc_codec::NestedDecodeInput,
-        H: mx_sc_codec::DecodeErrorHandler,
+        I: codec::NestedDecodeInput,
+        H: codec::DecodeErrorHandler,
     {
         Self::backwards_compatible_dep_decode_or_handle_err(input, h)
     }
@@ -97,8 +97,8 @@ impl<M: ManagedTypeApi> EsdtTokenPayment<M> {
         h: H,
     ) -> Result<Self, H::HandledErr>
     where
-        I: mx_sc_codec::NestedDecodeInput,
-        H: mx_sc_codec::DecodeErrorHandler,
+        I: codec::NestedDecodeInput,
+        H: codec::DecodeErrorHandler,
     {
         Ok(EsdtTokenPayment {
             token_identifier: TokenIdentifier::<M>::dep_decode_or_handle_err(input, h)?,
@@ -129,8 +129,8 @@ impl<M: ManagedTypeApi> EsdtTokenPayment<M> {
         h: H,
     ) -> Result<Self, H::HandledErr>
     where
-        I: mx_sc_codec::NestedDecodeInput,
-        H: mx_sc_codec::DecodeErrorHandler,
+        I: codec::NestedDecodeInput,
+        H: codec::DecodeErrorHandler,
     {
         let mut first_four_bytes = [0u8; 4];
         input.peek_into(&mut first_four_bytes[..], h)?;

--- a/framework/base/src/types/managed/wrapped/esdt_token_payment.rs
+++ b/framework/base/src/types/managed/wrapped/esdt_token_payment.rs
@@ -4,10 +4,13 @@ use crate::{
 };
 
 use crate as mx_sc; // needed by the codec and TypeAbi generated code
-use crate::derive::TypeAbi;
-use crate::codec::{ self,
-    mx_sc_codec_derive::{NestedEncode, TopEncode},
-    IntoMultiValue, NestedDecode, TopDecode,
+use crate::{
+    codec::{
+        self,
+        mx_sc_codec_derive::{NestedEncode, TopEncode},
+        IntoMultiValue, NestedDecode, TopDecode,
+    },
+    derive::TypeAbi,
 };
 
 #[derive(TopEncode, NestedEncode, TypeAbi, Clone, PartialEq, Eq, Debug)]

--- a/framework/base/src/types/managed/wrapped/managed_address.rs
+++ b/framework/base/src/types/managed/wrapped/managed_address.rs
@@ -6,7 +6,7 @@ use crate::{
     formatter::{hex_util::encode_bytes_as_hex, FormatByteReceiver, SCLowerHex},
     types::{heap::Address, ManagedBuffer, ManagedByteArray, ManagedType},
 };
-use mx_sc_codec::{
+use crate::codec::{
     CodecFrom, CodecFromSelf, DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
     NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
     TopEncodeOutput, TryStaticCast,

--- a/framework/base/src/types/managed/wrapped/managed_address.rs
+++ b/framework/base/src/types/managed/wrapped/managed_address.rs
@@ -3,13 +3,13 @@ use core::convert::{TryFrom, TryInto};
 use crate::{
     abi::{TypeAbi, TypeName},
     api::ManagedTypeApi,
+    codec::{
+        CodecFrom, CodecFromSelf, DecodeError, DecodeErrorHandler, EncodeErrorHandler,
+        NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode,
+        TopDecodeInput, TopEncode, TopEncodeOutput, TryStaticCast,
+    },
     formatter::{hex_util::encode_bytes_as_hex, FormatByteReceiver, SCLowerHex},
     types::{heap::Address, ManagedBuffer, ManagedByteArray, ManagedType},
-};
-use crate::codec::{
-    CodecFrom, CodecFromSelf, DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode,
-    NestedDecodeInput, NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
-    TopEncodeOutput, TryStaticCast,
 };
 
 #[repr(transparent)]

--- a/framework/base/src/types/managed/wrapped/managed_buffer_cached_builder.rs
+++ b/framework/base/src/types/managed/wrapped/managed_buffer_cached_builder.rs
@@ -1,4 +1,4 @@
-use mx_sc_codec::{EncodeError, EncodeErrorHandler, NestedEncodeOutput, TryStaticCast};
+use crate::codec::{EncodeError, EncodeErrorHandler, NestedEncodeOutput, TryStaticCast};
 
 use crate::{
     api::ManagedTypeApi,

--- a/framework/base/src/types/managed/wrapped/managed_byte_array.rs
+++ b/framework/base/src/types/managed/wrapped/managed_byte_array.rs
@@ -6,7 +6,7 @@ use crate::{
     formatter::{hex_util::encode_bytes_as_hex, FormatByteReceiver, SCLowerHex},
     types::{ManagedBuffer, ManagedType},
 };
-use mx_sc_codec::{
+use crate::codec::{
     DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput,
     NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
     TryStaticCast,

--- a/framework/base/src/types/managed/wrapped/managed_byte_array.rs
+++ b/framework/base/src/types/managed/wrapped/managed_byte_array.rs
@@ -3,13 +3,13 @@ use core::convert::TryFrom;
 use crate::{
     abi::{TypeAbi, TypeName},
     api::ManagedTypeApi,
+    codec::{
+        DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput,
+        NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
+        TryStaticCast,
+    },
     formatter::{hex_util::encode_bytes_as_hex, FormatByteReceiver, SCLowerHex},
     types::{ManagedBuffer, ManagedType},
-};
-use crate::codec::{
-    DecodeError, DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput,
-    NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
-    TryStaticCast,
 };
 
 const DECODE_ERROR_BAD_LENGTH: &str = "bad array length";

--- a/framework/base/src/types/managed/wrapped/managed_option.rs
+++ b/framework/base/src/types/managed/wrapped/managed_option.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use mx_sc_codec::{
+use crate::codec::{
     DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
     NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
 };

--- a/framework/base/src/types/managed/wrapped/managed_ref.rs
+++ b/framework/base/src/types/managed/wrapped/managed_ref.rs
@@ -1,6 +1,6 @@
 use core::{borrow::Borrow, marker::PhantomData, ops::Deref};
 
-use mx_sc_codec::{
+use crate::codec::{
     EncodeErrorHandler, NestedEncode, NestedEncodeOutput, TopEncode, TopEncodeOutput,
 };
 

--- a/framework/base/src/types/managed/wrapped/managed_vec.rs
+++ b/framework/base/src/types/managed/wrapped/managed_vec.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use core::{borrow::Borrow, iter::FromIterator, marker::PhantomData};
-use mx_sc_codec::{
+use crate::codec::{
     DecodeErrorHandler, EncodeErrorHandler, IntoMultiValue, NestedDecode, NestedDecodeInput,
     NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeMultiOutput,
     TopEncodeOutput,

--- a/framework/base/src/types/managed/wrapped/managed_vec.rs
+++ b/framework/base/src/types/managed/wrapped/managed_vec.rs
@@ -1,6 +1,11 @@
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::{ErrorApiImpl, InvalidSliceError, ManagedTypeApi},
+    codec::{
+        DecodeErrorHandler, EncodeErrorHandler, IntoMultiValue, NestedDecode, NestedDecodeInput,
+        NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
+        TopEncodeMultiOutput, TopEncodeOutput,
+    },
     types::{
         heap::{ArgBuffer, BoxedBytes},
         ManagedBuffer, ManagedBufferNestedDecodeInput, ManagedType, ManagedVecItem, ManagedVecRef,
@@ -9,11 +14,6 @@ use crate::{
 };
 use alloc::vec::Vec;
 use core::{borrow::Borrow, iter::FromIterator, marker::PhantomData};
-use crate::codec::{
-    DecodeErrorHandler, EncodeErrorHandler, IntoMultiValue, NestedDecode, NestedDecodeInput,
-    NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeMultiOutput,
-    TopEncodeOutput,
-};
 
 pub(crate) const INDEX_OUT_OF_RANGE_MSG: &[u8] = b"ManagedVec index out of range";
 

--- a/framework/base/src/types/managed/wrapped/token_identifier.rs
+++ b/framework/base/src/types/managed/wrapped/token_identifier.rs
@@ -1,10 +1,10 @@
 use crate::{
     abi::{TypeAbi, TypeName},
     api::{HandleConstraints, ManagedTypeApi, ManagedTypeApiImpl},
+    codec::*,
     formatter::{FormatByteReceiver, SCDisplay, SCLowerHex},
     types::{ManagedBuffer, ManagedType},
 };
-use crate::codec::*;
 
 use super::EgldOrEsdtTokenIdentifier;
 

--- a/framework/base/src/types/managed/wrapped/token_identifier.rs
+++ b/framework/base/src/types/managed/wrapped/token_identifier.rs
@@ -4,7 +4,7 @@ use crate::{
     formatter::{FormatByteReceiver, SCDisplay, SCLowerHex},
     types::{ManagedBuffer, ManagedType},
 };
-use mx_sc_codec::*;
+use crate::codec::*;
 
 use super::EgldOrEsdtTokenIdentifier;
 

--- a/framework/base/src/types/static_buffer/sparse_array.rs
+++ b/framework/base/src/types/static_buffer/sparse_array.rs
@@ -3,7 +3,7 @@ use crate::{
     api::{ErrorApi, ErrorApiImpl},
 };
 use core::marker::PhantomData;
-use mx_sc_codec::{arrayvec::ArrayVec, NestedDecode, NestedEncode, TopDecode, TopEncode};
+use crate::codec::{self, arrayvec::ArrayVec, NestedDecode, NestedEncode, TopDecode, TopEncode};
 
 const EMPTY_ENTRY: usize = 0;
 static INVALID_INDEX_ERR_MSG: &[u8] = b"Index out of bounds";
@@ -204,8 +204,8 @@ where
 {
     fn top_encode_or_handle_err<O, H>(&self, output: O, h: H) -> Result<(), H::HandledErr>
     where
-        O: mx_sc_codec::TopEncodeOutput,
-        H: mx_sc_codec::EncodeErrorHandler,
+        O: codec::TopEncodeOutput,
+        H: codec::EncodeErrorHandler,
     {
         let mut nested_buffer = output.start_nested_encode();
         for item in self.iter() {
@@ -223,8 +223,8 @@ where
 {
     fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, h: H) -> Result<(), H::HandledErr>
     where
-        O: mx_sc_codec::NestedEncodeOutput,
-        H: mx_sc_codec::EncodeErrorHandler,
+        O: codec::NestedEncodeOutput,
+        H: codec::EncodeErrorHandler,
     {
         self.len.dep_encode_or_handle_err(dest, h)?;
         for item in self.iter() {
@@ -241,8 +241,8 @@ where
 {
     fn top_decode_or_handle_err<I, H>(input: I, h: H) -> Result<Self, H::HandledErr>
     where
-        I: mx_sc_codec::TopDecodeInput,
-        H: mx_sc_codec::DecodeErrorHandler,
+        I: codec::TopDecodeInput,
+        H: codec::DecodeErrorHandler,
     {
         match ArrayVec::<usize, CAPACITY>::top_decode(input) {
             Ok(array_vec) => {
@@ -268,8 +268,8 @@ where
 {
     fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> Result<Self, H::HandledErr>
     where
-        I: mx_sc_codec::NestedDecodeInput,
-        H: mx_sc_codec::DecodeErrorHandler,
+        I: codec::NestedDecodeInput,
+        H: codec::DecodeErrorHandler,
     {
         match ArrayVec::<usize, CAPACITY>::dep_decode(input) {
             Ok(array_vec) => {

--- a/framework/base/src/types/static_buffer/sparse_array.rs
+++ b/framework/base/src/types/static_buffer/sparse_array.rs
@@ -1,9 +1,9 @@
 use crate::{
     abi::{TypeAbi, TypeDescriptionContainer, TypeName},
     api::{ErrorApi, ErrorApiImpl},
+    codec::{self, arrayvec::ArrayVec, NestedDecode, NestedEncode, TopDecode, TopEncode},
 };
 use core::marker::PhantomData;
-use crate::codec::{self, arrayvec::ArrayVec, NestedDecode, NestedEncode, TopDecode, TopEncode};
 
 const EMPTY_ENTRY: usize = 0;
 static INVALID_INDEX_ERR_MSG: &[u8] = b"Index out of bounds";

--- a/framework/codec-derive/src/nested_de_derive.rs
+++ b/framework/codec-derive/src/nested_de_derive.rs
@@ -11,11 +11,11 @@ pub fn dep_decode_snippet(
     let ty = &field.ty;
     if let Some(ident) = &field.ident {
         quote! {
-            #ident: <#ty as mx_sc_codec::NestedDecode>::dep_decode_or_handle_err(#input_value, h)?
+            #ident: <#ty as codec::NestedDecode>::dep_decode_or_handle_err(#input_value, h)?
         }
     } else {
         quote! {
-            <#ty as mx_sc_codec::NestedDecode>::dep_decode_or_handle_err(#input_value, h)?
+            <#ty as codec::NestedDecode>::dep_decode_or_handle_err(#input_value, h)?
         }
     }
 }
@@ -52,11 +52,11 @@ pub fn nested_decode_impl(ast: &syn::DeriveInput) -> TokenStream {
                     dep_decode_snippet(index, field, &quote! {input})
                 });
             quote! {
-                impl #impl_generics mx_sc_codec::NestedDecode for #name #ty_generics #where_clause {
+                impl #impl_generics codec::NestedDecode for #name #ty_generics #where_clause {
                     fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> core::result::Result<Self, H::HandledErr>
                     where
-                        I: mx_sc_codec::NestedDecodeInput,
-                        H: mx_sc_codec::DecodeErrorHandler,
+                        I: codec::NestedDecodeInput,
+                        H: codec::DecodeErrorHandler,
                     {
                         core::result::Result::Ok(
                             #name #field_dep_decode_snippets
@@ -74,15 +74,15 @@ pub fn nested_decode_impl(ast: &syn::DeriveInput) -> TokenStream {
                 variant_dep_decode_snippets(name, data_enum, &quote! {input});
 
             quote! {
-                impl #impl_generics mx_sc_codec::NestedDecode for #name #ty_generics #where_clause {
+                impl #impl_generics codec::NestedDecode for #name #ty_generics #where_clause {
                     fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> core::result::Result<Self, H::HandledErr>
                     where
-                        I: mx_sc_codec::NestedDecodeInput,
-                        H: mx_sc_codec::DecodeErrorHandler,
+                        I: codec::NestedDecodeInput,
+                        H: codec::DecodeErrorHandler,
                     {
-                        match <u8 as mx_sc_codec::NestedDecode>::dep_decode_or_handle_err(input, h)? {
+                        match <u8 as codec::NestedDecode>::dep_decode_or_handle_err(input, h)? {
                             #(#variant_dep_decode_snippets)*
-                            _ => core::result::Result::Err(h.handle_error(mx_sc_codec::DecodeError::INVALID_VALUE)),
+                            _ => core::result::Result::Err(h.handle_error(codec::DecodeError::INVALID_VALUE)),
                         }
                     }
                 }

--- a/framework/codec-derive/src/nested_en_derive.rs
+++ b/framework/codec-derive/src/nested_en_derive.rs
@@ -4,7 +4,7 @@ use quote::quote;
 
 pub fn dep_encode_snippet(value: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     quote! {
-        mx_sc_codec::NestedEncode::dep_encode_or_handle_err(&#value, dest, h)?;
+        codec::NestedEncode::dep_encode_or_handle_err(&#value, dest, h)?;
     }
 }
 
@@ -26,7 +26,7 @@ fn variant_dep_encode_snippets(
             });
             quote! {
                 #name::#variant_ident #local_var_declarations => {
-                    mx_sc_codec::NestedEncode::dep_encode_or_handle_err(&#variant_index_u8, dest, h)?;
+                    codec::NestedEncode::dep_encode_or_handle_err(&#variant_index_u8, dest, h)?;
                     #(#variant_field_snippets)*
                 },
             }
@@ -43,11 +43,11 @@ pub fn nested_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
                 dep_encode_snippet(&self_field_expr(index, field))
             });
             quote! {
-                impl #impl_generics mx_sc_codec::NestedEncode for #name #ty_generics #where_clause {
+                impl #impl_generics codec::NestedEncode for #name #ty_generics #where_clause {
                     fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, h: H) -> core::result::Result<(), H::HandledErr>
                     where
-                        O: mx_sc_codec::NestedEncodeOutput,
-                        H: mx_sc_codec::EncodeErrorHandler,
+                        O: codec::NestedEncodeOutput,
+                        H: codec::EncodeErrorHandler,
                     {
                         #(#field_dep_encode_snippets)*
                         core::result::Result::Ok(())
@@ -63,11 +63,11 @@ pub fn nested_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
             let variant_dep_encode_snippets = variant_dep_encode_snippets(name, data_enum);
 
             quote! {
-                impl #impl_generics mx_sc_codec::NestedEncode for #name #ty_generics #where_clause {
+                impl #impl_generics codec::NestedEncode for #name #ty_generics #where_clause {
                     fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, h: H) -> core::result::Result<(), H::HandledErr>
                     where
-                        O: mx_sc_codec::NestedEncodeOutput,
-                        H: mx_sc_codec::EncodeErrorHandler,
+                        O: codec::NestedEncodeOutput,
+                        H: codec::EncodeErrorHandler,
                     {
                         match self {
                             #(#variant_dep_encode_snippets)*

--- a/framework/codec-derive/src/top_de_derive.rs
+++ b/framework/codec-derive/src/top_de_derive.rs
@@ -60,8 +60,8 @@ fn top_decode_method_body(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
             quote! {
                 let mut nested_buffer = top_input.into_nested_buffer();
                 let result = #name #field_dep_decode_snippets ;
-                if !mx_sc_codec::NestedDecodeInput::is_depleted(&nested_buffer) {
-                    return core::result::Result::Err(h.handle_error(mx_sc_codec::DecodeError::INPUT_TOO_LONG));
+                if !codec::NestedDecodeInput::is_depleted(&nested_buffer) {
+                    return core::result::Result::Err(h.handle_error(codec::DecodeError::INPUT_TOO_LONG));
                 }
                 core::result::Result::Ok(result)
             }
@@ -75,9 +75,9 @@ fn top_decode_method_body(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
                 // fieldless enums are special, they can be top-decoded as u8 directly
                 let top_decode_arms = fieldless_enum_match_arm_result_ok(name, data_enum);
                 quote! {
-                    match <u8 as mx_sc_codec::TopDecode>::top_decode_or_handle_err(top_input, h)? {
+                    match <u8 as codec::TopDecode>::top_decode_or_handle_err(top_input, h)? {
                         #(#top_decode_arms)*
-                        _ => core::result::Result::Err(h.handle_error(mx_sc_codec::DecodeError::INVALID_VALUE)),
+                        _ => core::result::Result::Err(h.handle_error(codec::DecodeError::INVALID_VALUE)),
                     }
                 }
             } else {
@@ -86,15 +86,15 @@ fn top_decode_method_body(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
 
                 quote! {
                     let mut nested_buffer = top_input.into_nested_buffer();
-                    let result = match <u8 as mx_sc_codec::NestedDecode>::dep_decode_or_handle_err(&mut nested_buffer, h)? {
+                    let result = match <u8 as codec::NestedDecode>::dep_decode_or_handle_err(&mut nested_buffer, h)? {
                         #(#variant_dep_decode_snippets)*
                         _ => core::result::Result::Err(
-                            h.handle_error(mx_sc_codec::DecodeError::INVALID_VALUE),
+                            h.handle_error(codec::DecodeError::INVALID_VALUE),
                         ),
                     };
-                    if !mx_sc_codec::NestedDecodeInput::is_depleted(&nested_buffer) {
+                    if !codec::NestedDecodeInput::is_depleted(&nested_buffer) {
                         return core::result::Result::Err(
-                            h.handle_error(mx_sc_codec::DecodeError::INPUT_TOO_LONG),
+                            h.handle_error(codec::DecodeError::INPUT_TOO_LONG),
                         );
                     }
                     result
@@ -112,11 +112,11 @@ pub fn top_decode_impl(ast: &syn::DeriveInput) -> TokenStream {
     let auto_default = auto_default(ast);
 
     let gen = quote! {
-        impl #impl_generics mx_sc_codec::TopDecode for #name #ty_generics #where_clause {
+        impl #impl_generics codec::TopDecode for #name #ty_generics #where_clause {
             fn top_decode_or_handle_err<I, H>(top_input: I, h: H) -> core::result::Result<Self, H::HandledErr>
             where
-                I: mx_sc_codec::TopDecodeInput,
-                H: mx_sc_codec::DecodeErrorHandler,
+                I: codec::TopDecodeInput,
+                H: codec::DecodeErrorHandler,
             {
                 #auto_default
                 #top_decode_body
@@ -133,14 +133,14 @@ pub fn top_decode_or_default_impl(ast: &syn::DeriveInput) -> TokenStream {
     let top_decode_body = top_decode_method_body(ast);
 
     let gen = quote! {
-        impl #impl_generics mx_sc_codec::TopDecode for #name #ty_generics #where_clause {
+        impl #impl_generics codec::TopDecode for #name #ty_generics #where_clause {
             fn top_decode_or_handle_err<I, H>(top_input: I, h: H) -> core::result::Result<Self, H::HandledErr>
             where
-                I: mx_sc_codec::TopDecodeInput,
-                H: mx_sc_codec::DecodeErrorHandler,
+                I: codec::TopDecodeInput,
+                H: codec::DecodeErrorHandler,
             {
                 if top_input.byte_len() == 0 {
-                    core::result::Result::Ok(<#name #ty_generics as mx_sc_codec::DecodeDefault>::default())
+                    core::result::Result::Ok(<#name #ty_generics as codec::DecodeDefault>::default())
                 } else {
                     #top_decode_body
                 }

--- a/framework/codec-derive/src/top_en_derive.rs
+++ b/framework/codec-derive/src/top_en_derive.rs
@@ -18,7 +18,7 @@ pub fn variant_top_encode_snippets(
                 // top-encode discriminant directly
                 quote! {
                     #name::#variant_ident =>
-                        mx_sc_codec::TopEncode::top_encode_or_handle_err(&#variant_index_u8, output, h),
+                        codec::TopEncode::top_encode_or_handle_err(&#variant_index_u8, output, h),
                 }
             } else {
                 // dep-encode to buffer first
@@ -31,7 +31,7 @@ pub fn variant_top_encode_snippets(
                     #name::#variant_ident #local_var_declarations => {
                         let mut buffer = output.start_nested_encode();
                         let dest = &mut buffer;
-                        mx_sc_codec::NestedEncode::dep_encode_or_handle_err(&#variant_index_u8, dest, h)?;
+                        codec::NestedEncode::dep_encode_or_handle_err(&#variant_index_u8, dest, h)?;
                         #(#variant_field_snippets)*
                         output.finalize_nested_encode(buffer);
                         core::result::Result::Ok(())
@@ -81,11 +81,11 @@ pub fn top_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
     let top_encode_body = top_encode_method_body(ast);
 
     let gen = quote! {
-        impl #impl_generics mx_sc_codec::TopEncode for #name #ty_generics #where_clause {
+        impl #impl_generics codec::TopEncode for #name #ty_generics #where_clause {
             fn top_encode_or_handle_err<O, H>(&self, output: O, h: H) -> core::result::Result<(), H::HandledErr>
             where
-                O: mx_sc_codec::TopEncodeOutput,
-                H: mx_sc_codec::EncodeErrorHandler,
+                O: codec::TopEncodeOutput,
+                H: codec::EncodeErrorHandler,
             {
                 #top_encode_body
             }
@@ -100,13 +100,13 @@ pub fn top_encode_or_default_impl(ast: &syn::DeriveInput) -> TokenStream {
     let top_encode_body = top_encode_method_body(ast);
 
     let gen = quote! {
-        impl #impl_generics mx_sc_codec::TopEncode for #name #ty_generics #where_clause {
+        impl #impl_generics codec::TopEncode for #name #ty_generics #where_clause {
             fn top_encode_or_handle_err<O, H>(&self, output: O, h: H) -> core::result::Result<(), H::HandledErr>
             where
-                O: mx_sc_codec::TopEncodeOutput,
-                H: mx_sc_codec::EncodeErrorHandler,
+                O: codec::TopEncodeOutput,
+                H: codec::EncodeErrorHandler,
             {
-                if mx_sc_codec::EncodeDefault::is_default(self) {
+                if codec::EncodeDefault::is_default(self) {
                     output.set_slice_u8(&[]);
                     core::result::Result::Ok(())
                 } else {

--- a/framework/codec/src/impl_for_types/impl_phantom.rs
+++ b/framework/codec/src/impl_for_types/impl_phantom.rs
@@ -59,7 +59,7 @@ impl<T> NestedDecode for PhantomData<T> {
 
 #[cfg(test)]
 pub mod tests {
-    use crate as mx_sc_codec;
+    use crate as codec;
     use crate::test_util::{check_dep_encode_decode, check_top_encode_decode};
     use core::marker::PhantomData;
     use mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode};

--- a/framework/codec/tests/derive_empty_struct_test.rs
+++ b/framework/codec/tests/derive_empty_struct_test.rs
@@ -1,7 +1,8 @@
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::test_util::{check_dep_encode_decode, check_top_encode_decode};
+use codec::test_util::{check_dep_encode_decode, check_top_encode_decode};
 
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, PartialEq, Eq, Clone, Debug)]
 pub struct EmptyStruct1;

--- a/framework/codec/tests/derive_enum_or_default_test.rs
+++ b/framework/codec/tests/derive_enum_or_default_test.rs
@@ -1,7 +1,8 @@
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::test_util::{check_top_decode, check_top_encode_decode};
+use codec::test_util::{check_top_decode, check_top_encode_decode};
 
 // to test, run the following command in mx-sc-codec folder:
 // cargo expand --test enum_or_default_derive_test > expanded.rs
@@ -22,13 +23,13 @@ enum EnumWithDefault {
     },
 }
 
-impl mx_sc_codec::EncodeDefault for EnumWithDefault {
+impl codec::EncodeDefault for EnumWithDefault {
     fn is_default(&self) -> bool {
         *self == EnumWithDefault::Basic(0)
     }
 }
 
-impl mx_sc_codec::DecodeDefault for EnumWithDefault {
+impl codec::DecodeDefault for EnumWithDefault {
     fn default() -> Self {
         EnumWithDefault::Basic(0)
     }

--- a/framework/codec/tests/derive_enum_test.rs
+++ b/framework/codec/tests/derive_enum_test.rs
@@ -1,7 +1,8 @@
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::test_util::{check_dep_encode_decode, check_top_decode, check_top_encode_decode};
+use codec::test_util::{check_dep_encode_decode, check_top_decode, check_top_encode_decode};
 
 // to test, run the following command in mx-sc-codec folder:
 // cargo expand --test derive_enum_test > enum_expanded.rs

--- a/framework/codec/tests/derive_enum_tricky_defaults_fieldless_test.rs
+++ b/framework/codec/tests/derive_enum_tricky_defaults_fieldless_test.rs
@@ -1,7 +1,8 @@
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::test_util::{check_top_decode, check_top_encode, check_top_encode_decode};
+use codec::test_util::{check_top_decode, check_top_encode, check_top_encode_decode};
 
 // to test, run the following command in mx-sc-codec folder:
 // cargo expand --test enum_tricky_defaults_derive_test > enum_expanded.rs
@@ -19,13 +20,13 @@ enum TrickyDefaultDayOfWeek {
     Sunday,
 }
 
-impl mx_sc_codec::EncodeDefault for TrickyDefaultDayOfWeek {
+impl codec::EncodeDefault for TrickyDefaultDayOfWeek {
     fn is_default(&self) -> bool {
         matches!(self, TrickyDefaultDayOfWeek::Friday)
     }
 }
 
-impl mx_sc_codec::DecodeDefault for TrickyDefaultDayOfWeek {
+impl codec::DecodeDefault for TrickyDefaultDayOfWeek {
     fn default() -> Self {
         TrickyDefaultDayOfWeek::Friday
     }

--- a/framework/codec/tests/derive_enum_tricky_defaults_test.rs
+++ b/framework/codec/tests/derive_enum_tricky_defaults_test.rs
@@ -1,7 +1,8 @@
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::test_util::{check_top_decode, check_top_encode, check_top_encode_decode};
+use codec::test_util::{check_top_decode, check_top_encode, check_top_encode_decode};
 
 // to test, run the following command in mx-sc-codec folder:
 // cargo expand --test derive_enum_tricky_defaults_test > enum_expanded.rs
@@ -22,13 +23,13 @@ enum TrickyEnumWithDefault {
     },
 }
 
-impl mx_sc_codec::EncodeDefault for TrickyEnumWithDefault {
+impl codec::EncodeDefault for TrickyEnumWithDefault {
     fn is_default(&self) -> bool {
         matches!(self, TrickyEnumWithDefault::SecondVariant)
     }
 }
 
-impl mx_sc_codec::DecodeDefault for TrickyEnumWithDefault {
+impl codec::DecodeDefault for TrickyEnumWithDefault {
     fn default() -> Self {
         TrickyEnumWithDefault::SecondVariant
     }

--- a/framework/codec/tests/derive_hygiene.rs
+++ b/framework/codec/tests/derive_hygiene.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
 // This test doesn't run any code, the fact that it compiles is the actual testing.
@@ -88,10 +89,7 @@ trait SimpleTrait {
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, PartialEq, Eq, Clone, Debug)]
 struct StructWithNamedFieldsWithGeneric<ST: SimpleTrait>
 where
-    ST: mx_sc_codec::NestedEncode
-        + mx_sc_codec::NestedDecode
-        + mx_sc_codec::TopEncode
-        + mx_sc_codec::TopDecode,
+    ST: codec::NestedEncode + codec::NestedDecode + codec::TopEncode + codec::TopDecode,
 {
     data: u64,
     trait_stuff: ST,

--- a/framework/codec/tests/derive_struct_or_default_generic_test.rs
+++ b/framework/codec/tests/derive_struct_or_default_generic_test.rs
@@ -1,8 +1,8 @@
 extern crate mx_sc_codec_derive;
-use mx_sc_codec::*;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::test_util::check_top_encode_decode;
+use codec::{test_util::check_top_encode_decode, *};
 
 #[derive(TopEncodeOrDefault, TopDecodeOrDefault, PartialEq, Eq, Clone, Debug)]
 pub struct StructOrDefault<T>
@@ -16,7 +16,7 @@ where
     pub uint_64: u64,
 }
 
-impl<T> mx_sc_codec::EncodeDefault for StructOrDefault<T>
+impl<T> codec::EncodeDefault for StructOrDefault<T>
 where
     T: NestedEncode + NestedDecode + Default + 'static,
 {
@@ -25,7 +25,7 @@ where
     }
 }
 
-impl<T> mx_sc_codec::DecodeDefault for StructOrDefault<T>
+impl<T> codec::DecodeDefault for StructOrDefault<T>
 where
     T: NestedEncode + NestedDecode + Default + 'static,
 {

--- a/framework/codec/tests/derive_struct_or_default_test.rs
+++ b/framework/codec/tests/derive_struct_or_default_test.rs
@@ -1,7 +1,8 @@
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::test_util::check_top_encode_decode;
+use codec::test_util::check_top_encode_decode;
 
 #[derive(TopEncodeOrDefault, TopDecodeOrDefault, PartialEq, Eq, Clone, Debug)]
 pub struct StructOrDefault {
@@ -12,13 +13,13 @@ pub struct StructOrDefault {
     pub uint_64: u64,
 }
 
-impl mx_sc_codec::EncodeDefault for StructOrDefault {
+impl codec::EncodeDefault for StructOrDefault {
     fn is_default(&self) -> bool {
         self.int == 5
     }
 }
 
-impl mx_sc_codec::DecodeDefault for StructOrDefault {
+impl codec::DecodeDefault for StructOrDefault {
     fn default() -> Self {
         StructOrDefault {
             int: 5,

--- a/framework/codec/tests/derive_struct_test.rs
+++ b/framework/codec/tests/derive_struct_test.rs
@@ -1,7 +1,8 @@
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::test_util::{check_dep_encode_decode, check_top_encode_decode};
+use codec::test_util::{check_dep_encode_decode, check_top_encode_decode};
 
 // to test, run the following command in mx-sc-codec folder:
 // cargo expand --test derive_struct_test > expanded.rs

--- a/framework/codec/tests/derive_struct_with_generic_test.rs
+++ b/framework/codec/tests/derive_struct_with_generic_test.rs
@@ -1,7 +1,8 @@
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::{
+use codec::{
     test_util::{check_dep_encode_decode, check_top_encode_decode},
     *,
 };

--- a/framework/codec/tests/derive_tuple_struct_test.rs
+++ b/framework/codec/tests/derive_tuple_struct_test.rs
@@ -1,7 +1,8 @@
 extern crate mx_sc_codec_derive;
+use mx_sc_codec as codec;
 use mx_sc_codec_derive::*;
 
-use mx_sc_codec::test_util::{check_dep_encode_decode, check_top_encode_decode};
+use codec::test_util::{check_dep_encode_decode, check_top_encode_decode};
 
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, PartialEq, Eq, Clone, Debug)]
 struct TupleStruct(u8, u16, u32);

--- a/framework/codec/tests/explicit_impl_enum.rs
+++ b/framework/codec/tests/explicit_impl_enum.rs
@@ -1,4 +1,6 @@
-use mx_sc_codec::{
+use mx_sc_codec as codec;
+
+use codec::{
     test_util::{check_dep_encode_decode, check_top_encode_decode},
     top_decode_from_nested_or_handle_err, top_encode_from_nested, DecodeError, DecodeErrorHandler,
     EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput,

--- a/framework/codec/tests/explicit_impl_struct.rs
+++ b/framework/codec/tests/explicit_impl_struct.rs
@@ -1,11 +1,13 @@
+use mx_sc_codec as codec;
+
 // Some structures with explicit encode/decode, for testing.
-use core::fmt::Debug;
-use mx_sc_codec::{
+use codec::{
     test_util::{check_dep_encode_decode, check_top_encode_decode},
     top_decode_from_nested_or_handle_err, top_encode_from_nested, DecodeErrorHandler,
     EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput,
     TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
 };
+use core::fmt::Debug;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct S {

--- a/framework/codec/tests/explicit_impl_wrapped_array.rs
+++ b/framework/codec/tests/explicit_impl_wrapped_array.rs
@@ -1,4 +1,6 @@
-use mx_sc_codec::{
+use mx_sc_codec as codec;
+
+use codec::{
     test_util::check_top_encode_decode, top_decode_from_nested_or_handle_err, DecodeErrorHandler,
     EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode, NestedEncodeOutput,
     TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,

--- a/framework/debug/src/api/debug_handle_mock.rs
+++ b/framework/debug/src/api/debug_handle_mock.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use mx_sc::{
     api::{use_raw_handle, HandleConstraints, RawHandle},
-    mx_sc_codec::TryStaticCast,
+    codec::TryStaticCast,
     types::ManagedVecItem,
 };
 

--- a/framework/debug/src/api/managed_types/big_float_api_mock.rs
+++ b/framework/debug/src/api/managed_types/big_float_api_mock.rs
@@ -8,7 +8,7 @@ use std::convert::TryInto;
 use mx_sc::{
     api::{BigFloatApi, BigIntApi, ErrorApiImpl, HandleTypeInfo, Sign},
     err_msg,
-    mx_sc_codec::num_bigint::BigInt,
+    codec::num_bigint::BigInt,
 };
 use num_traits::ToPrimitive;
 

--- a/framework/debug/src/api/managed_types/big_float_api_mock.rs
+++ b/framework/debug/src/api/managed_types/big_float_api_mock.rs
@@ -7,8 +7,8 @@ use std::convert::TryInto;
 
 use mx_sc::{
     api::{BigFloatApi, BigIntApi, ErrorApiImpl, HandleTypeInfo, Sign},
-    err_msg,
     codec::num_bigint::BigInt,
+    err_msg,
 };
 use num_traits::ToPrimitive;
 

--- a/framework/debug/src/api/send_api_mock.rs
+++ b/framework/debug/src/api/send_api_mock.rs
@@ -14,7 +14,7 @@ use mx_sc::{
         UPGRADE_CONTRACT_FUNC_NAME,
     },
     err_msg,
-    mx_sc_codec::top_encode_to_vec_u8,
+    codec::top_encode_to_vec_u8,
     types::{
         heap::Address, ArgBuffer, BigUint, BoxedBytes, CodeMetadata, EsdtTokenPayment,
         ManagedAddress, ManagedArgBuffer, ManagedBuffer, ManagedType, ManagedVec, TokenIdentifier,

--- a/framework/debug/src/api/send_api_mock.rs
+++ b/framework/debug/src/api/send_api_mock.rs
@@ -13,8 +13,8 @@ use mx_sc::{
         ESDT_MULTI_TRANSFER_FUNC_NAME, ESDT_NFT_TRANSFER_FUNC_NAME, ESDT_TRANSFER_FUNC_NAME,
         UPGRADE_CONTRACT_FUNC_NAME,
     },
-    err_msg,
     codec::top_encode_to_vec_u8,
+    err_msg,
     types::{
         heap::Address, ArgBuffer, BigUint, BoxedBytes, CodeMetadata, EsdtTokenPayment,
         ManagedAddress, ManagedArgBuffer, ManagedBuffer, ManagedType, ManagedVec, TokenIdentifier,

--- a/framework/debug/src/lib.rs
+++ b/framework/debug/src/lib.rs
@@ -24,7 +24,7 @@ pub use world_mock::BlockchainMock;
 pub use mandos;
 
 // Re-exporting for convenience. Using the crate as imported in the codec to make sure the save version is used everywhere.
-pub use mx_sc::mx_sc_codec::num_bigint;
+pub use mx_sc::codec::num_bigint;
 
 #[macro_use]
 extern crate alloc;

--- a/framework/debug/src/managed_test_util.rs
+++ b/framework/debug/src/managed_test_util.rs
@@ -1,6 +1,6 @@
 use mx_sc::{
     contract_base::ManagedSerializer,
-    mx_sc_codec::{test_util::check_top_encode, TopDecode, TopEncode},
+    codec::{test_util::check_top_encode, TopDecode, TopEncode},
     types::{heap::BoxedBytes, ManagedBuffer},
 };
 

--- a/framework/debug/src/managed_test_util.rs
+++ b/framework/debug/src/managed_test_util.rs
@@ -1,6 +1,6 @@
 use mx_sc::{
-    contract_base::ManagedSerializer,
     codec::{test_util::check_top_encode, TopDecode, TopEncode},
+    contract_base::ManagedSerializer,
     types::{heap::BoxedBytes, ManagedBuffer},
 };
 

--- a/framework/debug/src/mandos_system/executor/contract_info.rs
+++ b/framework/debug/src/mandos_system/executor/contract_info.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 use mx_sc::{
     api::ManagedTypeApi,
     contract_base::ProxyObjBase,
-    mx_sc_codec::{CodecFrom, EncodeErrorHandler, TopEncode, TopEncodeOutput},
+    codec::{CodecFrom, EncodeErrorHandler, TopEncode, TopEncodeOutput},
     types::{Address, ManagedAddress},
 };
 

--- a/framework/debug/src/mandos_system/executor/contract_info.rs
+++ b/framework/debug/src/mandos_system/executor/contract_info.rs
@@ -2,8 +2,8 @@ use std::ops::{Deref, DerefMut};
 
 use mx_sc::{
     api::ManagedTypeApi,
-    contract_base::ProxyObjBase,
     codec::{CodecFrom, EncodeErrorHandler, TopEncode, TopEncodeOutput},
+    contract_base::ProxyObjBase,
     types::{Address, ManagedAddress},
 };
 

--- a/framework/debug/src/mandos_system/executor/sc_call.rs
+++ b/framework/debug/src/mandos_system/executor/sc_call.rs
@@ -1,5 +1,5 @@
 use crate::mandos_system::model::{ScCallStep, Step, TxESDT, TypedScCall, TypedScCallExecutor};
-use mx_sc::mx_sc_codec::{CodecFrom, PanicErrorHandler, TopEncodeMulti};
+use mx_sc::codec::{CodecFrom, PanicErrorHandler, TopEncodeMulti};
 
 use crate::{
     tx_execution::sc_call_with_async_and_callback,

--- a/framework/debug/src/mandos_system/executor/sc_deploy.rs
+++ b/framework/debug/src/mandos_system/executor/sc_deploy.rs
@@ -3,7 +3,7 @@ use crate::{
     tx_mock::TxFunctionName,
 };
 use mx_sc::{
-    mx_sc_codec::{CodecFrom, PanicErrorHandler, TopEncodeMulti},
+    codec::{CodecFrom, PanicErrorHandler, TopEncodeMulti},
     types::heap::Address,
 };
 

--- a/framework/debug/src/mandos_system/executor/sc_query.rs
+++ b/framework/debug/src/mandos_system/executor/sc_query.rs
@@ -7,7 +7,7 @@ use crate::{
     DebugApi,
 };
 use mx_sc::{
-    mx_sc_codec::{CodecFrom, PanicErrorHandler, TopEncodeMulti},
+    codec::{CodecFrom, PanicErrorHandler, TopEncodeMulti},
     types::ContractCall,
 };
 

--- a/framework/debug/src/mandos_system/model/step/step_sc_call.rs
+++ b/framework/debug/src/mandos_system/model/step/step_sc_call.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use mx_sc::{
-    mx_sc_codec::{CodecFrom, PanicErrorHandler, TopEncodeMulti},
+    codec::{CodecFrom, PanicErrorHandler, TopEncodeMulti},
     types::{ContractCall, ManagedArgBuffer},
 };
 

--- a/framework/debug/src/mandos_system/model/step/step_sc_query.rs
+++ b/framework/debug/src/mandos_system/model/step/step_sc_query.rs
@@ -1,5 +1,5 @@
 use mx_sc::{
-    mx_sc_codec::{CodecFrom, TopEncodeMulti},
+    codec::{CodecFrom, TopEncodeMulti},
     types::ContractCall,
 };
 

--- a/framework/debug/src/mandos_system/model/step/typed_sc_call.rs
+++ b/framework/debug/src/mandos_system/model/step/typed_sc_call.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use mx_sc::mx_sc_codec::{CodecFrom, TopEncodeMulti};
+use mx_sc::codec::{CodecFrom, TopEncodeMulti};
 
 use crate::mandos_system::model::{
     AddressValue, BigUintValue, BytesValue, TxCall, TxESDT, TxExpect, U64Value,

--- a/framework/debug/src/mandos_system/model/step/typed_sc_deploy.rs
+++ b/framework/debug/src/mandos_system/model/step/typed_sc_deploy.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use mandos::interpret_trait::{InterpretableFrom, InterpreterContext};
 use mx_sc::{
-    mx_sc_codec::{CodecFrom, TopEncodeMulti},
+    codec::{CodecFrom, TopEncodeMulti},
     types::{Address, CodeMetadata},
 };
 

--- a/framework/debug/src/mandos_system/model/step/typed_sc_query.rs
+++ b/framework/debug/src/mandos_system/model/step/typed_sc_query.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use mx_sc::mx_sc_codec::{CodecFrom, TopEncodeMulti};
+use mx_sc::codec::{CodecFrom, TopEncodeMulti};
 
 use crate::mandos_system::model::{AddressValue, BytesValue, TxExpect, TxQuery};
 

--- a/framework/debug/src/meta/meta_generate_snippets/snippet_template_gen.rs
+++ b/framework/debug/src/meta/meta_generate_snippets/snippet_template_gen.rs
@@ -12,7 +12,7 @@ pub(crate) fn write_snippet_imports(file: &mut File, contract_crate_name: &str) 
 use {contract_crate_name}::ProxyTrait as _;
 use mx_sc_snippets::{{
     mx_sc::{{
-        mx_sc_codec::multi_types::*,
+        codec::multi_types::*,
         types::{{Address, CodeMetadata}},
     }},
     mx_sc_debug::{{

--- a/framework/debug/src/testing_framework/contract_obj_wrapper.rs
+++ b/framework/debug/src/testing_framework/contract_obj_wrapper.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::PathBuf, rc::Rc, str::FromStr};
 
 use mx_sc::{
     contract_base::{CallableContract, ContractBase},
-    mx_sc_codec::{TopDecode, TopEncode},
+    codec::{TopDecode, TopEncode},
     types::{
         heap::{Address, H256},
         EsdtLocalRole,

--- a/framework/debug/src/testing_framework/contract_obj_wrapper.rs
+++ b/framework/debug/src/testing_framework/contract_obj_wrapper.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, path::PathBuf, rc::Rc, str::FromStr};
 
 use mx_sc::{
-    contract_base::{CallableContract, ContractBase},
     codec::{TopDecode, TopEncode},
+    contract_base::{CallableContract, ContractBase},
     types::{
         heap::{Address, H256},
         EsdtLocalRole,

--- a/framework/debug/src/testing_framework/tx_mandos.rs
+++ b/framework/debug/src/testing_framework/tx_mandos.rs
@@ -1,6 +1,6 @@
 use crate::{num_bigint, tx_mock::TxTokenTransfer};
 use mx_sc::{
-    mx_sc_codec::{top_encode_to_vec_u8_or_panic, TopEncode},
+    codec::{top_encode_to_vec_u8_or_panic, TopEncode},
     types::heap::Address,
 };
 use num_traits::Zero;

--- a/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_add_quantity_mock.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_add_quantity_mock.rs
@@ -1,7 +1,7 @@
 use crate::num_bigint::BigUint;
 use mx_sc::{
     api::ESDT_NFT_ADD_QUANTITY_FUNC_NAME,
-    mx_sc_codec::{top_encode_to_vec_u8, TopDecode},
+    codec::{top_encode_to_vec_u8, TopDecode},
 };
 
 use crate::{

--- a/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_add_uri_mock.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_add_uri_mock.rs
@@ -1,6 +1,6 @@
 use mx_sc::{
     api::ESDT_NFT_ADD_URI_FUNC_NAME,
-    mx_sc_codec::{top_encode_to_vec_u8, TopDecode},
+    codec::{top_encode_to_vec_u8, TopDecode},
 };
 
 use crate::tx_mock::{BlockchainUpdate, TxCache, TxInput, TxLog, TxResult};

--- a/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_burn_mock.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_burn_mock.rs
@@ -1,7 +1,7 @@
 use crate::num_bigint::BigUint;
 use mx_sc::{
     api::ESDT_NFT_BURN_FUNC_NAME,
-    mx_sc_codec::{top_encode_to_vec_u8, TopDecode},
+    codec::{top_encode_to_vec_u8, TopDecode},
 };
 
 use crate::tx_mock::{BlockchainUpdate, TxCache, TxInput, TxLog, TxResult};

--- a/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_create_mock.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_create_mock.rs
@@ -1,7 +1,7 @@
 use crate::num_bigint::BigUint;
 use mx_sc::{
     api::ESDT_NFT_CREATE_FUNC_NAME,
-    mx_sc_codec::{top_encode_to_vec_u8, TopDecode},
+    codec::{top_encode_to_vec_u8, TopDecode},
 };
 
 use crate::{

--- a/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_update_attriutes_mock.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/esdt_nft/esdt_nft_update_attriutes_mock.rs
@@ -1,6 +1,6 @@
 use mx_sc::{
     api::ESDT_NFT_UPDATE_ATTRIBUTES_FUNC_NAME,
-    mx_sc_codec::{top_encode_to_vec_u8, TopDecode},
+    codec::{top_encode_to_vec_u8, TopDecode},
 };
 
 use crate::tx_mock::{BlockchainUpdate, TxCache, TxInput, TxLog, TxResult};

--- a/framework/debug/src/tx_execution/builtin_function_mocks/general/change_owner_mock.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/general/change_owner_mock.rs
@@ -1,4 +1,4 @@
-use mx_sc::{api::CHANGE_OWNER_BUILTIN_FUNC_NAME, mx_sc_codec::TopDecode, types::heap::Address};
+use mx_sc::{api::CHANGE_OWNER_BUILTIN_FUNC_NAME, codec::TopDecode, types::heap::Address};
 
 use crate::tx_mock::{BlockchainUpdate, TxCache, TxInput, TxResult};
 

--- a/framework/debug/src/tx_execution/builtin_function_mocks/transfer/esdt_multi_transfer_mock.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/transfer/esdt_multi_transfer_mock.rs
@@ -1,4 +1,4 @@
-use mx_sc::{api::ESDT_MULTI_TRANSFER_FUNC_NAME, mx_sc_codec::TopDecode, types::heap::Address};
+use mx_sc::{api::ESDT_MULTI_TRANSFER_FUNC_NAME, codec::TopDecode, types::heap::Address};
 
 use crate::{
     tx_execution::builtin_function_mocks::builtin_func_trait::BuiltinFunctionEsdtTransferInfo,

--- a/framework/debug/src/tx_execution/builtin_function_mocks/transfer/esdt_nft_transfer_mock.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/transfer/esdt_nft_transfer_mock.rs
@@ -2,7 +2,7 @@ use crate::{
     tx_execution::builtin_function_mocks::builtin_func_trait::BuiltinFunctionEsdtTransferInfo,
     tx_mock::{BlockchainUpdate, TxCache, TxInput, TxResult},
 };
-use mx_sc::{api::ESDT_NFT_TRANSFER_FUNC_NAME, mx_sc_codec::TopDecode, types::heap::Address};
+use mx_sc::{api::ESDT_NFT_TRANSFER_FUNC_NAME, codec::TopDecode, types::heap::Address};
 
 use super::{
     super::builtin_func_trait::BuiltinFunction,

--- a/framework/debug/src/tx_execution/builtin_function_mocks/transfer/transfer_common.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/transfer/transfer_common.rs
@@ -7,7 +7,7 @@ use crate::{
         BlockchainUpdate, TxCache, TxFunctionName, TxInput, TxLog, TxResult, TxTokenTransfer,
     },
 };
-use mx_sc::{mx_sc_codec::TopDecode, types::heap::Address};
+use mx_sc::{codec::TopDecode, types::heap::Address};
 use num_bigint::BigUint;
 use num_traits::Zero;
 

--- a/framework/debug/src/tx_mock/tx_async_call_data.rs
+++ b/framework/debug/src/tx_mock/tx_async_call_data.rs
@@ -3,7 +3,7 @@ use crate::{
     tx_mock::{TxInput, TxResult},
 };
 use mx_sc::{
-    mx_sc_codec::*,
+    codec::*,
     types::heap::{Address, H256},
 };
 

--- a/framework/debug/tests/derive_managed_vec_item_biguint_test.rs
+++ b/framework/debug/tests/derive_managed_vec_item_biguint_test.rs
@@ -1,8 +1,8 @@
 use mx_sc::{
     api::{HandleConstraints, ManagedTypeApi},
     derive::ManagedVecItem,
-    mx_sc_codec,
-    mx_sc_codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
+    codec,
+    codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
     types::{BigUint, ManagedType},
 };
 use mx_sc_debug::DebugApi;

--- a/framework/debug/tests/derive_managed_vec_item_biguint_test.rs
+++ b/framework/debug/tests/derive_managed_vec_item_biguint_test.rs
@@ -1,8 +1,8 @@
 use mx_sc::{
     api::{HandleConstraints, ManagedTypeApi},
-    derive::ManagedVecItem,
     codec,
     codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
+    derive::ManagedVecItem,
     types::{BigUint, ManagedType},
 };
 use mx_sc_debug::DebugApi;

--- a/framework/debug/tests/derive_managed_vec_item_esdt_token_payment_test.rs
+++ b/framework/debug/tests/derive_managed_vec_item_esdt_token_payment_test.rs
@@ -1,8 +1,8 @@
 use mx_sc::{
     api::{HandleConstraints, ManagedTypeApi},
-    derive::ManagedVecItem,
     codec,
     codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
+    derive::ManagedVecItem,
     types::{BigUint, EsdtTokenPayment, ManagedByteArray, ManagedType, TokenIdentifier},
 };
 use mx_sc_debug::DebugApi;

--- a/framework/debug/tests/derive_managed_vec_item_esdt_token_payment_test.rs
+++ b/framework/debug/tests/derive_managed_vec_item_esdt_token_payment_test.rs
@@ -1,8 +1,8 @@
 use mx_sc::{
     api::{HandleConstraints, ManagedTypeApi},
     derive::ManagedVecItem,
-    mx_sc_codec,
-    mx_sc_codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
+    codec,
+    codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
     types::{BigUint, EsdtTokenPayment, ManagedByteArray, ManagedType, TokenIdentifier},
 };
 use mx_sc_debug::DebugApi;

--- a/framework/debug/tests/derive_managed_vec_item_simple_enum.rs
+++ b/framework/debug/tests/derive_managed_vec_item_simple_enum.rs
@@ -1,7 +1,7 @@
 use mx_sc::{
     derive::ManagedVecItem,
-    mx_sc_codec,
-    mx_sc_codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
+    codec,
+    codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
 };
 
 // to test, run the following command in mx-sc-debug folder:

--- a/framework/debug/tests/derive_managed_vec_item_simple_enum.rs
+++ b/framework/debug/tests/derive_managed_vec_item_simple_enum.rs
@@ -1,7 +1,7 @@
 use mx_sc::{
-    derive::ManagedVecItem,
     codec,
     codec::mx_sc_codec_derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
+    derive::ManagedVecItem,
 };
 
 // to test, run the following command in mx-sc-debug folder:

--- a/framework/debug/tests/derive_managed_vec_item_struct_1_test.rs
+++ b/framework/debug/tests/derive_managed_vec_item_struct_1_test.rs
@@ -1,4 +1,4 @@
-use mx_sc::mx_sc_codec::test_util::{check_dep_encode_decode, check_top_encode_decode};
+use mx_sc::codec::test_util::{check_dep_encode_decode, check_top_encode_decode};
 use mx_sc_debug::DebugApi;
 
 mx_sc::derive_imports!();

--- a/framework/debug/tests/esdt_token_payment_test.rs
+++ b/framework/debug/tests/esdt_token_payment_test.rs
@@ -1,5 +1,5 @@
 use mx_sc::{
-    mx_sc_codec::{self, DefaultErrorHandler, TopEncode},
+    codec::{self, DefaultErrorHandler, TopEncode},
     types::{BigUint, EsdtTokenPayment, TokenIdentifier},
 };
 use mx_sc_debug::DebugApi;
@@ -10,14 +10,14 @@ fn esdt_token_payment_backwards_compatible_top_decode_or_handle_err<I, H>(
     h: H,
 ) -> Result<EsdtTokenPayment<DebugApi>, H::HandledErr>
 where
-    I: mx_sc_codec::TopDecodeInput,
-    H: mx_sc_codec::DecodeErrorHandler,
+    I: codec::TopDecodeInput,
+    H: codec::DecodeErrorHandler,
 {
     let mut nested_buffer = top_input.into_nested_buffer();
     let result =
         EsdtTokenPayment::backwards_compatible_dep_decode_or_handle_err(&mut nested_buffer, h)?;
-    if !mx_sc_codec::NestedDecodeInput::is_depleted(&nested_buffer) {
-        return Err(h.handle_error(mx_sc_codec::DecodeError::INPUT_TOO_LONG));
+    if !codec::NestedDecodeInput::is_depleted(&nested_buffer) {
+        return Err(h.handle_error(codec::DecodeError::INPUT_TOO_LONG));
     }
     Ok(result)
 }
@@ -28,13 +28,13 @@ fn esdt_token_payment_regular_top_decode_or_handle_err<I, H>(
     h: H,
 ) -> Result<EsdtTokenPayment<DebugApi>, H::HandledErr>
 where
-    I: mx_sc_codec::TopDecodeInput,
-    H: mx_sc_codec::DecodeErrorHandler,
+    I: codec::TopDecodeInput,
+    H: codec::DecodeErrorHandler,
 {
     let mut nested_buffer = top_input.into_nested_buffer();
     let result = EsdtTokenPayment::regular_dep_decode_or_handle_err(&mut nested_buffer, h)?;
-    if !mx_sc_codec::NestedDecodeInput::is_depleted(&nested_buffer) {
-        return Err(h.handle_error(mx_sc_codec::DecodeError::INPUT_TOO_LONG));
+    if !codec::NestedDecodeInput::is_depleted(&nested_buffer) {
+        return Err(h.handle_error(codec::DecodeError::INPUT_TOO_LONG));
     }
     Ok(result)
 }

--- a/framework/debug/tests/hex_call_data_arg_load.rs
+++ b/framework/debug/tests/hex_call_data_arg_load.rs
@@ -1,7 +1,7 @@
 #![feature(exhaustive_patterns)]
 
 use mx_sc::{
-    mx_sc_codec::{
+    codec::{
         multi_types::{MultiValue2, MultiValueVec, OptionalValue},
         PanicErrorHandler, TopDecodeMulti, TopDecodeMultiInput,
     },

--- a/framework/debug/tests/multi_value_encoded_test.rs
+++ b/framework/debug/tests/multi_value_encoded_test.rs
@@ -1,5 +1,5 @@
 use mx_sc::{
-    mx_sc_codec::multi_types::MultiValue5,
+    codec::multi_types::MultiValue5,
     types::{BigUint, MultiValueEncoded},
 };
 use mx_sc_debug::DebugApi;

--- a/framework/derive/src/generate/auto_impl_event.rs
+++ b/framework/derive/src/generate/auto_impl_event.rs
@@ -110,7 +110,7 @@ pub fn generate_legacy_event_impl(m: &Method, event_id_bytes: &[u8]) -> proc_mac
             } else {
                 let pat = &arg.pat;
                 quote! {
-                    let data_vec = match mx_sc::mx_sc_codec::top_encode_to_vec_u8(&#pat) {
+                    let data_vec = match mx_sc::codec::top_encode_to_vec_u8(&#pat) {
                         Result::Ok(data_vec) => data_vec,
                         Result::Err(encode_err) => mx_sc::api::ErrorApiImpl::signal_error(
                             &Self::Api::error_api_impl(),

--- a/framework/derive/src/generate/proxy_gen.rs
+++ b/framework/derive/src/generate/proxy_gen.rs
@@ -299,12 +299,6 @@ pub fn proxy_obj_code(contract: &ContractTrait) -> proc_macro2::TokenStream {
 
 fn equivalent_encode_path_gen(ty: &syn::Type) -> syn::Path {
     let owned_type = convert_to_owned_type(ty);
-    syn::parse_str(
-        format!(
-            "mx_sc::codec::CodecInto<{}>",
-            owned_type.to_token_stream()
-        )
-        .as_str(),
-    )
-    .unwrap()
+    syn::parse_str(format!("mx_sc::codec::CodecInto<{}>", owned_type.to_token_stream()).as_str())
+        .unwrap()
 }

--- a/framework/derive/src/generate/proxy_gen.rs
+++ b/framework/derive/src/generate/proxy_gen.rs
@@ -301,7 +301,7 @@ fn equivalent_encode_path_gen(ty: &syn::Type) -> syn::Path {
     let owned_type = convert_to_owned_type(ty);
     syn::parse_str(
         format!(
-            "mx_sc::mx_sc_codec::CodecInto<{}>",
+            "mx_sc::codec::CodecInto<{}>",
             owned_type.to_token_stream()
         )
         .as_str(),

--- a/framework/snippets/src/interactor_result.rs
+++ b/framework/snippets/src/interactor_result.rs
@@ -7,7 +7,7 @@ use log::info;
 use mx_sc_debug::{
     bech32,
     mx_sc::{
-        mx_sc_codec::{PanicErrorHandler, TopDecodeMulti},
+        codec::{PanicErrorHandler, TopDecodeMulti},
         types::Address,
     },
 };

--- a/framework/snippets/src/interactor_sc_call.rs
+++ b/framework/snippets/src/interactor_sc_call.rs
@@ -4,7 +4,7 @@ use log::info;
 use mx_sc_debug::{
     mandos_system::model::{ScCallStep, TransferStep, TxCall, TypedScCall},
     mx_sc::{
-        mx_sc_codec::{multi_types::IgnoreValue, CodecFrom, TopEncodeMulti},
+        codec::{multi_types::IgnoreValue, CodecFrom, TopEncodeMulti},
         types::ContractCallWithEgld,
     },
     DebugApi,

--- a/framework/snippets/src/interactor_sc_deploy.rs
+++ b/framework/snippets/src/interactor_sc_deploy.rs
@@ -3,7 +3,7 @@ use elrond_sdk_erdrs::data::{address::Address as ErdrsAddress, transaction::Tran
 use log::info;
 use mx_sc_debug::{
     mandos_system::model::{ScDeployStep, TypedScDeploy},
-    mx_sc::mx_sc_codec::{CodecFrom, TopEncodeMulti},
+    mx_sc::codec::{CodecFrom, TopEncodeMulti},
 };
 
 const DEPLOY_RECEIVER: [u8; 32] = [0u8; 32];

--- a/framework/snippets/src/interactor_vm_query.rs
+++ b/framework/snippets/src/interactor_vm_query.rs
@@ -3,7 +3,7 @@ use elrond_sdk_erdrs::data::vm::VmValueRequest;
 use log::info;
 use mx_sc_debug::{
     mx_sc::{
-        mx_sc_codec::{CodecFrom, PanicErrorHandler},
+        codec::{CodecFrom, PanicErrorHandler},
         types::ContractCall,
     },
     DebugApi,

--- a/tools/erdpy-snippet-generator/src/cmd_builder.rs
+++ b/tools/erdpy-snippet-generator/src/cmd_builder.rs
@@ -1,4 +1,4 @@
-use mx_sc::mx_sc_codec::{top_encode_to_vec_u8_or_panic, TopEncode};
+use mx_sc::codec::{top_encode_to_vec_u8_or_panic, TopEncode};
 
 const FLAG_PREFIX: &str = "--";
 const HEX_PREFIX: &str = "0x";

--- a/tools/erdpy-snippet-generator/src/erdpy_snippet_generator.rs
+++ b/tools/erdpy-snippet-generator/src/erdpy_snippet_generator.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use mx_sc::mx_sc_codec::{top_encode_to_vec_u8_or_panic, TopEncode};
+use mx_sc::codec::{top_encode_to_vec_u8_or_panic, TopEncode};
 use num_traits::Zero;
 
 mod cmd_builder;

--- a/tools/rust-debugger/format-tests/src/format_tests.rs
+++ b/tools/rust-debugger/format-tests/src/format_tests.rs
@@ -1,5 +1,5 @@
 use mx_sc::{
-    mx_sc_codec::multi_types::OptionalValue,
+    codec::multi_types::OptionalValue,
     esdt::ESDTSystemSmartContractProxy,
     types::{
         heap::{Address, BoxedBytes},

--- a/tools/rust-debugger/pretty-printers/mx_sc_lldb_pretty_printers.py
+++ b/tools/rust-debugger/pretty-printers/mx_sc_lldb_pretty_printers.py
@@ -51,7 +51,7 @@ HEAP_ADDRESS_TYPE = f"{MOD_PATH}::h256_address::Address"
 BOXED_BYTES_TYPE = f"{MOD_PATH}::boxed_bytes::BoxedBytes"
 
 # 6. Elrond codec - Multi-types
-MOD_PATH = "codec::multi_types"
+MOD_PATH = "mx_sc_codec::multi_types"
 
 OPTIONAL_VALUE_TYPE = f"{MOD_PATH}::multi_value_optional::OptionalValue<{ANY_TYPE}>::{SOME_OR_NONE}"
 

--- a/tools/rust-debugger/pretty-printers/mx_sc_lldb_pretty_printers.py
+++ b/tools/rust-debugger/pretty-printers/mx_sc_lldb_pretty_printers.py
@@ -51,7 +51,7 @@ HEAP_ADDRESS_TYPE = f"{MOD_PATH}::h256_address::Address"
 BOXED_BYTES_TYPE = f"{MOD_PATH}::boxed_bytes::BoxedBytes"
 
 # 6. Elrond codec - Multi-types
-MOD_PATH = "mx_sc_codec::multi_types"
+MOD_PATH = "codec::multi_types"
 
 OPTIONAL_VALUE_TYPE = f"{MOD_PATH}::multi_value_optional::OptionalValue<{ANY_TYPE}>::{SOME_OR_NONE}"
 


### PR DESCRIPTION
Reexports don't need to bear the full name. It is a great time to make them more succint.