### PR TITLE
sc-meta wallet test-wallet CLI

### DIFF
--- a/contracts/examples/adder/.gitignore
+++ b/contracts/examples/adder/.gitignore
@@ -9,3 +9,8 @@
 # Mandos test trace
 adder_trace*.scen.json
 trace*.scen.json
+
+# Script artifacts
+snippets/*.pem
+snippets/*.data-storage.json
+snippets/*.interaction.json

--- a/contracts/examples/adder/snippets/adder.snippets.sh
+++ b/contracts/examples/adder/snippets/adder.snippets.sh
@@ -13,7 +13,8 @@ TX_TOOL=("${BASE[@]}" "${TX_CMD}")
 DATA_TOOL=("${BASE[@]}" data)
 # ──────────────────────────────────────────────────────────────────────────────
 
-ALICE="../../../../sdk/core/src/test_wallets/alice.pem"
+sc-meta wallet test-wallet --name alice
+ALICE="alice.pem"
 
 case "${NETWORK}" in
     devnet)           PROXY=https://devnet-gateway.multiversx.com;  CHAIN=D ;;

--- a/contracts/examples/adder/snippets/adder.snippets.sh
+++ b/contracts/examples/adder/snippets/adder.snippets.sh
@@ -13,7 +13,9 @@ TX_TOOL=("${BASE[@]}" "${TX_CMD}")
 DATA_TOOL=("${BASE[@]}" data)
 # ──────────────────────────────────────────────────────────────────────────────
 
-sc-meta wallet test-wallet --name alice
+if [[ "${TOOL_VARIANT}" == "sc-meta" ]]; then
+    sc-meta wallet test-wallet --name alice
+fi
 ALICE="alice.pem"
 
 case "${NETWORK}" in

--- a/framework/meta/.gitignore
+++ b/framework/meta/.gitignore
@@ -1,1 +1,2 @@
 tests/cs_tx_cli_test/outfiles
+tests/cs_tx_cli_test/alice.pem

--- a/framework/meta/src/cli/cli_args_standalone.rs
+++ b/framework/meta/src/cli/cli_args_standalone.rs
@@ -667,7 +667,7 @@ pub struct WalletBech32Args {
 #[derive(Default, Clone, PartialEq, Eq, Debug, Args)]
 pub struct WalletTestWalletArgs {
     /// The name of the test wallet.
-    /// Allowed values: alice, bob, carol, dan, eve, frank, grace, heidi, ivan, judy, mallory, mike, sophie, simon, szonja.
+    /// Providing an invalid name will print the full list of valid names.
     #[arg(long = "name", verbatim_doc_comment)]
     pub name: String,
 

--- a/framework/meta/src/cli/cli_args_standalone.rs
+++ b/framework/meta/src/cli/cli_args_standalone.rs
@@ -598,8 +598,15 @@ pub enum WalletAction {
         about = "Encodes/decodes a bech32 address to/from hex"
     )]
     Bech32(WalletBech32Args),
+
     #[command(name = "convert", about = "Converts a wallet")]
     Convert(WalletConvertArgs),
+
+    #[command(
+        name = "test-wallet",
+        about = "Saves a test wallet PEM file to disk. Do not use on mainnet."
+    )]
+    TestWallet(WalletTestWalletArgs),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Parser)]
@@ -655,4 +662,16 @@ pub struct WalletBech32Args {
     pub hex_address: Option<String>,
     #[arg(long = "decode", verbatim_doc_comment)]
     pub bech32_address: Option<String>,
+}
+
+#[derive(Default, Clone, PartialEq, Eq, Debug, Args)]
+pub struct WalletTestWalletArgs {
+    /// The name of the test wallet.
+    /// Allowed values: alice, bob, carol, dan, eve, frank, grace, heidi, ivan, judy, mallory, mike, sophie, simon, szonja.
+    #[arg(long = "name", verbatim_doc_comment)]
+    pub name: String,
+
+    /// Output path for the PEM file. Defaults to ./<name>.pem in the current directory.
+    #[arg(long = "path", verbatim_doc_comment)]
+    pub path: Option<String>,
 }

--- a/framework/meta/src/cmd/wallet.rs
+++ b/framework/meta/src/cmd/wallet.rs
@@ -1,6 +1,9 @@
 use core::str;
 
-use crate::cli::{WalletAction, WalletArgs, WalletBech32Args, WalletConvertArgs, WalletNewArgs};
+use crate::cli::{
+    WalletAction, WalletArgs, WalletBech32Args, WalletConvertArgs, WalletNewArgs,
+    WalletTestWalletArgs,
+};
 use bip39::{Language, Mnemonic};
 use multiversx_sc::types::{self, Address};
 use multiversx_sc_snippets::sdk::{crypto::public_key::PublicKey, wallet::Wallet};
@@ -16,6 +19,7 @@ pub fn wallet(args: &WalletArgs) {
         WalletAction::New(new_args) => new(new_args),
         WalletAction::Bech32(bech32_args) => bech32_conversion(bech32_args),
         WalletAction::Convert(convert_args) => convert(convert_args),
+        WalletAction::TestWallet(test_wallet_args) => test_wallet_cmd(test_wallet_args),
     }
 }
 
@@ -235,4 +239,13 @@ fn new(new_args: &WalletNewArgs) {
         }
         None => {}
     }
+}
+
+fn test_wallet_cmd(args: &WalletTestWalletArgs) {
+    let name = &args.name;
+    let pem = multiversx_sc_snippets::test_wallets::pem_contents(name);
+    let path = args.path.clone().unwrap_or_else(|| format!("{name}.pem"));
+    let mut file = File::create(&path).unwrap();
+    file.write_all(pem.as_bytes()).unwrap();
+    println!("Saved test wallet '{name}' to '{path}'");
 }

--- a/framework/meta/src/cmd/wallet.rs
+++ b/framework/meta/src/cmd/wallet.rs
@@ -243,7 +243,14 @@ fn new(new_args: &WalletNewArgs) {
 
 fn test_wallet_cmd(args: &WalletTestWalletArgs) {
     let name = &args.name;
-    let pem = multiversx_sc_snippets::test_wallets::pem_contents(name);
+    let pem = match multiversx_sc_snippets::test_wallets::pem_contents(name) {
+        Some(pem) => pem,
+        None => {
+            let valid = multiversx_sc_snippets::test_wallets::valid_names().join(", ");
+            eprintln!("Unknown test wallet name: '{name}'. Valid names: {valid}");
+            std::process::exit(1);
+        }
+    };
     let path = args.path.clone().unwrap_or_else(|| format!("{name}.pem"));
     let mut file = File::create(&path).unwrap();
     file.write_all(pem.as_bytes()).unwrap();

--- a/framework/meta/tests/cs_tx_cli_test.rs
+++ b/framework/meta/tests/cs_tx_cli_test.rs
@@ -275,7 +275,24 @@ async fn test_adder_deploy_add_get_sum() {
 #[cfg_attr(not(feature = "chain-simulator-tests"), ignore)]
 async fn test_egld_transfer_alice_to_bob() {
     let workspace = find_current_workspace().unwrap();
-    let alice_pem_path = workspace.join("framework/meta/tests/alice.pem");
+    let test_artefacts_dir = workspace.join("framework/meta/tests/cs_tx_cli_test");
+    let alice_pem_path = test_artefacts_dir.join("alice.pem");
+
+    let sc_meta_bin = env!("CARGO_BIN_EXE_sc-meta");
+
+    // Generate alice.pem via the CLI so the file is not stored in the repo.
+    let status = Command::new(sc_meta_bin)
+        .args([
+            "wallet",
+            "test-wallet",
+            "--name",
+            "alice",
+            "--path",
+            alice_pem_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to generate alice.pem");
+    assert!(status.success(), "sc-meta wallet test-wallet failed");
 
     // Connect to the chain simulator.
     let interactor = Interactor::new(CHAIN_SIMULATOR_URL)
@@ -318,8 +335,6 @@ async fn test_egld_transfer_alice_to_bob() {
     let bob_bech32 = bob_address.to_bech32_default();
 
     // ── execute the transfer via the sc-meta CLI ──────────────────────────────
-    let sc_meta_bin = env!("CARGO_BIN_EXE_sc-meta");
-
     let status = Command::new(sc_meta_bin)
         .args([
             "tx",

--- a/sdk/core/src/test_wallets.rs
+++ b/sdk/core/src/test_wallets.rs
@@ -143,25 +143,16 @@ pub fn for_shard(shard_id: ShardId) -> Wallet {
     }
 }
 
-fn valid_names() -> Vec<&'static str> {
+pub fn valid_names() -> Vec<&'static str> {
     WALLETS.iter().map(|(n, _)| *n).collect()
 }
 
-/// Returns the raw PEM file contents for the named test wallet.
+/// Returns the raw PEM file contents for the named test wallet, or `None` if the name is unknown.
 ///
-/// Valid names: `alice`, `bob`, `carol`, `dan`, `eve`, `frank`, `grace`, `heidi`,
-/// `ivan`, `judy`, `mallory`, `mike`, `sophie`, `simon`, `szonja`.
-///
-/// Panics if the name is not one of the above.
-pub fn pem_contents(name: &str) -> &'static str {
+/// For the list of valid names see [`valid_names()`].
+pub fn pem_contents(name: &str) -> Option<&'static str> {
     WALLETS
         .iter()
         .find(|(n, _)| *n == name)
         .map(|(_, pem)| *pem)
-        .unwrap_or_else(|| {
-            panic!(
-                "Unknown test wallet name: '{name}'. Valid names: {}",
-                valid_names().join(", ")
-            )
-        })
 }

--- a/sdk/core/src/test_wallets.rs
+++ b/sdk/core/src/test_wallets.rs
@@ -2,68 +2,105 @@ use multiversx_chain_core::types::ShardId;
 
 use crate::wallet::Wallet;
 
+const ALICE_PEM: &str = include_str!("test_wallets/alice.pem");
+const BOB_PEM: &str = include_str!("test_wallets/bob.pem");
+const CAROL_PEM: &str = include_str!("test_wallets/carol.pem");
+const DAN_PEM: &str = include_str!("test_wallets/dan.pem");
+const EVE_PEM: &str = include_str!("test_wallets/eve.pem");
+const FRANK_PEM: &str = include_str!("test_wallets/frank.pem");
+const GRACE_PEM: &str = include_str!("test_wallets/grace.pem");
+const HEIDI_PEM: &str = include_str!("test_wallets/heidi.pem");
+const IVAN_PEM: &str = include_str!("test_wallets/ivan.pem");
+const JUDY_PEM: &str = include_str!("test_wallets/judy.pem");
+const MALLORY_PEM: &str = include_str!("test_wallets/mallory.pem");
+const MIKE_PEM: &str = include_str!("test_wallets/mike.pem");
+const SOPHIE_PEM: &str = include_str!("test_wallets/s0phie.pem");
+const SIMON_PEM: &str = include_str!("test_wallets/s1mon.pem");
+const SZONJA_PEM: &str = include_str!("test_wallets/s2onja.pem");
+
+const WALLETS: &[(&str, &str)] = &[
+    ("alice", ALICE_PEM),
+    ("bob", BOB_PEM),
+    ("carol", CAROL_PEM),
+    ("dan", DAN_PEM),
+    ("eve", EVE_PEM),
+    ("frank", FRANK_PEM),
+    ("grace", GRACE_PEM),
+    ("heidi", HEIDI_PEM),
+    ("ivan", IVAN_PEM),
+    ("judy", JUDY_PEM),
+    ("mallory", MALLORY_PEM),
+    ("mike", MIKE_PEM),
+    ("sophie", SOPHIE_PEM),
+    ("s0phie", SOPHIE_PEM),
+    ("simon", SIMON_PEM),
+    ("s1mon", SIMON_PEM),
+    ("szonja", SZONJA_PEM),
+    ("s2onja", SZONJA_PEM),
+];
+
 fn test_wallet(pem_file_contents: &str) -> Wallet {
     Wallet::from_pem_file_contents(pem_file_contents.to_string()).unwrap()
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn alice() -> Wallet {
-    test_wallet(include_str!("test_wallets/alice.pem"))
+    test_wallet(ALICE_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn bob() -> Wallet {
-    test_wallet(include_str!("test_wallets/bob.pem"))
+    test_wallet(BOB_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn carol() -> Wallet {
-    test_wallet(include_str!("test_wallets/carol.pem"))
+    test_wallet(CAROL_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn dan() -> Wallet {
-    test_wallet(include_str!("test_wallets/dan.pem"))
+    test_wallet(DAN_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn eve() -> Wallet {
-    test_wallet(include_str!("test_wallets/eve.pem"))
+    test_wallet(EVE_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn frank() -> Wallet {
-    test_wallet(include_str!("test_wallets/frank.pem"))
+    test_wallet(FRANK_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn grace() -> Wallet {
-    test_wallet(include_str!("test_wallets/grace.pem"))
+    test_wallet(GRACE_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn heidi() -> Wallet {
-    test_wallet(include_str!("test_wallets/heidi.pem"))
+    test_wallet(HEIDI_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn ivan() -> Wallet {
-    test_wallet(include_str!("test_wallets/ivan.pem"))
+    test_wallet(IVAN_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn judy() -> Wallet {
-    test_wallet(include_str!("test_wallets/judy.pem"))
+    test_wallet(JUDY_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn mallory() -> Wallet {
-    test_wallet(include_str!("test_wallets/mallory.pem"))
+    test_wallet(MALLORY_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
 pub fn mike() -> Wallet {
-    test_wallet(include_str!("test_wallets/mike.pem"))
+    test_wallet(MIKE_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
@@ -72,7 +109,7 @@ pub fn mike() -> Wallet {
 ///
 /// Address: 0x14af28ce7d79117f689228b1af89d16e8b0c16a3d36062a2b6eeb8fbab6c0000
 pub fn sophie() -> Wallet {
-    test_wallet(include_str!("test_wallets/s0phie.pem"))
+    test_wallet(SOPHIE_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
@@ -81,7 +118,7 @@ pub fn sophie() -> Wallet {
 ///
 /// Address: 0x4b9ab2524a7d15416fb78d4d88249dc30272bd6ee1b8a07d4342c33a40a00001
 pub fn simon() -> Wallet {
-    test_wallet(include_str!("test_wallets/s1mon.pem"))
+    test_wallet(SIMON_PEM)
 }
 
 /// Test wallet. Do not use on mainnet.
@@ -90,7 +127,7 @@ pub fn simon() -> Wallet {
 ///
 /// Address: 0x5ea3f378aaaa9f51cef76093b62e1041c90b415016dfa49760d7a846a8d90002
 pub fn szonja() -> Wallet {
-    test_wallet(include_str!("test_wallets/s2onja.pem"))
+    test_wallet(SZONJA_PEM)
 }
 
 /// Test wallets. Do not use on mainnet.
@@ -104,4 +141,27 @@ pub fn for_shard(shard_id: ShardId) -> Wallet {
         2 => szonja(),
         _ => panic!("No test wallet for shard id {shard_id_num}"),
     }
+}
+
+fn valid_names() -> Vec<&'static str> {
+    WALLETS.iter().map(|(n, _)| *n).collect()
+}
+
+/// Returns the raw PEM file contents for the named test wallet.
+///
+/// Valid names: `alice`, `bob`, `carol`, `dan`, `eve`, `frank`, `grace`, `heidi`,
+/// `ivan`, `judy`, `mallory`, `mike`, `sophie`, `simon`, `szonja`.
+///
+/// Panics if the name is not one of the above.
+pub fn pem_contents(name: &str) -> &'static str {
+    WALLETS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, pem)| *pem)
+        .unwrap_or_else(|| {
+            panic!(
+                "Unknown test wallet name: '{name}'. Valid names: {}",
+                valid_names().join(", ")
+            )
+        })
 }


### PR DESCRIPTION
## Pull request overview

This PR adds a `sc-meta wallet test-wallet` CLI subcommand for generating built-in test wallet PEM files on disk, then updates tests and example snippets to use this flow instead of relying on PEM files stored in the repository.

**Changes:**
- Added a `pem_contents(name)` accessor and centralized embedded PEM contents in `sdk/core` test wallets.
- Added `sc-meta wallet test-wallet` CLI command and updated the chain-simulator CLI test to generate `alice.pem` at runtime.
- Updated the adder example snippets and `.gitignore` entries to accommodate generated artifacts.
