### PR TITLE
sc-meta install all windows fix

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install sc-meta
         run: cargo install multiversx-sc-meta
 
+      - name: Install sc-meta dependencies
+        run: sc-meta install all
+
       - name: Run sc-meta commands
         run: |
           cd contracts/feature-tests/basic-features

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
           rustflags: ""
 
       - name: Install sc-meta
-        run: cargo install multiversx-sc-meta
+        run: cargo install --path framework/meta
 
       - name: Install sc-meta dependencies
         run: sc-meta install all

--- a/framework/meta/src/cmd/install.rs
+++ b/framework/meta/src/cmd/install.rs
@@ -9,8 +9,6 @@ use crate::cli::{
     InstallWasmOptArgs,
 };
 
-use self::install_scenario_go::ScenarioGoInstaller;
-
 pub async fn install(args: &InstallArgs) {
     // validated before, can unwrap directly
     let command = args.command.as_ref().unwrap();
@@ -30,9 +28,7 @@ pub async fn install(args: &InstallArgs) {
 }
 
 async fn install_scenario_go(sg_args: &InstallMxScenarioGoArgs) {
-    ScenarioGoInstaller::new(sg_args.tag.clone())
-        .install()
-        .await;
+    install_scenario_go::install(sg_args.tag.clone()).await;
 }
 
 fn install_wasm32(_wasm32_args: &InstallWasm32Args) {

--- a/framework/meta/src/cmd/install/install_debugger.rs
+++ b/framework/meta/src/cmd/install/install_debugger.rs
@@ -39,10 +39,15 @@ fn remove_old_lldb_extension() {
         .status();
 
     // Run to clean .vscode/extensions/ folder of the remains of previous extension installations
-    let _ = Command::new("rm")
-        .arg("-rf")
-        .arg("~/.vscode/extensions/vadim*")
-        .status();
+    let extensions_dir = home_dir().join(".vscode").join("extensions");
+    if let Ok(entries) = fs::read_dir(&extensions_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_string_lossy().starts_with("vadim") {
+                let _ = fs::remove_dir_all(entry.path());
+            }
+        }
+    }
 }
 fn install_lldb_extension() -> io::Result<()> {
     let extension_id = "vadimcn.vscode-lldb";
@@ -114,6 +119,14 @@ fn get_path_to_settings() -> PathBuf {
             // For Linux
             Path::new(&user_home)
                 .join(".config")
+                .join("Code")
+                .join("User")
+                .join("settings.json")
+        }
+        "windows" => {
+            // For Windows
+            let appdata = env::var("APPDATA").expect("Could not find APPDATA environment variable");
+            Path::new(&appdata)
                 .join("Code")
                 .join("User")
                 .join("settings.json")

--- a/framework/meta/src/cmd/install/install_debugger.rs
+++ b/framework/meta/src/cmd/install/install_debugger.rs
@@ -13,7 +13,6 @@ pub const TARGET_PATH: &str = ".vscode/extensions/";
 
 pub async fn install_debugger(custom_path: Option<PathBuf>) {
     let testing = custom_path.is_some();
-    remove_old_lldb_extension();
     let _ = install_lldb_extension();
     install_script(custom_path).await;
     if !testing {
@@ -29,26 +28,6 @@ fn home_dir() -> PathBuf {
     std::env::home_dir().expect("Could not find home directory")
 }
 
-fn remove_old_lldb_extension() {
-    let extension_id = "vadimcn.vscode-lldb";
-
-    // Run the VSCode command to remove the previous installed extension
-    let _ = Command::new("code")
-        .arg("--uninstall-extension")
-        .arg(extension_id)
-        .status();
-
-    // Run to clean .vscode/extensions/ folder of the remains of previous extension installations
-    let extensions_dir = home_dir().join(".vscode").join("extensions");
-    if let Ok(entries) = fs::read_dir(&extensions_dir) {
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            if name.to_string_lossy().starts_with("vadim") {
-                let _ = fs::remove_dir_all(entry.path());
-            }
-        }
-    }
-}
 fn install_lldb_extension() -> io::Result<()> {
     let extension_id = "vadimcn.vscode-lldb";
 
@@ -56,6 +35,7 @@ fn install_lldb_extension() -> io::Result<()> {
     let install_lldb_command = Command::new("code")
         .arg("--install-extension")
         .arg(extension_id)
+        .arg("--force")
         .status()?;
 
     if install_lldb_command.success() {

--- a/framework/meta/src/cmd/install/install_debugger.rs
+++ b/framework/meta/src/cmd/install/install_debugger.rs
@@ -1,6 +1,7 @@
 use colored::Colorize;
 
 use crate::cmd::template::RepoSource;
+use super::system_info::{get_system_info, SystemInfo};
 use std::fs::{self};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -83,10 +84,9 @@ fn get_script_path(path: PathBuf) -> PathBuf {
 }
 
 fn get_path_to_settings() -> PathBuf {
-    let os = env::consts::OS;
     let user_home = home_dir();
-    match os {
-        "macos" => {
+    match get_system_info() {
+        SystemInfo::MacOs => {
             // For macOS
             Path::new(&user_home)
                 .join("Library")
@@ -95,7 +95,7 @@ fn get_path_to_settings() -> PathBuf {
                 .join("User")
                 .join("settings.json")
         }
-        "linux" => {
+        SystemInfo::Linux => {
             // For Linux
             Path::new(&user_home)
                 .join(".config")
@@ -103,7 +103,7 @@ fn get_path_to_settings() -> PathBuf {
                 .join("User")
                 .join("settings.json")
         }
-        "windows" => {
+        SystemInfo::Windows => {
             // For Windows
             let appdata = env::var("APPDATA").expect("Could not find APPDATA environment variable");
             Path::new(&appdata)
@@ -111,7 +111,6 @@ fn get_path_to_settings() -> PathBuf {
                 .join("User")
                 .join("settings.json")
         }
-        _ => panic!("OS not supported"),
     }
 }
 

--- a/framework/meta/src/cmd/install/install_debugger.rs
+++ b/framework/meta/src/cmd/install/install_debugger.rs
@@ -1,7 +1,7 @@
 use colored::Colorize;
 
+use super::system_info::{SystemInfo, get_system_info};
 use crate::cmd::template::RepoSource;
-use super::system_info::{get_system_info, SystemInfo};
 use std::fs::{self};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -15,6 +15,13 @@ pub const TARGET_PATH: &str = ".vscode/extensions/";
 pub async fn install_debugger(custom_path: Option<PathBuf>) {
     let testing = custom_path.is_some();
     let _ = install_lldb_extension();
+    if get_system_info() == SystemInfo::Windows {
+        println!(
+            "{}",
+            "On Windows, the VS Code window opened by this tool can be safely closed after installation."
+                .yellow()
+        );
+    }
     install_script(custom_path).await;
     if !testing {
         // if we are testing we skip the configuration path, not to mess up with the current vscode configuration

--- a/framework/meta/src/cmd/install/install_scenario_go.rs
+++ b/framework/meta/src/cmd/install/install_scenario_go.rs
@@ -40,6 +40,7 @@ fn select_zip_name() -> String {
     match get_system_info() {
         SystemInfo::Linux => "mx_scenario_go_linux_amd64.zip".to_string(),
         SystemInfo::MacOs => "mx_scenario_go_darwin_amd64.zip".to_string(),
+        SystemInfo::Windows => String::new(),
     }
 }
 
@@ -57,6 +58,11 @@ impl ScenarioGoInstaller {
     }
 
     pub async fn install(&self) {
+        if get_system_info() == SystemInfo::Windows {
+            println!("mx-scenario-go is not supported on Windows, skipping.");
+            return;
+        }
+
         let release_raw = self
             .get_scenario_go_release_json()
             .await

--- a/framework/meta/src/cmd/install/install_scenario_go.rs
+++ b/framework/meta/src/cmd/install/install_scenario_go.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, anyhow};
+use colored::Colorize;
 use core::time;
 use serde_json::Value;
 use std::{
@@ -59,7 +60,10 @@ impl ScenarioGoInstaller {
 
     pub async fn install(&self) {
         if get_system_info() == SystemInfo::Windows {
-            println!("mx-scenario-go is not supported on Windows, skipping.");
+            println!(
+                "{}",
+                "mx-scenario-go is not supported on Windows, skipping.".yellow()
+            );
             return;
         }
 

--- a/framework/meta/src/cmd/install/install_scenario_go.rs
+++ b/framework/meta/src/cmd/install/install_scenario_go.rs
@@ -22,14 +22,14 @@ const SCENARIO_CLI_RELEASES_BASE_URL: &str =
 const CARGO_HOME: &str = env!("CARGO_HOME");
 
 #[derive(Clone, Debug)]
-pub struct ScenarioGoRelease {
+struct ScenarioGoRelease {
     #[allow(dead_code)]
-    pub tag_name: String,
-    pub download_url: String,
+    tag_name: String,
+    download_url: String,
 }
 
 #[derive(Clone, Debug)]
-pub struct ScenarioGoInstaller {
+struct ScenarioGoInstaller {
     tag: Option<String>,
     zip_name: String,
     user_agent: String,
@@ -37,36 +37,39 @@ pub struct ScenarioGoInstaller {
     cargo_bin_folder: PathBuf,
 }
 
-fn select_zip_name() -> String {
-    match get_system_info() {
+fn select_zip_name(system_info: SystemInfo) -> String {
+    match system_info {
         SystemInfo::Linux => "mx_scenario_go_linux_amd64.zip".to_string(),
         SystemInfo::MacOs => "mx_scenario_go_darwin_amd64.zip".to_string(),
-        SystemInfo::Windows => String::new(),
+        SystemInfo::Windows => unreachable!("mx-scenario-go is not supported on Windows"),
     }
 }
 
-impl ScenarioGoInstaller {
-    pub fn new(tag: Option<String>) -> Self {
-        let cargo_home = PathBuf::from(CARGO_HOME);
-        let cargo_bin_folder = cargo_home.join("bin");
-        ScenarioGoInstaller {
-            tag,
-            zip_name: select_zip_name(),
-            user_agent: USER_AGENT.to_string(),
-            temp_dir_path: std::env::temp_dir(),
-            cargo_bin_folder,
-        }
+pub async fn install(tag: Option<String>) {
+    let system_info = get_system_info();
+    if system_info == SystemInfo::Windows {
+        println!(
+            "{}",
+            "mx-scenario-go is not supported on Windows, skipping.".yellow()
+        );
+        return;
     }
 
-    pub async fn install(&self) {
-        if get_system_info() == SystemInfo::Windows {
-            println!(
-                "{}",
-                "mx-scenario-go is not supported on Windows, skipping.".yellow()
-            );
-            return;
-        }
+    let cargo_home = PathBuf::from(CARGO_HOME);
+    let cargo_bin_folder = cargo_home.join("bin");
+    let installer = ScenarioGoInstaller {
+        tag,
+        zip_name: select_zip_name(system_info),
+        user_agent: USER_AGENT.to_string(),
+        temp_dir_path: std::env::temp_dir(),
+        cargo_bin_folder,
+    };
 
+    installer.install().await;
+}
+
+impl ScenarioGoInstaller {
+    async fn install(&self) {
         let release_raw = self
             .get_scenario_go_release_json()
             .await

--- a/framework/meta/src/cmd/install/system_info.rs
+++ b/framework/meta/src/cmd/install/system_info.rs
@@ -2,6 +2,7 @@
 pub enum SystemInfo {
     Linux,
     MacOs,
+    Windows,
 }
 
 pub fn get_system_info() -> SystemInfo {
@@ -9,6 +10,7 @@ pub fn get_system_info() -> SystemInfo {
     match os {
         "linux" => SystemInfo::Linux,
         "macos" => SystemInfo::MacOs,
+        "windows" => SystemInfo::Windows,
         _ => panic!("unknown configuration: {os}"),
     }
 }


### PR DESCRIPTION
## Pull request overview

This PR updates `sc-meta install all` behavior to better handle Windows environments by detecting Windows explicitly and skipping unsupported components, while adjusting Windows CI to exercise the local `sc-meta` and its dependency installation.

**Changes:**
- Extend OS detection to include Windows (`SystemInfo::Windows`).
- Skip `mx-scenario-go` installation on Windows and add Windows-specific messaging for debugger installation.
- Update Windows CI workflow to install `sc-meta` from the repo and run `sc-meta install all`.

### Reviewed changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 3 comments.

| File | Description |
| ---- | ----------- |
| framework/meta/src/cmd/install/system_info.rs | Adds Windows to OS detection enum + mapping. |
| framework/meta/src/cmd/install/install_scenario_go.rs | Skips scenario-go installation on Windows; introduces Windows branch in zip selection. |
| framework/meta/src/cmd/install/install_debugger.rs | Uses shared OS detection; forces LLDB extension install; adds Windows settings path and messaging. |
| .github/workflows/windows.yml | Installs local `sc-meta` and runs `sc-meta install all` in Windows CI. |
