### PR TITLE
interactor - print explorer url after tx/ new contract

### DIFF
--- a/framework/base/src/types/interaction/tx_from.rs
+++ b/framework/base/src/types/interaction/tx_from.rs
@@ -12,7 +12,7 @@ where
 
 /// Marks the non-empty sender of a transaction.
 ///
-/// Enforces the reciipent to be explicitly specified.
+/// Enforces the sender to be explicitly specified.
 #[diagnostic::on_unimplemented(
     message = "Type `{Self}` cannot be used as a sender value (does not implement `TxFromSpecified<{Env}>`)",
     label = "sender needs to be explicit",

--- a/framework/meta/scripts/contract.snippets.sh
+++ b/framework/meta/scripts/contract.snippets.sh
@@ -61,6 +61,7 @@ deployPayableFeatures() {
         --chain="${CHAIN}" \
         --send \
         --outfile="${OUTFILE_DEPLOY}" \
+        --wait-result \
         || return
 
     ADDRESS_PAYABLE_FEATURES=$("${DATA_TOOL[@]}" parse --file="${OUTFILE_DEPLOY}" --expression="data['contractAddress']" 2>/dev/null)
@@ -79,6 +80,7 @@ upgrade() {
         --chain="${CHAIN}" \
         --send \
         --outfile="${OUTFILE_UPGRADE}" \
+        --wait-result \
         || return
 }
 
@@ -93,6 +95,7 @@ add() {
         --chain="${CHAIN}" \
         --send \
         --outfile="${OUTFILE_CALL}" \
+        --wait-result \
         || return
 }
 

--- a/framework/meta/src/cmd/tx/tx_cli_common.rs
+++ b/framework/meta/src/cmd/tx/tx_cli_common.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use anyhow::{Context, Result, anyhow};
+use multiversx_sc_snippets::ExplorerUrl;
 use multiversx_sc_snippets::{
     hex,
     imports::{
@@ -85,7 +86,11 @@ pub(super) async fn broadcast_and_save(
         .send_transaction(&output.emitted_transaction)
         .await
         .context("failed to broadcast transaction")?;
-    println!("Transaction hash: {tx_hash}");
+    if let Some(ex) = ExplorerUrl::from_chain_id(&output.emitted_transaction.chain_id) {
+        println!("transaction: {}", ex.tx_url(&tx_hash));
+    } else {
+        println!("transaction hash: {tx_hash}");
+    }
 
     let mut output_with_hash = TxOutputFile {
         emitted_transaction_hash: tx_hash.clone(),

--- a/framework/meta/src/cmd/tx/tx_cli_deploy.rs
+++ b/framework/meta/src/cmd/tx/tx_cli_deploy.rs
@@ -2,6 +2,7 @@ use std::fs;
 
 use anyhow::{Context, Result};
 use multiversx_sc::chain_core::std::new_address::compute_new_address_bech32;
+use multiversx_sc_snippets::ExplorerUrl;
 use multiversx_sc_snippets::imports::{BytesValue, Interactor, InteractorIntoSdkTransaction};
 
 use super::parse_code_metadata::parse_code_metadata;
@@ -53,7 +54,11 @@ async fn tx_deploy_inner(args: &DeployArgs) -> Result<()> {
     let tx = tx_builder.into_sdk_transaction();
 
     let contract_address = compute_new_address_bech32(&tx.sender, nonce);
-    println!("Contract address: {contract_address}");
+    if let Some(ex) = ExplorerUrl::from_chain_id(&tx.chain_id) {
+        println!("new contract: {}", ex.address_url(&contract_address));
+    } else {
+        println!("new contract address: {contract_address}");
+    }
 
     sign_and_dispatch(
         wallet,

--- a/framework/meta/src/cmd/tx/tx_cli_deploy.rs
+++ b/framework/meta/src/cmd/tx/tx_cli_deploy.rs
@@ -54,7 +54,11 @@ async fn tx_deploy_inner(args: &DeployArgs) -> Result<()> {
     let tx = tx_builder.into_sdk_transaction();
 
     let contract_address = compute_new_address_bech32(&tx.sender, nonce);
-    if let Some(ex) = ExplorerUrl::from_chain_id(&tx.chain_id) {
+
+    // TODO: refactor, by working with an interactor object in the future,
+    // who keeps the effective network config/chain ID
+    let effective_chain_id = args.gateway.chain.as_deref().unwrap_or(&tx.chain_id);
+    if let Some(ex) = ExplorerUrl::from_chain_id(effective_chain_id) {
         println!("new contract: {}", ex.address_url(&contract_address));
     } else {
         println!("new contract address: {contract_address}");

--- a/framework/snippets/src/interactor.rs
+++ b/framework/snippets/src/interactor.rs
@@ -1,3 +1,4 @@
+mod explorer_url;
 mod interactor_base;
 mod interactor_chain_simulator;
 mod interactor_dns;
@@ -5,6 +6,7 @@ mod interactor_scenario;
 mod interactor_sender;
 mod interactor_tx;
 
+pub use explorer_url::ExplorerUrl;
 pub use interactor_base::*;
 pub use interactor_dns::*;
 pub use interactor_sender::*;

--- a/framework/snippets/src/interactor/explorer_url.rs
+++ b/framework/snippets/src/interactor/explorer_url.rs
@@ -1,0 +1,38 @@
+use multiversx_sc_scenario::imports::Bech32Address;
+
+/// Builds explorer URLs for a specific MultiversX network.
+///
+/// Constructed via [`ExplorerUrl::from_chain_id`].
+pub struct ExplorerUrl {
+    base_url: &'static str,
+}
+
+impl ExplorerUrl {
+    pub const MAINNET_EXPLORER: &str = "https://explorer.multiversx.com";
+    pub const TESTNET_EXPLORER: &str = "https://testnet-explorer.multiversx.com";
+    pub const DEVNET_EXPLORER: &str = "https://devnet-explorer.multiversx.com";
+
+    /// Returns an `ExplorerUrl` for the given chain ID, or `None` for unknown chains.
+    pub fn from_chain_id(chain_id: &str) -> Option<Self> {
+        explorer_base_url_from_chain_id(chain_id).map(|base_url| ExplorerUrl { base_url })
+    }
+
+    /// Returns the explorer URL for a transaction hash.
+    pub fn tx_url(&self, tx_hash: &str) -> String {
+        format!("{}/transactions/{tx_hash}", self.base_url)
+    }
+
+    /// Returns the explorer URL for an account address.
+    pub fn address_url(&self, address: &Bech32Address) -> String {
+        format!("{}/accounts/{}", self.base_url, address.bech32)
+    }
+}
+
+fn explorer_base_url_from_chain_id(chain_id: &str) -> Option<&'static str> {
+    match chain_id {
+        "1" => Some(ExplorerUrl::MAINNET_EXPLORER),
+        "T" => Some(ExplorerUrl::TESTNET_EXPLORER),
+        "D" => Some(ExplorerUrl::DEVNET_EXPLORER),
+        _ => None,
+    }
+}

--- a/framework/snippets/src/interactor/explorer_url.rs
+++ b/framework/snippets/src/interactor/explorer_url.rs
@@ -36,3 +36,54 @@ fn explorer_base_url_from_chain_id(chain_id: &str) -> Option<&'static str> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_chain_id_known() {
+        assert!(ExplorerUrl::from_chain_id("1").is_some());
+        assert!(ExplorerUrl::from_chain_id("T").is_some());
+        assert!(ExplorerUrl::from_chain_id("D").is_some());
+    }
+
+    #[test]
+    fn test_from_chain_id_unknown() {
+        assert!(ExplorerUrl::from_chain_id("").is_none());
+        assert!(ExplorerUrl::from_chain_id("X").is_none());
+    }
+
+    #[test]
+    fn test_tx_url() {
+        let ex = ExplorerUrl::from_chain_id("1").unwrap();
+        assert_eq!(
+            ex.tx_url("abc123"),
+            "https://explorer.multiversx.com/transactions/abc123"
+        );
+
+        let ex = ExplorerUrl::from_chain_id("T").unwrap();
+        assert_eq!(
+            ex.tx_url("abc123"),
+            "https://testnet-explorer.multiversx.com/transactions/abc123"
+        );
+
+        let ex = ExplorerUrl::from_chain_id("D").unwrap();
+        assert_eq!(
+            ex.tx_url("abc123"),
+            "https://devnet-explorer.multiversx.com/transactions/abc123"
+        );
+    }
+
+    #[test]
+    fn test_address_url() {
+        let ex = ExplorerUrl::from_chain_id("1").unwrap();
+        let addr = Bech32Address::from_bech32_string(
+            "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th".to_string(),
+        );
+        assert_eq!(
+            ex.address_url(&addr),
+            "https://explorer.multiversx.com/accounts/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        );
+    }
+}

--- a/framework/snippets/src/interactor/interactor_base.rs
+++ b/framework/snippets/src/interactor/interactor_base.rs
@@ -6,6 +6,8 @@ use multiversx_sc_scenario::{
     multiversx_sc::types::Address,
 };
 use multiversx_sdk::gateway::{GatewayAsyncService, NetworkConfigRequest, SetStateAccount};
+
+use super::ExplorerUrl;
 use std::{
     collections::HashMap,
     fs::File,
@@ -34,6 +36,7 @@ where
     pub post_runners: ScenarioRunnerList,
 
     pub current_dir: PathBuf,
+    pub explorer_url: Option<ExplorerUrl>,
 }
 
 impl<GatewayProxy> InteractorBase<GatewayProxy>
@@ -48,6 +51,7 @@ where
             .await
             .expect("could not get network config");
         let gas_price = network_config.min_gas_price;
+        let explorer_url = ExplorerUrl::from_chain_id(&network_config.chain_id);
         Self {
             proxy,
             use_chain_simulator: false,
@@ -58,6 +62,7 @@ where
             post_runners: ScenarioRunnerList::empty(),
             current_dir: PathBuf::default(),
             gas_price,
+            explorer_url,
         }
     }
 

--- a/framework/snippets/src/interactor/interactor_scenario/interactor_sc_call.rs
+++ b/framework/snippets/src/interactor/interactor_scenario/interactor_sc_call.rs
@@ -78,8 +78,12 @@ where
 
         match tx_hash {
             Ok(tx_hash) => {
-                println!("sc call tx hash: {tx_hash}");
                 log::info!("sc call tx hash: {tx_hash}");
+                if let Some(ex) = &self.explorer_url {
+                    println!("sc call: {}", ex.tx_url(&tx_hash));
+                } else {
+                    println!("sc call tx hash: {tx_hash}");
+                }
                 tx_hash
             }
             Err(err) => {

--- a/framework/snippets/src/interactor/interactor_scenario/interactor_sc_deploy.rs
+++ b/framework/snippets/src/interactor/interactor_scenario/interactor_sc_deploy.rs
@@ -55,8 +55,12 @@ where
 
         match tx_hash_result {
             Ok(tx_hash) => {
-                println!("sc deploy tx hash: {tx_hash}");
                 log::info!("sc deploy tx hash: {tx_hash}");
+                if let Some(ex) = &self.explorer_url {
+                    println!("sc deploy: {}", ex.tx_url(&tx_hash));
+                } else {
+                    println!("sc deploy tx hash: {tx_hash}");
+                }
                 tx_hash
             }
             Err(err) => {
@@ -97,16 +101,20 @@ where
         let nonce = tx.nonce;
         sc_deploy_step.save_response(network_response::parse_tx_response(tx, return_code));
 
-        let deploy_address = sc_deploy_step
+        let new_address = sc_deploy_step
             .response()
             .new_deployed_address
             .clone()
             .unwrap();
-        let deploy_address_bech32 = Bech32Address::encode_address(self.get_hrp(), deploy_address);
+        let new_address_bech32 = Bech32Address::encode_address(self.get_hrp(), new_address);
 
-        let set_state_step = SetStateStep::new().new_address(addr, nonce, &deploy_address_bech32);
+        let set_state_step = SetStateStep::new().new_address(addr, nonce, &new_address_bech32);
 
-        println!("deploy address: {deploy_address_bech32}");
+        if let Some(ex) = &self.explorer_url {
+            println!("new contract: {}", ex.address_url(&new_address_bech32));
+        } else {
+            println!("new contract address: {new_address_bech32}");
+        }
         self.pre_runners.run_set_state_step(&set_state_step);
         self.post_runners.run_set_state_step(&set_state_step);
 


### PR DESCRIPTION
## Pull request overview

This PR enhances the developer UX of the snippets interactor and the `sc-meta` tx CLI by printing MultiversX Explorer links (transaction + newly deployed contract) when the network chain ID is recognized.

**Changes:**
- Introduces `ExplorerUrl` helper for generating explorer links based on chain ID.
- Updates interactor deploy/call flows to print explorer transaction/contract URLs when available.
- Updates `sc-meta tx` CLI deploy/broadcast output to print explorer URLs, 
- Fixed a doc comment in `TxFromSpecified`.
