### PR TITLE
wasm build fix for rust 1.96 + CI update

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,17 +20,17 @@ jobs:
       runs-on: ubuntu-latest
 
   rust-tests-max:
-    name: Rust Tests (rustc 1.92)
+    name: Rust Tests (rustc 1.96)
     uses: multiversx/mx-sc-actions/.github/workflows/rust-tests.yml@v6.0.1
     with:
-      rust-toolchain: 1.92
+      rust-toolchain: 1.96
       runs-on: ubuntu-latest
 
   setup:
     name: Setup Environment
     uses: multiversx/mx-sc-actions/.github/workflows/setup.yml@v6.0.1
     with:
-      rust-toolchain: 1.87
+      rust-toolchain: 1.96
       runs-on: ubuntu-latest
       rust-target: wasm32v1-none
       path-to-sc-meta: framework/meta
@@ -42,7 +42,7 @@ jobs:
     needs: setup
     uses: multiversx/mx-sc-actions/.github/workflows/build-contracts.yml@v6.0.1
     with:
-      rust-toolchain: 1.87
+      rust-toolchain: 1.96
       runs-on: ubuntu-latest
       rust-target: wasm32v1-none
 
@@ -51,7 +51,7 @@ jobs:
     needs: build-contracts
     uses: multiversx/mx-sc-actions/.github/workflows/wasm-tests.yml@v6.0.1
     with:
-      rust-toolchain: 1.87
+      rust-toolchain: 1.96
       runs-on: ubuntu-latest
 
   generate-report:
@@ -59,7 +59,7 @@ jobs:
     needs: build-contracts
     uses: multiversx/mx-sc-actions/.github/workflows/report.yml@v6.0.1
     with:
-      rust-toolchain: 1.87
+      rust-toolchain: 1.96
       runs-on: ubuntu-latest
 
   test-coverage:
@@ -68,7 +68,7 @@ jobs:
     needs: setup
     uses: multiversx/mx-sc-actions/.github/workflows/coverage.yml@v6.0.1
     with:
-      rust-toolchain: 1.87
+      rust-toolchain: 1.96
       runs-on: ubuntu-latest
       coverage-args: "--ignore-filename-regex='meta/src' --ignore-filename-regex='wasm-adapter' --ignore-filename-regex='benchmarks/' --ignore-filename-regex='tests/' --output ./coverage.md"
 
@@ -77,7 +77,7 @@ jobs:
     needs: setup
     uses: multiversx/mx-sc-actions/.github/workflows/proxy-compare.yml@v6.0.1
     with:
-      rust-toolchain: 1.87
+      rust-toolchain: 1.96
       runs-on: ubuntu-latest
 
   clippy-check:
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: 1.96
           components: clippy
       - uses: giraffate/clippy-action@v1
         env:

--- a/.github/workflows/gas-test.yml
+++ b/.github/workflows/gas-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: ["1.92", "1.85"]
+        toolchain: ["1.96", "1.85"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/interactor-tests.yml
+++ b/.github/workflows/interactor-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: 1.96
 
       - name: Install sc-meta
         run: cargo install --path framework/meta --locked

--- a/.github/workflows/lldb-formatter-tests.yml
+++ b/.github/workflows/lldb-formatter-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.95
+          toolchain: 1.96
 
       - name: Download vscode-lldb
         uses: robinraju/release-downloader@v1

--- a/.github/workflows/lldb-formatter-tests.yml
+++ b/.github/workflows/lldb-formatter-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.96
+          toolchain: 1.95
 
       - name: Download vscode-lldb
         uses: robinraju/release-downloader@v1

--- a/.github/workflows/plotter-test.yml
+++ b/.github/workflows/plotter-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: 1.96
           target: wasm32-unknown-unknown
 
       - name: Prerequisites

--- a/.github/workflows/sc-meta-ci.yml
+++ b/.github/workflows/sc-meta-ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: 1.96
           target: wasm32v1-none
 
       - name: Install prerequisites
@@ -49,7 +49,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: 1.96
           target: wasm32-unknown-unknown
 
       - name: Install prerequisites
@@ -77,7 +77,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: 1.96
           target: wasm32v1-none
 
       - name: Install prerequisites
@@ -99,7 +99,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: 1.96
           target: wasm32v1-none
 
       - name: Install prerequisites
@@ -120,7 +120,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: 1.96
 
       - name: Run install debugger test
         run: cargo test -p multiversx-sc-meta --features install-debugger-test --test install_debugger_test -- test_install_debugger --exact --nocapture

--- a/.github/workflows/sc-meta-ci.yml
+++ b/.github/workflows/sc-meta-ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.96
+          toolchain: 1.95
           target: wasm32-unknown-unknown
 
       - name: Install prerequisites
@@ -77,7 +77,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.96
+          toolchain: 1.95
           target: wasm32v1-none
 
       - name: Install prerequisites
@@ -99,7 +99,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.96
+          toolchain: 1.95
           target: wasm32v1-none
 
       - name: Install prerequisites

--- a/.github/workflows/vm-bls-test.yml
+++ b/.github/workflows/vm-bls-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: 1.96
 
       - name: Rust VM tests, including BLS
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.96
           target: wasm32-unknown-unknown
           rustflags: ""
 

--- a/framework/wasm-adapter/src/api/blockchain_api_node.rs
+++ b/framework/wasm-adapter/src/api/blockchain_api_node.rs
@@ -9,6 +9,7 @@ use multiversx_sc::{
     types::heap::{Address, Box, H256},
 };
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     // address utils
     fn getSCAddress(resultOffset: *mut u8);

--- a/framework/wasm-adapter/src/api/call_value_api_node.rs
+++ b/framework/wasm-adapter/src/api/call_value_api_node.rs
@@ -1,6 +1,7 @@
 use super::VmApiImpl;
 use multiversx_sc::api::{CallValueApi, CallValueApiImpl};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn checkNoPayment();
 

--- a/framework/wasm-adapter/src/api/crypto_api_node.rs
+++ b/framework/wasm-adapter/src/api/crypto_api_node.rs
@@ -4,6 +4,7 @@ use multiversx_sc::{
     types::MessageHashType,
 };
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn managedSha256(inputHandle: i32, outputHandle: i32) -> i32;
 

--- a/framework/wasm-adapter/src/api/endpoint_arg_api_node.rs
+++ b/framework/wasm-adapter/src/api/endpoint_arg_api_node.rs
@@ -1,6 +1,7 @@
 use crate::api::VmApiImpl;
 use multiversx_sc::api::{EndpointArgumentApi, EndpointArgumentApiImpl};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn getNumArguments() -> i32;
     fn getArgumentLength(id: i32) -> i32;

--- a/framework/wasm-adapter/src/api/endpoint_finish_api_node.rs
+++ b/framework/wasm-adapter/src/api/endpoint_finish_api_node.rs
@@ -1,6 +1,7 @@
 use super::VmApiImpl;
 use multiversx_sc::api::{EndpointFinishApi, EndpointFinishApiImpl};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn finish(dataOffset: *const u8, length: i32);
 

--- a/framework/wasm-adapter/src/api/error_api_node.rs
+++ b/framework/wasm-adapter/src/api/error_api_node.rs
@@ -1,6 +1,7 @@
 use crate::{api::VmApiImpl, error_hook};
 use multiversx_sc::api::{ErrorApi, ErrorApiImpl};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn managedSignalError(messageHandle: i32) -> !;
 }

--- a/framework/wasm-adapter/src/api/log_api_node.rs
+++ b/framework/wasm-adapter/src/api/log_api_node.rs
@@ -1,6 +1,7 @@
 use super::VmApiImpl;
 use multiversx_sc::api::{LogApi, LogApiImpl};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn managedWriteLog(topicsHandle: i32, dataHandle: i32);
 }

--- a/framework/wasm-adapter/src/api/managed_types/big_float_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/big_float_api_node.rs
@@ -2,6 +2,7 @@ use core::cmp::Ordering;
 
 use multiversx_sc::api::{BigFloatApiImpl, Sign};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn bigFloatNewFromParts(integralPart: i32, fractionalPart: i32, exponent: i32) -> i32;
     fn bigFloatNewFromFrac(numerator: i64, denominator: i64) -> i32;

--- a/framework/wasm-adapter/src/api/managed_types/big_int_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/big_int_api_node.rs
@@ -2,6 +2,7 @@ use core::cmp::Ordering;
 
 use multiversx_sc::api::{BigIntApiImpl, Sign};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn bigIntNew(value: i64) -> i32;
 

--- a/framework/wasm-adapter/src/api/managed_types/elliptic_curve_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/elliptic_curve_api_node.rs
@@ -1,5 +1,6 @@
 use multiversx_sc::{api::EllipticCurveApiImpl, types::heap::BoxedBytes};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn createEC(dataOffset: i32, dataLength: i32) -> i32;
 

--- a/framework/wasm-adapter/src/api/managed_types/managed_buffer_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/managed_buffer_api_node.rs
@@ -4,6 +4,7 @@ use multiversx_sc::{
     types::heap::BoxedBytes,
 };
 
+#[link(wasm_import_module = "env")]
 #[allow(dead_code)]
 unsafe extern "C" {
     fn mBufferNew() -> i32;

--- a/framework/wasm-adapter/src/api/managed_types/managed_map_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/managed_map_api_node.rs
@@ -1,5 +1,6 @@
 use multiversx_sc::api::ManagedMapApiImpl;
 
+#[link(wasm_import_module = "env")]
 #[allow(dead_code)]
 unsafe extern "C" {
     fn managedMapNew() -> i32;

--- a/framework/wasm-adapter/src/api/managed_types/managed_type_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/managed_type_api_node.rs
@@ -1,6 +1,7 @@
 use crate::api::VmApiImpl;
 use multiversx_sc::api::{ManagedTypeApi, ManagedTypeApiImpl};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn mBufferToBigIntUnsigned(mBufferHandle: i32, bigIntHandle: i32) -> i32;
     fn mBufferToBigIntSigned(mBufferHandle: i32, bigIntHandle: i32) -> i32;

--- a/framework/wasm-adapter/src/api/send_api_node.rs
+++ b/framework/wasm-adapter/src/api/send_api_node.rs
@@ -1,6 +1,7 @@
 use crate::api::VmApiImpl;
 use multiversx_sc::api::{RawHandle, SendApi, SendApiImpl, const_handles};
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn managedTransferValueExecute(
         dstHandle: i32,

--- a/framework/wasm-adapter/src/api/storage_api_node.rs
+++ b/framework/wasm-adapter/src/api/storage_api_node.rs
@@ -3,6 +3,7 @@ use multiversx_sc::api::{
     StorageReadApi, StorageReadApiImpl, StorageWriteApi, StorageWriteApiImpl,
 };
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     // managed buffer API
     fn mBufferStorageStore(keyHandle: i32, mBufferHandle: i32) -> i32;

--- a/framework/wasm-adapter/src/error_hook.rs
+++ b/framework/wasm-adapter/src/error_hook.rs
@@ -1,3 +1,4 @@
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn signalError(messageOffset: *const u8, messageLength: i32) -> !;
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93"
+channel = "1.96"


### PR DESCRIPTION
## Pull request overview

Updates the repository to Rust 1.96 and adjusts the wasm adapter + CI so wasm imports continue to resolve correctly under the newer compiler.

**Changes:**
- Bump the repo Rust toolchain to 1.96 and update multiple CI workflows to use newer pinned toolchains.
- Add `#[link(wasm_import_module = "env")]` to wasm `extern "C"` import blocks across the wasm adapter to ensure imports bind to the intended module.
- Refresh CI matrices/job toolchains (notably gas-test and shared action workflows) to include 1.96.
