### PR TITLE
ManagedVecItem impl for time types (TimestampMillis, TimestampSeconds, DurationMillis, DurationSeconds)

### DIFF
--- a/framework/base/src/types/managed/wrapped/managed_vec_item.rs
+++ b/framework/base/src/types/managed/wrapped/managed_vec_item.rs
@@ -4,7 +4,10 @@ use generic_array::{
     GenericArray,
     typenum::{U1, U2, U4, U8},
 };
-use multiversx_chain_core::types::{EsdtLocalRole, EsdtTokenType};
+use multiversx_chain_core::types::{
+    DurationMillis, DurationSeconds, EsdtLocalRole, EsdtTokenType, TimestampMillis,
+    TimestampSeconds,
+};
 use multiversx_sc_codec::multi_types::{MultiValue2, MultiValue3};
 
 use crate::{
@@ -202,6 +205,36 @@ impl ManagedVecItem for bool {
         false
     }
 }
+
+macro_rules! impl_u64_newtype {
+    ($ty:ident, $as_u64:ident) => {
+        impl ManagedVecItem for $ty {
+            type PAYLOAD = ManagedVecItemPayloadBuffer<U8>;
+            const SKIPS_RESERIALIZATION: bool = true;
+            type Ref<'a> = Self;
+
+            unsafe fn read_from_payload(payload: &Self::PAYLOAD) -> Self {
+                $ty::new(u64::from_be_bytes(payload.buffer.into_array()))
+            }
+
+            unsafe fn borrow_from_payload<'a>(payload: &Self::PAYLOAD) -> Self::Ref<'a> {
+                $ty::new(u64::from_be_bytes(payload.buffer.into_array()))
+            }
+
+            fn save_to_payload(self, payload: &mut Self::PAYLOAD) {
+                payload.buffer = GenericArray::from_array(self.$as_u64().to_be_bytes());
+            }
+
+            fn requires_drop() -> bool {
+                false
+            }
+        }
+    };
+}
+impl_u64_newtype! {DurationMillis, as_u64_millis}
+impl_u64_newtype! {DurationSeconds, as_u64_seconds}
+impl_u64_newtype! {TimestampMillis, as_u64_millis}
+impl_u64_newtype! {TimestampSeconds, as_u64_seconds}
 
 impl<T> ManagedVecItem for Option<T>
 where

--- a/framework/derive/src/preprocessing/substitution_map.rs
+++ b/framework/derive/src/preprocessing/substitution_map.rs
@@ -21,11 +21,19 @@ impl SubstitutionsMap {
         self.trie.insert(key.into(), value.into());
     }
 
+    /// Checks whether the beginning of `tt_iter` matches any key in the substitution map.
+    ///
+    /// Consumes tokens from `tt_iter` one at a time, building up a candidate key and probing
+    /// the trie on each step. Stops as soon as there are no more trie descendants for the
+    /// current prefix (i.e. no longer key can possibly match).
+    ///
+    /// Returns the **longest** match found as `Some((length, substitution))`, where `length`
+    /// is the number of tokens consumed that form the matching key and `substitution` is the
+    /// corresponding replacement `TokenStream`. Returns `None` if no key matches.
     pub fn check_subsequence(&self, tt_iter: IntoIter) -> Option<(usize, &TokenStream)> {
-        let mut current_length: usize = 1;
         let mut result: Option<(usize, &TokenStream)> = None;
         let mut current_key = TokenStream::new();
-        for tt in tt_iter {
+        for (current_length, tt) in (1..).zip(tt_iter) {
             current_key.extend(once(tt));
             let trie_key = TrieTokenStream::new(current_key.clone());
             if let Some(sub) = self.trie.get(&trie_key) {
@@ -34,7 +42,6 @@ impl SubstitutionsMap {
             if self.trie.get_raw_descendant(&trie_key).is_none() {
                 break;
             }
-            current_length += 1;
         }
         result
     }

--- a/framework/scenario/tests/derive_managed_vec_item_struct_2_test.rs
+++ b/framework/scenario/tests/derive_managed_vec_item_struct_2_test.rs
@@ -1,6 +1,5 @@
-use multiversx_sc::types::{ManagedVecItemPayload, ManagedVecItemPayloadBuffer};
-
-multiversx_sc::derive_imports!();
+use multiversx_sc::derive_imports::*;
+use multiversx_sc::imports::*;
 
 // to test, run the following command in the crate folder:
 // cargo expand --test derive_managed_vec_item_struct_2_test > expanded.rs
@@ -16,6 +15,10 @@ pub struct Struct2 {
     pub bool_field: bool,
     pub opt_field: Option<u8>,
     pub arr: u32,
+    pub duration_millis: DurationMillis,
+    pub duration_seconds: DurationSeconds,
+    pub timestamp_millis: TimestampMillis,
+    pub timestamp_seconds: TimestampSeconds,
 }
 
 #[test]
@@ -23,7 +26,7 @@ pub struct Struct2 {
 fn struct_2_static() {
     assert_eq!(
         <Struct2 as multiversx_sc::types::ManagedVecItem>::payload_size(),
-        22
+        54
     );
     assert!(!<Struct2 as multiversx_sc::types::ManagedVecItem>::SKIPS_RESERIALIZATION);
     assert!(!<Struct2 as multiversx_sc::types::ManagedVecItem>::requires_drop());
@@ -39,17 +42,25 @@ fn struct_to_bytes_writer() {
         bool_field: true,
         opt_field: Some(5),
         arr: 0x61116222,
+        duration_millis: DurationMillis::new(10),
+        duration_seconds: DurationSeconds::new(20),
+        timestamp_millis: TimestampMillis::new(30),
+        timestamp_seconds: TimestampSeconds::new(40),
     };
 
     #[rustfmt::skip]
     let expected_payload = [
-        /* u_8  */ 0x01,
-        /* u_16 */ 0x00, 0x02,
-        /* u_32 */ 0x00, 0x00, 0x00, 0x03,
-        /* u_64 */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04,
-        /* bool */ 0x01,
-        /* opt  */ 0x01, 0x05,
-        /* arr  */ 0x61, 0x11, 0x62, 0x22,
+        /* u_8              */ 0x01,
+        /* u_16             */ 0x00, 0x02,
+        /* u_32             */ 0x00, 0x00, 0x00, 0x03,
+        /* u_64             */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04,
+        /* bool             */ 0x01,
+        /* opt              */ 0x01, 0x05,
+        /* arr              */ 0x61, 0x11, 0x62, 0x22,
+        /* duration_millis  */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a,
+        /* duration_seconds */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14,
+        /* timestamp_millis */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1e,
+        /* timestamp_secs   */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28,
     ];
 
     let mut payload = ManagedVecItemPayloadBuffer::new_buffer();
@@ -67,17 +78,25 @@ fn struct_2_from_bytes_reader() {
         bool_field: false,
         opt_field: Some(5),
         arr: 0x61116222,
+        duration_millis: DurationMillis::new(10),
+        duration_seconds: DurationSeconds::new(20),
+        timestamp_millis: TimestampMillis::new(30),
+        timestamp_seconds: TimestampSeconds::new(40),
     };
 
     #[rustfmt::skip]
     let payload = [
-        /* u_8  */ 0x01,
-        /* u_16 */ 0x00, 0x02,
-        /* u_32 */ 0x00, 0x00, 0x00, 0x03,
-        /* u_64 */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04,
-        /* bool */ 0x00,
-        /* opt  */ 0x01, 0x05,
-        /* arr  */ 0x61, 0x11, 0x62, 0x22,
+        /* u_8              */ 0x01,
+        /* u_16             */ 0x00, 0x02,
+        /* u_32             */ 0x00, 0x00, 0x00, 0x03,
+        /* u_64             */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04,
+        /* bool             */ 0x00,
+        /* opt              */ 0x01, 0x05,
+        /* arr              */ 0x61, 0x11, 0x62, 0x22,
+        /* duration_millis  */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a,
+        /* duration_seconds */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14,
+        /* timestamp_millis */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1e,
+        /* timestamp_secs   */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28,
     ];
 
     <Struct2 as multiversx_sc::types::ManagedVecItem>::temp_decode(


### PR DESCRIPTION
## Pull request overview

Adds `ManagedVecItem` support for MultiversX time newtypes so they can be stored in `ManagedVec` and participate in derive-generated payload logic, with scenario coverage updated accordingly.

**Changes:**
- Implement `ManagedVecItem` for `DurationMillis`, `DurationSeconds`, `TimestampMillis`, and `TimestampSeconds` as fixed-size 8-byte payload items.
- Extend the existing `ManagedVecItem` derive scenario test (`Struct2`) to include these time types and validate payload size/byte layout.
- Refactor `SubstitutionsMap::check_subsequence` to compute match lengths more directly and document the “longest prefix match” behavior.
