### PR TITLE
Wallet Mnemonic refactor

### DIFF
--- a/framework/meta/src/cmd/wallet_cmd.rs
+++ b/framework/meta/src/cmd/wallet_cmd.rs
@@ -3,7 +3,7 @@ use std::{
     io::{self, Read, Write},
 };
 
-use bip39::{Language, Mnemonic};
+use bip39::Language;
 use rand::Rng;
 
 use multiversx_sc::types::Address;
@@ -15,7 +15,7 @@ use multiversx_sc_snippets::{
         wallet::{Keystore, KeystoreRandomness, Wallet},
     },
 };
-use multiversx_sdk::wallet::{KeystoreError, WalletPem};
+use multiversx_sdk::wallet::{KeystoreError, Mnemonic, WalletPem};
 
 use crate::cli::cli_args_sender::get_keystore_password;
 use crate::cli::{
@@ -50,7 +50,7 @@ fn convert(convert_args: &WalletConvertArgs) {
         ("mnemonic", "pem") => match infile {
             Some(file) => {
                 mnemonic_str = fs::read_to_string(file).unwrap();
-                let wallet = Wallet::from_mnemonic_string(mnemonic_str).unwrap();
+                let wallet = Wallet::from(Mnemonic::parse(&mnemonic_str).unwrap());
                 write_resulted_pem(wallet.to_pem(hrp), outfile);
             }
             None => {
@@ -58,7 +58,7 @@ fn convert(convert_args: &WalletConvertArgs) {
                     "Insert text below. Press 'Ctrl-D' (Linux / MacOS) or 'Ctrl-Z' (Windows) when done."
                 );
                 _ = io::stdin().read_to_string(&mut mnemonic_str).unwrap();
-                let wallet = Wallet::from_mnemonic_string(mnemonic_str).unwrap();
+                let wallet = Wallet::from(Mnemonic::parse(&mnemonic_str).unwrap());
                 write_resulted_pem(wallet.to_pem(hrp), outfile);
             }
         },
@@ -168,7 +168,7 @@ fn bech32_conversion(bech32_args: &WalletBech32Args) {
 }
 
 pub fn generate_mnemonic() -> Mnemonic {
-    Mnemonic::generate_in(Language::English, 24).unwrap()
+    Mnemonic::from(bip39::Mnemonic::generate_in(Language::English, 24).unwrap())
 }
 
 struct NewWalletInfo {
@@ -179,7 +179,7 @@ struct NewWalletInfo {
 impl NewWalletInfo {
     fn generate() -> Self {
         let mnemonic = generate_mnemonic();
-        let wallet = Wallet::from_mnemonic_string(mnemonic.to_string()).unwrap();
+        let wallet = Wallet::from(mnemonic.clone());
         NewWalletInfo { mnemonic, wallet }
     }
 

--- a/framework/meta/src/cmd/wallet_cmd.rs
+++ b/framework/meta/src/cmd/wallet_cmd.rs
@@ -50,7 +50,7 @@ fn convert(convert_args: &WalletConvertArgs) {
         ("mnemonic", "pem") => match infile {
             Some(file) => {
                 mnemonic_str = fs::read_to_string(file).unwrap();
-                let wallet = Wallet::from(Mnemonic::parse(&mnemonic_str).unwrap());
+                let wallet = Wallet::try_from(Mnemonic::parse(&mnemonic_str).unwrap()).unwrap();
                 write_resulted_pem(wallet.to_pem(hrp), outfile);
             }
             None => {
@@ -58,7 +58,7 @@ fn convert(convert_args: &WalletConvertArgs) {
                     "Insert text below. Press 'Ctrl-D' (Linux / MacOS) or 'Ctrl-Z' (Windows) when done."
                 );
                 _ = io::stdin().read_to_string(&mut mnemonic_str).unwrap();
-                let wallet = Wallet::from(Mnemonic::parse(&mnemonic_str).unwrap());
+                let wallet = Wallet::try_from(Mnemonic::parse(&mnemonic_str).unwrap()).unwrap();
                 write_resulted_pem(wallet.to_pem(hrp), outfile);
             }
         },
@@ -179,7 +179,7 @@ struct NewWalletInfo {
 impl NewWalletInfo {
     fn generate() -> Self {
         let mnemonic = generate_mnemonic();
-        let wallet = Wallet::from(mnemonic.clone());
+        let wallet = Wallet::try_from(mnemonic.clone()).unwrap();
         NewWalletInfo { mnemonic, wallet }
     }
 

--- a/sdk/core/src/wallet.rs
+++ b/sdk/core/src/wallet.rs
@@ -1,6 +1,7 @@
 mod keystore;
 mod keystore_error;
 mod keystore_json;
+mod mnemonic;
 mod private_key;
 mod public_key;
 mod wallet_impl;
@@ -12,6 +13,7 @@ pub use keystore::Keystore;
 pub use keystore::KeystoreRandomness;
 pub use keystore_error::KeystoreError;
 pub use keystore_json::*;
+pub use mnemonic::Mnemonic;
 pub use private_key::{PRIVATE_KEY_LENGTH, PrivateKey, SEED_LENGTH};
 pub use public_key::{PUBLIC_KEY_LENGTH, PublicKey};
 pub use wallet_impl::Wallet;

--- a/sdk/core/src/wallet/mnemonic.rs
+++ b/sdk/core/src/wallet/mnemonic.rs
@@ -18,12 +18,12 @@ pub struct Mnemonic(bip39::Mnemonic);
 impl Mnemonic {
     /// Parses a mnemonic phrase.
     ///
-    /// Embedded newlines are stripped before parsing, so file contents can be
+    /// All whitespace sequences (spaces, tabs, `\n`, `\r\n`, etc.) are
+    /// collapsed to single spaces before parsing, so file contents can be
     /// passed directly without pre-processing.
     pub fn parse(s: &str) -> Result<Self> {
-        Ok(Mnemonic(bip39::Mnemonic::parse(
-            s.replace('\n', "").trim(),
-        )?))
+        let normalized = s.split_whitespace().collect::<Vec<_>>().join(" ");
+        Ok(Mnemonic(bip39::Mnemonic::parse(&normalized)?))
     }
 
     /// Derives a [`PrivateKey`] using the MultiversX HD path

--- a/sdk/core/src/wallet/mnemonic.rs
+++ b/sdk/core/src/wallet/mnemonic.rs
@@ -1,0 +1,90 @@
+use std::fmt;
+
+use anyhow::Result;
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha512;
+
+use super::private_key::PrivateKey;
+
+const EGLD_COIN_TYPE: u32 = 508;
+const HARDENED: u32 = 0x80000000;
+
+/// A BIP-39 mnemonic used to derive [`PrivateKey`]s via the MultiversX HD path.
+///
+/// Wraps [`bip39::Mnemonic`] and provides MultiversX-specific key derivation.
+#[derive(Clone)]
+pub struct Mnemonic(bip39::Mnemonic);
+
+impl Mnemonic {
+    /// Parses a mnemonic phrase.
+    ///
+    /// Embedded newlines are stripped before parsing, so file contents can be
+    /// passed directly without pre-processing.
+    pub fn parse(s: &str) -> Result<Self> {
+        Ok(Mnemonic(bip39::Mnemonic::parse(
+            s.replace('\n', "").trim(),
+        )?))
+    }
+
+    /// Derives a [`PrivateKey`] using the MultiversX HD path
+    /// `m/44'/508'/<account>'/0'/<address_index>'`.
+    pub fn to_private_key(&self, account: u32, address_index: u32) -> PrivateKey {
+        let seed = self.to_bip39_seed();
+        self.bip32_derive(&seed, account, address_index)
+    }
+
+    fn to_bip39_seed(&self) -> [u8; 64] {
+        self.0.to_seed_normalized("")
+    }
+
+    fn bip32_derive(&self, seed: &[u8; 64], account: u32, address_index: u32) -> PrivateKey {
+        let serialized_key_len = 32;
+        let hardened_child_padding: u8 = 0;
+
+        let mut digest =
+            Hmac::<Sha512>::new_from_slice(b"ed25519 seed").expect("HMAC can take key of any size");
+        digest.update(seed);
+        let intermediary: Vec<u8> = digest.finalize().into_bytes().into_iter().collect();
+        let mut key = intermediary[..serialized_key_len].to_vec();
+        let mut chain_code = intermediary[serialized_key_len..].to_vec();
+
+        for child_idx in [
+            44 | HARDENED,
+            EGLD_COIN_TYPE | HARDENED,
+            account | HARDENED,
+            HARDENED,
+            address_index | HARDENED,
+        ] {
+            let mut buff = [vec![hardened_child_padding], key.clone()].concat();
+            buff.push((child_idx >> 24) as u8);
+            buff.push((child_idx >> 16) as u8);
+            buff.push((child_idx >> 8) as u8);
+            buff.push(child_idx as u8);
+
+            digest =
+                Hmac::<Sha512>::new_from_slice(&chain_code).expect("HMAC can take key of any size");
+            digest.update(&buff);
+            let intermediary: Vec<u8> = digest.finalize().into_bytes().into_iter().collect();
+            key = intermediary[..serialized_key_len].to_vec();
+            chain_code = intermediary[serialized_key_len..].to_vec();
+        }
+
+        let seed_bytes: &[u8; 32] = key
+            .as_slice()
+            .try_into()
+            .expect("BIP32 derived key has unexpected length");
+        PrivateKey::from_seed_bytes(seed_bytes)
+    }
+}
+
+impl From<bip39::Mnemonic> for Mnemonic {
+    fn from(m: bip39::Mnemonic) -> Self {
+        Mnemonic(m)
+    }
+}
+
+impl fmt::Display for Mnemonic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/sdk/core/src/wallet/mnemonic.rs
+++ b/sdk/core/src/wallet/mnemonic.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha512;
 
@@ -23,12 +23,14 @@ impl Mnemonic {
     /// passed directly without pre-processing.
     pub fn parse(s: &str) -> Result<Self> {
         let normalized = s.split_whitespace().collect::<Vec<_>>().join(" ");
-        Ok(Mnemonic(bip39::Mnemonic::parse(&normalized)?))
+        Ok(Mnemonic(
+            bip39::Mnemonic::parse(&normalized).context("invalid mnemonic phrase")?,
+        ))
     }
 
     /// Derives a [`PrivateKey`] using the MultiversX HD path
     /// `m/44'/508'/<account>'/0'/<address_index>'`.
-    pub fn to_private_key(&self, account: u32, address_index: u32) -> PrivateKey {
+    pub fn to_private_key(&self, account: u32, address_index: u32) -> Result<PrivateKey> {
         let seed = self.to_bip39_seed();
         self.bip32_derive(&seed, account, address_index)
     }
@@ -37,12 +39,17 @@ impl Mnemonic {
         self.0.to_seed_normalized("")
     }
 
-    fn bip32_derive(&self, seed: &[u8; 64], account: u32, address_index: u32) -> PrivateKey {
+    fn bip32_derive(
+        &self,
+        seed: &[u8; 64],
+        account: u32,
+        address_index: u32,
+    ) -> Result<PrivateKey> {
         let serialized_key_len = 32;
         let hardened_child_padding: u8 = 0;
 
-        let mut digest =
-            Hmac::<Sha512>::new_from_slice(b"ed25519 seed").expect("HMAC can take key of any size");
+        let mut digest = Hmac::<Sha512>::new_from_slice(b"ed25519 seed")
+            .context("failed to initialise root HMAC-SHA512 digest")?;
         digest.update(seed);
         let intermediary: Vec<u8> = digest.finalize().into_bytes().into_iter().collect();
         let mut key = intermediary[..serialized_key_len].to_vec();
@@ -61,8 +68,8 @@ impl Mnemonic {
             buff.push((child_idx >> 8) as u8);
             buff.push(child_idx as u8);
 
-            digest =
-                Hmac::<Sha512>::new_from_slice(&chain_code).expect("HMAC can take key of any size");
+            digest = Hmac::<Sha512>::new_from_slice(&chain_code)
+                .context("failed to initialise child HMAC-SHA512 digest")?;
             digest.update(&buff);
             let intermediary: Vec<u8> = digest.finalize().into_bytes().into_iter().collect();
             key = intermediary[..serialized_key_len].to_vec();
@@ -72,8 +79,8 @@ impl Mnemonic {
         let seed_bytes: &[u8; 32] = key
             .as_slice()
             .try_into()
-            .expect("BIP32 derived key has unexpected length");
-        PrivateKey::from_seed_bytes(seed_bytes)
+            .context("BIP32 derived key has unexpected length")?;
+        Ok(PrivateKey::from_seed_bytes(seed_bytes))
     }
 }
 

--- a/sdk/core/src/wallet/private_key.rs
+++ b/sdk/core/src/wallet/private_key.rs
@@ -13,7 +13,7 @@ pub const PRIVATE_KEY_LENGTH: usize = 64;
 pub const SEED_LENGTH: usize = 32;
 
 #[derive(Clone, PartialEq, Eq)]
-pub struct PrivateKey(pub ed25519::Ed25519SigningKey);
+pub struct PrivateKey(pub(crate) ed25519::Ed25519SigningKey);
 
 impl PrivateKey {
     /// Constructs a [`PrivateKey`] from a 32-byte ed25519 seed.

--- a/sdk/core/src/wallet/private_key.rs
+++ b/sdk/core/src/wallet/private_key.rs
@@ -1,24 +1,16 @@
 use std::fmt::Display;
 
 use anyhow::{Result, anyhow};
-use bip39::Mnemonic;
-use hmac::{Hmac, KeyInit, Mac};
 use multiversx_chain_core::std::crypto::ed25519;
-use pbkdf2::pbkdf2;
 use serde::{
     de::{Deserialize, Deserializer},
     ser::{Serialize, Serializer},
 };
-use sha2::Sha512;
-use zeroize::Zeroize;
 
 use super::wallet_signature::WalletSignature;
 
 pub const PRIVATE_KEY_LENGTH: usize = 64;
 pub const SEED_LENGTH: usize = 32;
-
-const EGLD_COIN_TYPE: u32 = 508;
-const HARDENED: u32 = 0x80000000;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct PrivateKey(pub ed25519::Ed25519SigningKey);
@@ -97,75 +89,6 @@ impl PrivateKey {
     pub fn from_hex_str(pk: &str) -> Result<Self> {
         let bytes = hex::decode(pk)?;
         PrivateKey::from_bytes(bytes.as_slice())
-    }
-
-    fn seed_from_mnemonic(mnemonic: Mnemonic, password: &str) -> [u8; 64] {
-        let mut salt = String::with_capacity(8 + password.len());
-        salt.push_str("mnemonic");
-        salt.push_str(password);
-
-        let mut seed = [0u8; 64];
-
-        let _ = pbkdf2::<Hmac<Sha512>>(
-            mnemonic.to_string().as_bytes(),
-            salt.as_bytes(),
-            2048,
-            &mut seed,
-        );
-
-        salt.zeroize();
-
-        seed
-    }
-
-    /// Derives a [`PrivateKey`] from a BIP-39 mnemonic using the MultiversX HD path
-    /// `m/44'/508'/<account>'/0'/<address_index>'`.
-    ///
-    /// Returns an error if the internal BIP-32 key derivation produces a key of
-    /// unexpected length (should not happen in practice).
-    pub fn from_mnemonic(
-        mnemonic: Mnemonic,
-        account: u32,
-        address_index: u32,
-    ) -> Result<PrivateKey> {
-        let seed = Self::seed_from_mnemonic(mnemonic, "");
-
-        let serialized_key_len = 32;
-        let hardened_child_padding: u8 = 0;
-
-        let mut digest =
-            Hmac::<Sha512>::new_from_slice(b"ed25519 seed").expect("HMAC can take key of any size");
-        digest.update(&seed);
-        let intermediary: Vec<u8> = digest.finalize().into_bytes().into_iter().collect();
-        let mut key = intermediary[..serialized_key_len].to_vec();
-        let mut chain_code = intermediary[serialized_key_len..].to_vec();
-
-        for child_idx in [
-            44 | HARDENED,
-            EGLD_COIN_TYPE | HARDENED,
-            account | HARDENED,
-            HARDENED,
-            address_index | HARDENED,
-        ] {
-            let mut buff = [vec![hardened_child_padding], key.clone()].concat();
-            buff.push((child_idx >> 24) as u8);
-            buff.push((child_idx >> 16) as u8);
-            buff.push((child_idx >> 8) as u8);
-            buff.push(child_idx as u8);
-
-            digest =
-                Hmac::<Sha512>::new_from_slice(&chain_code).expect("HMAC can take key of any size");
-            digest.update(&buff);
-            let intermediary: Vec<u8> = digest.finalize().into_bytes().into_iter().collect();
-            key = intermediary[..serialized_key_len].to_vec();
-            chain_code = intermediary[serialized_key_len..].to_vec();
-        }
-
-        let seed: &[u8; 32] = key
-            .as_slice()
-            .try_into()
-            .map_err(|_| anyhow!("BIP32 derived key has unexpected length"))?;
-        Ok(PrivateKey::from_seed_bytes(seed))
     }
 
     /// Returns the full 64-byte keypair as `[seed (32 bytes) || public_key (32 bytes)]`.

--- a/sdk/core/src/wallet/wallet_impl.rs
+++ b/sdk/core/src/wallet/wallet_impl.rs
@@ -46,11 +46,13 @@ impl From<PrivateKey> for Wallet {
     }
 }
 
-impl From<Mnemonic> for Wallet {
+impl TryFrom<Mnemonic> for Wallet {
+    type Error = anyhow::Error;
+
     /// Derives the wallet at account 0, address index 0 from the mnemonic.
-    fn from(mnemonic: Mnemonic) -> Self {
-        let private_key = mnemonic.to_private_key(0, 0);
-        Self::new(private_key, WalletSource::Mnemonic)
+    fn try_from(mnemonic: Mnemonic) -> Result<Self> {
+        let private_key = mnemonic.to_private_key(0, 0)?;
+        Ok(Self::new(private_key, WalletSource::Mnemonic))
     }
 }
 

--- a/sdk/core/src/wallet/wallet_impl.rs
+++ b/sdk/core/src/wallet/wallet_impl.rs
@@ -2,7 +2,6 @@ use core::str;
 use std::path::Path;
 
 use anyhow::Result;
-use bip39::Mnemonic;
 use multiversx_chain_core::{
     std::{Bech32Address, Bech32Hrp, crypto},
     types::Address,
@@ -11,7 +10,7 @@ use serde_json::json;
 
 use crate::{
     data::transaction::Transaction,
-    wallet::{PrivateKey, PublicKey, WalletPem, WalletSignature, WalletSource},
+    wallet::{Mnemonic, PrivateKey, PublicKey, WalletPem, WalletSignature, WalletSource},
 };
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -47,13 +46,15 @@ impl From<PrivateKey> for Wallet {
     }
 }
 
-impl Wallet {
-    pub fn from_mnemonic_string(mnemonic_str: String) -> Result<Wallet> {
-        let mnemonic = Mnemonic::parse(mnemonic_str.replace('\n', ""))?;
-        let private_key = PrivateKey::from_mnemonic(mnemonic, 0u32, 0u32)?;
-        Ok(Self::new(private_key, WalletSource::Mnemonic))
+impl From<Mnemonic> for Wallet {
+    /// Derives the wallet at account 0, address index 0 from the mnemonic.
+    fn from(mnemonic: Mnemonic) -> Self {
+        let private_key = mnemonic.to_private_key(0, 0);
+        Self::new(private_key, WalletSource::Mnemonic)
     }
+}
 
+impl Wallet {
     #[deprecated(
         since = "0.67.0",
         note = "Use `PrivateKey::from_hex_str(hex).map(Wallet::from)` instead"

--- a/sdk/core/tests/wallet_test.rs
+++ b/sdk/core/tests/wallet_test.rs
@@ -6,7 +6,7 @@ use multiversx_sdk::wallet::PublicKey;
 fn test_private_key_from_mnemonic() {
     let mnemonic = Mnemonic::parse("acid twice post genre topic observe valid viable gesture fortune funny dawn around blood enemy page update reduce decline van bundle zebra rookie real").unwrap();
 
-    let private_key = mnemonic.to_private_key(0, 0);
+    let private_key = mnemonic.to_private_key(0, 0).unwrap();
     let public_key = PublicKey::from(&private_key);
     let address = public_key.to_address();
     assert_eq!(
@@ -22,7 +22,7 @@ fn test_private_key_from_mnemonic() {
         address.to_bech32_default().bech32
     );
 
-    let private_key = mnemonic.to_private_key(0, 1);
+    let private_key = mnemonic.to_private_key(0, 1).unwrap();
     let public_key = PublicKey::from(&private_key);
     let address = public_key.to_address();
     assert_eq!(

--- a/sdk/core/tests/wallet_test.rs
+++ b/sdk/core/tests/wallet_test.rs
@@ -1,13 +1,12 @@
-use bip39::Mnemonic;
-
 use multiversx_sdk::test_wallets;
-use multiversx_sdk::wallet::{PrivateKey, PublicKey};
+use multiversx_sdk::wallet::Mnemonic;
+use multiversx_sdk::wallet::PublicKey;
 
 #[test]
 fn test_private_key_from_mnemonic() {
-    let mnemonic: Mnemonic = Mnemonic::parse_normalized("acid twice post genre topic observe valid viable gesture fortune funny dawn around blood enemy page update reduce decline van bundle zebra rookie real").unwrap();
+    let mnemonic = Mnemonic::parse("acid twice post genre topic observe valid viable gesture fortune funny dawn around blood enemy page update reduce decline van bundle zebra rookie real").unwrap();
 
-    let private_key = PrivateKey::from_mnemonic(mnemonic.clone(), 0, 0).unwrap();
+    let private_key = mnemonic.to_private_key(0, 0);
     let public_key = PublicKey::from(&private_key);
     let address = public_key.to_address();
     assert_eq!(
@@ -23,7 +22,7 @@ fn test_private_key_from_mnemonic() {
         address.to_bech32_default().bech32
     );
 
-    let private_key = PrivateKey::from_mnemonic(mnemonic, 0, 1).unwrap();
+    let private_key = mnemonic.to_private_key(0, 1);
     let public_key = PublicKey::from(&private_key);
     let address = public_key.to_address();
     assert_eq!(


### PR DESCRIPTION
## Pull request overview

Refactors wallet mnemonic handling by introducing an SDK-level `wallet::Mnemonic` wrapper that encapsulates BIP-39 parsing and MultiversX HD key derivation, and updates call sites to use the new API.

**Changes:**
- Added `sdk/core/src/wallet/mnemonic.rs` with `Mnemonic::parse()` and `Mnemonic::to_private_key()`.
- Updated wallet creation paths to derive keys via `Mnemonic` (tests + meta CLI).
- Removed mnemonic-derivation logic from `PrivateKey` and tightened `PrivateKey` field visibility.