### PR TITLE
template replacement fix - snippets & interactor paths

### DIFF
--- a/.github/workflows/sc-meta-ci.yml
+++ b/.github/workflows/sc-meta-ci.yml
@@ -108,3 +108,19 @@ jobs:
 
       - name: Run repro build docker test
         run: cargo test -p multiversx-sc-meta --features repro-build-test --test repro_build_test -- repro_build_docker --exact --nocapture
+
+  install_debugger_test:
+    name: Install debugger test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.87
+
+      - name: Run install debugger test
+        run: cargo test -p multiversx-sc-meta --features install-debugger-test --test install_debugger_test -- test_install_debugger --exact --nocapture

--- a/contracts/examples/adder/mxsc-template.toml
+++ b/contracts/examples/adder/mxsc-template.toml
@@ -6,6 +6,10 @@ rename_pairs = [
         "blockchain.set_current_dir_from_workspace(\"contracts/examples/adder\");",
         "// blockchain.set_current_dir_from_workspace(\"relative path to your workspace, if applicable\");",
     ],
+    [
+        "interactor.set_current_dir_from_workspace(\"contracts/examples/adder/interactor\");",
+        "// interactor.set_current_dir_from_workspace(\"relative path to your workspace, if applicable\");",
+    ],
 ]
 files_include = [
     "meta",
@@ -22,6 +26,6 @@ files_include = [
     "interactor/.gitignore",
     "interactor/src",
     "interactor/tests",
-    "snippets",
+    "snippets/adder.snippets.sh",
 ]
 has_interactor = true

--- a/framework/meta/Cargo.toml
+++ b/framework/meta/Cargo.toml
@@ -25,6 +25,7 @@ template-test-current = []
 template-test-released = []
 chain-simulator-tests = []
 repro-build-test = []
+install-debugger-test = []
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/framework/meta/src/cmd/template/template_adjuster.rs
+++ b/framework/meta/src/cmd/template/template_adjuster.rs
@@ -7,8 +7,7 @@ use multiversx_sc_meta_lib::cargo_toml::CargoTomlContents;
 use ruplacer::Query;
 use toml::value::Table;
 
-const TEST_DIRECTORY_NAME: &str = "tests";
-const INTERACT_DIRECTORY_NAME: &str = "interact";
+const SNIPPETS_DIRECTORY_NAME: &str = "snippets";
 const CARGO_TOML: &str = "Cargo.toml";
 const DEFAULT_AUTHOR: &str = "you";
 
@@ -93,47 +92,51 @@ impl TemplateAdjuster {
     }
 
     pub fn rename_template_to(&self) {
-        self.rename_trait_to();
-        self.rename_in_cargo_toml();
-        self.rename_in_tests();
-        self.rename_in_interactor();
+        self.rename_in_files();
         self.rename_solution_files();
     }
 
-    fn rename_trait_to(&self) {
+    fn rename_in_files(&self) {
+        let new_snake = self.target.new_name.to_case(Case::Snake);
+        let old_snake = self.metadata.name.to_case(Case::Snake);
         let new_trait = self.target.new_name.to_case(Case::UpperCamel);
         let old_trait = &self.metadata.contract_trait;
-        let new_name = self.target.new_name.to_case(Case::Snake);
-        let old_name = self.metadata.name.to_case(Case::Snake);
-        let new_package = format!("{new_name}::");
-        let old_package = format!("{old_name}::");
-        let new_proxy_mod = format!("{new_name}_proxy");
-        let old_proxy_mod = format!("{old_name}_proxy");
+        let new_src_file = rs_file_name(&new_snake);
+        let old_wasm = wasm_file_name(&self.metadata.name);
+        let new_wasm = wasm_file_name(&self.target.new_name);
+        let old_mxsc = mxsc_file_name(&self.metadata.name);
+        let new_mxsc = mxsc_file_name(&self.target.new_name);
 
-        replace_in_files(
-            &self.target.contract_dir(),
-            "*rs",
-            &[
-                Query::simple(old_trait, &new_trait),
-                Query::simple(&old_package, &new_package),
-                Query::simple(&old_proxy_mod, &new_proxy_mod),
-            ][..],
-        );
+        // All .rs replacements in a single pass from the contract root.
+        // Queries that only apply to specific subdirectories (tests, interactor) are
+        // harmless no-ops in other .rs files because their patterns are specific enough.
+        // rename_pairs must come first: later queries (e.g. as_path) can corrupt their patterns.
+        let mut rs_queries = Vec::<Query>::new();
+        for (old, new) in &self.metadata.rename_pairs {
+            rs_queries.push(Query::simple(old, new));
+        }
+        rs_queries.extend([
+            Query::simple(old_trait, &new_trait),
+            Query::simple(&format!("{old_snake}::"), &format!("{new_snake}::")),
+            Query::simple(&format!("{old_snake}_proxy"), &format!("{new_snake}_proxy")),
+            Query::simple(
+                &as_path(&self.metadata.name),
+                &as_path(&self.target.new_name),
+            ),
+            Query::simple(&scenario_path(&old_snake), &scenario_path(&new_snake)),
+            Query::simple(&old_wasm, &new_wasm),
+            Query::simple(&old_mxsc, &new_mxsc),
+        ]);
+        replace_in_files(&self.target.contract_dir(), "*rs", &rs_queries);
 
         replace_in_files(
             &self.target.contract_dir(),
             "*sc-config.toml",
-            &[Query::simple(&old_proxy_mod, &new_proxy_mod)][..],
+            &[Query::simple(
+                &format!("{old_snake}_proxy"),
+                &format!("{new_snake}_proxy"),
+            )],
         );
-    }
-
-    fn rename_in_cargo_toml(&self) {
-        let old_path = self.metadata.src_file.clone();
-        let new_path = rs_file_name(&self.target.new_name.to_case(Case::Snake));
-        let old_meta = format!("{}-meta", self.metadata.name);
-        let new_meta = format!("{}-meta", &self.target.new_name);
-        let old_wasm = format!("{}-wasm", self.metadata.name);
-        let new_wasm = format!("{}-wasm", &self.target.new_name);
 
         replace_in_files(
             &self.target.contract_dir(),
@@ -143,77 +146,41 @@ impl TemplateAdjuster {
                     &package_name_expr(&self.metadata.name),
                     &package_name_expr(&self.target.new_name),
                 ),
-                Query::simple(&old_path, &new_path),
-                Query::simple(&package_name_expr(&old_meta), &package_name_expr(&new_meta)),
+                Query::simple(&self.metadata.src_file, &new_src_file),
+                Query::simple(
+                    &package_name_expr(&format!("{}-meta", self.metadata.name)),
+                    &package_name_expr(&format!("{}-meta", self.target.new_name)),
+                ),
                 Query::simple(
                     &dependency_decl_expr(&self.metadata.name),
                     &dependency_decl_expr(&self.target.new_name),
                 ),
-                Query::simple(&package_name_expr(&old_wasm), &package_name_expr(&new_wasm)),
-            ][..],
+                Query::simple(
+                    &package_name_expr(&format!("{}-wasm", self.metadata.name)),
+                    &package_name_expr(&format!("{}-wasm", self.target.new_name)),
+                ),
+            ],
         );
-    }
 
-    fn rename_in_tests(&self) {
-        let new_name = self.target.new_name.to_case(Case::Snake);
-        let old_name = self.metadata.name.to_case(Case::Snake);
-
-        let mut queries = Vec::<Query>::new();
-        for (old, new) in self.metadata.rename_pairs.iter() {
-            queries.push(Query::simple(old, new))
-        }
-
-        let new_path = as_path(&self.target.new_name);
-        let old_path = as_path(&self.metadata.name);
-        queries.push(Query::simple(&old_path, &new_path));
-
-        let new_scenarios = scenario_path(&new_name);
-        let old_scenarios = scenario_path(&old_name);
-        queries.push(Query::simple(&old_scenarios, &new_scenarios));
-
-        let old_wasm = wasm_file_name(&self.metadata.name);
-        let new_wasm = wasm_file_name(&self.target.new_name);
-
-        let old_mxsc = mxsc_file_name(&self.metadata.name);
-        let new_mxsc = mxsc_file_name(&self.target.new_name);
-
-        self.rename_in_scenarios(&old_wasm, &new_wasm);
-        self.rename_in_scenarios(&old_mxsc, &new_mxsc);
-
-        queries.push(Query::simple(&old_wasm, &new_wasm));
-        queries.push(Query::simple(&old_mxsc, &new_mxsc));
-
-        replace_in_files(
-            &self.target.contract_dir().join(TEST_DIRECTORY_NAME),
-            "*.rs",
-            &queries,
-        );
-    }
-
-    fn rename_in_scenarios(&self, old: &str, new: &str) {
+        let output_path_queries = &[
+            Query::simple(&old_wasm, &new_wasm),
+            Query::simple(&old_mxsc, &new_mxsc),
+        ];
         replace_in_files(
             &self.target.contract_dir(),
             "*.scen.json",
-            &[Query::simple(old, new)][..],
+            output_path_queries,
         );
-
         replace_in_files(
             &self.target.contract_dir(),
             "*.steps.json",
-            &[Query::simple(old, new)][..],
+            output_path_queries,
         );
-    }
-
-    fn rename_in_interactor(&self) {
-        let old_mxsc = mxsc_file_name(&self.metadata.name);
-        let new_mxsc = mxsc_file_name(&self.target.new_name);
-
-        let queries = vec![Query::simple(&old_mxsc, &new_mxsc)];
 
         replace_in_files(
-            &self.target.contract_dir().join(INTERACT_DIRECTORY_NAME),
-            "*.rs",
-            &queries,
+            &self.target.contract_dir().join(SNIPPETS_DIRECTORY_NAME),
+            "*.sh",
+            output_path_queries,
         );
     }
 

--- a/framework/meta/tests/install_debugger_test.rs
+++ b/framework/meta/tests/install_debugger_test.rs
@@ -4,6 +4,7 @@ use multiversx_sc_meta_lib::tools::find_current_workspace;
 const INSTALL_DEBUGGER_TEMP_DIR_NAME: &str = "install-debugger-test";
 
 #[tokio::test]
+#[cfg_attr(not(feature = "install-debugger-test"), ignore)]
 async fn test_install_debugger() {
     let workspace_path = find_current_workspace().unwrap();
     let target_path = workspace_path.join(INSTALL_DEBUGGER_TEMP_DIR_NAME);

--- a/tools/releases-explained/explained-v0.66.0.md
+++ b/tools/releases-explained/explained-v0.66.0.md
@@ -78,11 +78,11 @@ Key capabilities:
 
 - **Docker-based local build**: contracts are compiled inside a Docker container with a fixed toolchain, ensuring the output Wasm is identical regardless of the host machine.
 - sc-meta reproducible-build download with an --overwrite flag for refreshing previously downloaded artifacts.
-- sc-meta reproducible-build publish and sc-meta reproducible-build publish with polling and a configurable maximum-attempt limit, for interacting with a contract registry.
+- sc-meta reproducible-build publish and sc-meta reproducible-build unpublish with polling and a configurable maximum-attempt limit, for interacting with a contract registry.
 - Source pack/unpack (zip): the source tree can be packed into a zip for distribution and unpacked for verification, with full test coverage.
 - artifacts.json generation and code-hash verification: after a build, a manifest of output files and their hashes is produced. A subsequent verification step compares the deployed code hash against this manifest.
-- sc-meta reproducible-build publish init-config: generates a project-level configuration TOML that records the Docker image and other settings used for the reproducible build.
-- sc-meta reproducible-build publish release-notes CLI: generates release notes from the build artifacts.
+- sc-meta reproducible-build init-config: generates a project-level configuration TOML that records the Docker image and other settings used for the reproducible build.
+- sc-meta reproducible-build release-notes CLI: generates release notes from the build artifacts.
 - Integration test and CI support: the tooling includes integration tests and hooks for running reproducible-build verification in CI pipelines.
 
 

--- a/tools/releases-explained/explained-v0.66.0.md
+++ b/tools/releases-explained/explained-v0.66.0.md
@@ -19,70 +19,70 @@ This document walks through each area in turn.
 
 ### Memory and thread safety for managed types
 
-Perhaps the most consequential correctness fix in this release is the introduction of proper `Drop` implementations for managed types.
+Perhaps the most consequential correctness fix in this release is the introduction of proper Drop implementations for managed types.
 
-Previously, managed types such as `ManagedBuffer`, `BigInt`, `BigFloat`, `ManagedVec`, and `ManagedMap` did not call their VM-side destructor when dropped in Rust. This is only relevant in `StaticApi` contexts — that is, in tests, interactors, and Rust services — where the VM heap is managed by the Rust process itself. In those contexts, failing to call the destructor caused memory leaks and, in some edge cases, double-drop bugs. Both issues are now resolved: each of these types calls the appropriate VM hook when its Rust value is dropped.
+Previously, managed types such as ManagedBuffer, BigInt, BigFloat, ManagedVec, and ManagedMap did not call their VM-side destructor when dropped in Rust. This is only relevant in StaticApi contexts — that is, in tests, interactors, and Rust services — where the VM heap is managed by the Rust process itself. In those contexts, failing to call the destructor caused memory leaks and, in some edge cases, double-drop bugs. Both issues are now resolved: each of these types calls the appropriate VM hook when its Rust value is dropped.
 
-Alongside the destructor fix, the `ManagedVecItem` derive macro was updated to generate the `requires_drop` flag correctly, a slice out-of-bounds bug in `ManagedVec` was fixed, and a bug in `MultiValueEncoded::to_arg_buffer` was corrected. Memory benchmarks were added to track managed type allocations over time.
+Alongside the destructor fix, the ManagedVecItem derive macro was updated to generate the requires_drop flag correctly, a slice out-of-bounds bug in ManagedVec was fixed, and a bug in MultiValueEncoded::to_arg_buffer was corrected. Memory benchmarks were added to track managed type allocations over time.
 
-On the thread-safety side, `DebugHandle` and `StaticApiHandle` are now explicitly `!Send`, and all managed types implement `!Send + !Sync`. Tests enforce this at compile time. Managed types were never safe to share across threads, but the marker traits now make the compiler enforce it.
+On the thread-safety side, DebugHandle and StaticApiHandle are now explicitly !Send, and all managed types implement !Send + !Sync. Tests enforce this at compile time. Managed types were never safe to share across threads, but the marker traits now make the compiler enforce it.
 
 
 ### Mathematical library additions
 
 v0.66.0 adds a substantial set of mathematical utilities to the base framework.
 
-`BigUint` gains:
-- `nth_root`: integer nth-root computation.
-- `SaturatingSub` and `SaturatingSubAssign`: subtraction that saturates at zero rather than panicking on underflow.
-- `FromStr` / `parse()`: construct a `BigUint` from a decimal string, implemented via the standard `FromStr` trait.
+BigUint gains:
+- nth_root: integer nth-root computation.
+- SaturatingSub and SaturatingSubAssign: subtraction that saturates at zero rather than panicking on underflow.
+- FromStr / parse(): construct a BigUint from a decimal string, implemented via the standard FromStr trait.
 
 Two new standalone functions are introduced:
-- `linear_interpolation`: computes a linearly interpolated value between two endpoints.
-- `weighted_average`: computes a weighted average of a set of values.
+- linear_interpolation: computes a linearly interpolated value between two endpoints.
+- weighted_average: computes a weighted average of a set of values.
 
-`ManagedDecimal` receives the most additions of any single type:
-- `exp_approx`: an exponential approximation function.
-- `compounded_interest` and `compounded_interest_factor`: methods for compound-interest calculations.
-- `mul` and `div` with half-up rounding mode, complementing the existing truncating variants.
-- `nth_root`: nth-root support, matching `BigUint`.
-- Fixes to `into_raw_units` and `as_raw_units` conversions that previously produced incorrect results in some cases.
+ManagedDecimal receives the most additions of any single type:
+- exp_approx: an exponential approximation function.
+- compounded_interest and compounded_interest_factor: methods for compound-interest calculations.
+- mul and div with half-up rounding mode, complementing the existing truncating variants.
+- nth_root: nth-root support, matching BigUint.
+- Fixes to into_raw_units and as_raw_units conversions that previously produced incorrect results in some cases.
 - Backwards-compatibility fixes to ensure existing code continues to work after the other changes.
 
 
 ### sc-meta: transaction CLI (sc-meta tx)
 
-A new top-level command group, `sc-meta tx`, has been added. It provides a command-line interface for composing, signing, and broadcasting transactions directly from the terminal, without writing a separate interactor or script. The command set is modelled after `mxpy`, the Python-based MultiversX CLI, with the goal of eventually offering a pure-Rust alternative. Not all mxpy features have been migrated yet; this release covers the core transaction workflows.
+A new top-level command group, sc-meta tx, has been added. It provides a command-line interface for composing, signing, and broadcasting transactions directly from the terminal, without writing a separate interactor or script. The command set is modelled after mxpy, the Python-based MultiversX CLI, with the goal of eventually offering a pure-Rust alternative. Not all mxpy features have been migrated yet; this release covers the core transaction workflows.
 
 The available subcommands are:
 
-- `sc-meta tx deploy` — deploy a contract.
-- `sc-meta tx call` — call an endpoint on a deployed contract.
-- `sc-meta tx query` — query a contract endpoint without consuming gas.
-- `sc-meta tx sign` — sign a transaction offline and write the signed payload to a file.
-- `sc-meta tx upgrade` — upgrade a deployed contract to a new code version.
+- sc-meta tx deploy — deploy a contract.
+- sc-meta tx call — call an endpoint on a deployed contract.
+- sc-meta tx query — query a contract endpoint without consuming gas.
+- sc-meta tx sign — sign a transaction offline and write the signed payload to a file.
+- sc-meta tx upgrade — upgrade a deployed contract to a new code version.
 
 Common flags across the subcommands include:
-- `--payments` / `--token-transfers` for attaching ESDT token transfers to a transaction.
-- `--wait-result` (requires `--send`) to block until the transaction result is available.
-- `--code-metadata` arguments were refactored for clarity.
+- --payments / --token-transfers for attaching ESDT token transfers to a transaction.
+- --wait-result (requires --send) to block until the transaction result is available.
+- --code-metadata arguments were refactored for clarity.
 
 After a transaction is submitted, the explorer URL for the transaction is printed to the console. The same URL is also displayed in interactor workflows and whenever a new contract is deployed.
 
 
 ### sc-meta: reproducible builds (sc-meta reproducible-build)
 
-The `sc-meta reproducible-build` command group provides tooling for building contracts in a reproducible environment and verifying that a deployed contract matches a given source tree.
+The sc-meta reproducible-build command group provides tooling for building contracts in a reproducible environment and verifying that a deployed contract matches a given source tree.
 
 Key capabilities:
 
 - **Docker-based local build**: contracts are compiled inside a Docker container with a fixed toolchain, ensuring the output Wasm is identical regardless of the host machine.
-- `sc-meta all download` with an `--overwrite` flag for refreshing previously downloaded artifacts.
-- `sc-meta all publish` and `unpublish` with polling and a configurable maximum-attempt limit, for interacting with a contract registry.
+- sc-meta reproducible-build download with an --overwrite flag for refreshing previously downloaded artifacts.
+- sc-meta reproducible-build publish and sc-meta reproducible-build publish with polling and a configurable maximum-attempt limit, for interacting with a contract registry.
 - Source pack/unpack (zip): the source tree can be packed into a zip for distribution and unpacked for verification, with full test coverage.
-- `artifacts.json` generation and code-hash verification: after a build, a manifest of output files and their hashes is produced. A subsequent verification step compares the deployed code hash against this manifest.
-- `repro-build init-config`: generates a project-level configuration TOML that records the Docker image and other settings used for the reproducible build.
-- `repro-build release-notes` CLI: generates release notes from the build artifacts.
+- artifacts.json generation and code-hash verification: after a build, a manifest of output files and their hashes is produced. A subsequent verification step compares the deployed code hash against this manifest.
+- sc-meta reproducible-build publish init-config: generates a project-level configuration TOML that records the Docker image and other settings used for the reproducible build.
+- sc-meta reproducible-build publish release-notes CLI: generates release notes from the build artifacts.
 - Integration test and CI support: the tooling includes integration tests and hooks for running reproducible-build verification in CI pipelines.
 
 
@@ -90,16 +90,16 @@ Key capabilities:
 
 Several other sc-meta commands received updates:
 
-- **Wallet**: `sc-meta wallet new` now hides the password input from the console using `rpassword`, preventing accidental password exposure. A new `sc-meta wallet test-wallet` command was added for verifying wallet files.
-- **Data CLI**: `sc-meta data` is a new subcommand for reading and manipulating contract storage, intended for scripting use cases.
-- `sc-meta new --force` flag: overwrites an existing template directory without prompting. A related `--overwrite` bugfix was also included.
-- `sc-meta install wasm32` gains a `--toolchain` flag for specifying which Rust toolchain to target.
-- `sc-meta install debugger` on Windows now has duplicate-protection and configures `rust-analyzer.debug.engine` automatically.
-- `sc-meta install all` was fixed on Windows.
-- `sc-meta all codehash` now has a fallback for contracts where the hash cannot be computed directly.
+- **Wallet**: sc-meta wallet new now hides the password input from the console using rpassword, preventing accidental password exposure. A new sc-meta wallet test-wallet command was added for verifying wallet files.
+- **Data CLI**: sc-meta data is a new subcommand for reading and manipulating contract storage, intended for scripting use cases.
+- sc-meta new --force flag: overwrites an existing template directory without prompting. A related --overwrite bugfix was also included.
+- sc-meta install wasm32 gains a --toolchain flag for specifying which Rust toolchain to target.
+- sc-meta install debugger on Windows now has duplicate-protection and configures rust-analyzer.debug.engine automatically.
+- sc-meta install all was fixed on Windows.
+- sc-meta all codehash now has a fallback for contracts where the hash cannot be computed directly.
 - Duplicate contract names are now detected and reported as an error.
-- `sc-meta rust version` is now displayed in full.
-- The `CARGO_NET_GIT_FETCH_WITH_CLI` environment variable is now propagated through contract builds, which is required in some corporate network environments.
+- sc-meta rust version is now displayed in full.
+- The CARGO_NET_GIT_FETCH_WITH_CLI environment variable is now propagated through contract builds, which is required in some corporate network environments.
 
 
 ### Rust VM gas schedule updates
@@ -107,22 +107,22 @@ Several other sc-meta commands received updates:
 The Rust VM received gas schedule updates for gas schedule v9 and above. Specific changes include:
 
 - Fixed gas accounting for type conversions and additional VM hooks.
-- Gas accounting for `ManagedMap` operations was added.
+- Gas accounting for ManagedMap operations was added.
 - An overflow check was added to the multiply-gas helper, preventing silent miscalculations.
-- `wasmer-prod` received a fix for a missing breakpoint after an early exit or out-of-gas condition, which could previously cause incorrect execution flow.
+- wasmer-prod received a fix for a missing breakpoint after an early exit or out-of-gas condition, which could previously cause incorrect execution flow.
 
 
 ### Chain core additions
 
-The `multiversx-chain-core` crate received several additions:
+The multiversx-chain-core crate received several additions:
 
 - A standard code hash function is now part of chain core, with a corresponding VM hook for reading a contract's code hash on-chain.
 - Basic crypto functions were consolidated into chain core, centralizing what was previously scattered across crates.
 - Deploy address computation logic was centralized in chain core.
 
-`Bech32Address` received targeted improvements:
-- A `try_from_bech32_string` constructor that returns an explicit error rather than panicking on invalid input.
-- A `FromStr` implementation, making `Bech32Address` parseable via the standard `str::parse()` mechanism.
+Bech32Address received targeted improvements:
+- A try_from_bech32_string constructor that returns an explicit error rather than panicking on invalid input.
+- A FromStr implementation, making Bech32Address parseable via the standard str::parse() mechanism.
 - A clearer error message when an empty string is passed as input.
 
 
@@ -132,12 +132,12 @@ The SDK was refactored and extended:
 
 - Interactor gas price support: interactors can now specify a gas price for transactions, rather than relying solely on the default.
 - REST API types and naming were updated to match the Go SDK implementation, improving consistency for developers working across both SDKs.
-- `Wallet::from_pem_file` and related `Wallet` methods now accept any `AsRef<Path>` argument instead of a concrete `&Path`, making them easier to use with `String`, `PathBuf`, and other path types.
+- Wallet::from_pem_file and related Wallet methods now accept any AsRef<Path> argument instead of a concrete &Path, making them easier to use with String, PathBuf, and other path types.
 
 
 ### ManagedByteArray display
 
-`ManagedByteArray` now implements `SCDisplay` and `SCBinary`, allowing fixed-size byte arrays to be printed in display and binary format. This is useful for logging raw byte sequences in contract output and in tests.
+ManagedByteArray now implements SCDisplay and SCBinary, allowing fixed-size byte arrays to be printed in display and binary format. This is useful for logging raw byte sequences in contract output and in tests.
 
 
 ### Dependency upgrades


### PR DESCRIPTION
## Pull request overview

This PR updates the `sc-meta new` template-adjustment logic to correctly rename/replace references across interactor/snippets paths, and adds CI coverage for the debugger installer test.

**Changes:**
- Consolidate template rename/replace logic into a single `.rs` pass from the contract root and add `.sh` replacements under `snippets/`.
- Gate the `install_debugger_test` behind a Cargo feature and add a dedicated GitHub Actions job to run it.

