### PR TITLE
Fix: Undefined Behavior in BoxedBytes::from_concat on Zero-Length Input

### DIFF
--- a/chain/core/src/types/boxed_bytes.rs
+++ b/chain/core/src/types/boxed_bytes.rs
@@ -74,6 +74,11 @@ impl BoxedBytes {
             index -= 1;
             result_len += slices[index].len();
         }
+        // Calling `alloc` with a zero-sized layout is undefined behavior.
+        // Return a valid empty instance directly instead of entering the unsafe path.
+        if result_len == 0 {
+            return BoxedBytes::empty();
+        }
         unsafe {
             let layout = Layout::from_size_align(result_len, core::mem::align_of::<u8>()).unwrap();
             let result_ptr = alloc(layout);
@@ -254,6 +259,40 @@ mod tests {
     fn test_concat_empty_2() {
         let bb = BoxedBytes::from_concat(&[]);
         assert_eq!(bb, BoxedBytes::from(&b""[..]));
+    }
+
+    /// Regression test: previously triggered UB by calling `alloc(size=0)`.
+    #[test]
+    fn test_concat_single_empty_slice() {
+        let bb = BoxedBytes::from_concat(&[&b""[..]]);
+        assert_eq!(bb, BoxedBytes::empty());
+        assert!(bb.is_empty());
+    }
+
+    #[test]
+    fn test_concat_single_nonempty_slice() {
+        let bb = BoxedBytes::from_concat(&[&b"hello"[..]]);
+        assert_eq!(bb, BoxedBytes::from(&b"hello"[..]));
+    }
+
+    #[test]
+    fn test_concat_leading_empty_slices() {
+        let bb = BoxedBytes::from_concat(&[&b""[..], &b""[..], &b"abc"[..]]);
+        assert_eq!(bb, BoxedBytes::from(&b"abc"[..]));
+    }
+
+    #[test]
+    fn test_concat_trailing_empty_slices() {
+        let bb = BoxedBytes::from_concat(&[&b"abc"[..], &b""[..], &b""[..]]);
+        assert_eq!(bb, BoxedBytes::from(&b"abc"[..]));
+    }
+
+    #[test]
+    fn test_concat_result_is_empty_instance() {
+        // All-empty concat must return a proper empty BoxedBytes, not a dangling pointer.
+        let bb = BoxedBytes::from_concat(&[&b""[..], &b""[..]]);
+        assert_eq!(bb.len(), 0);
+        assert_eq!(bb.as_slice(), &b""[..]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`BoxedBytes::from_concat` called `alloc(Layout { size: 0, align: 1 })` when all
input slices were empty or the slice list was empty. Calling the global allocator
with a zero-sized layout violates Rust's allocator contract and produces undefined
behavior.

## Root Cause

The unsafe allocation path had no guard for `result_len == 0`. The fix adds an
early return via `BoxedBytes::empty()` before entering the `unsafe` block.
`BoxedBytes::empty()` boxes a `[u8; 0]` ZST, which the stdlib handles entirely at
compile time using `NonNull::dangling()` — the allocator is never invoked.

## Impact by Allocator

MultiversX smart contracts can be compiled with one of four allocators, each with
different behavior when `alloc(size=0)` is called:

| Allocator | `alloc(size=0)` behavior | `dealloc` behavior | Net impact |
|---|---|---|---|
| `AllocationForbidden` *(default)* | Calls `signal_error("memory allocation forbidden")` — hard contract abort | Same — abort | **Denial of service.** Any endpoint receiving empty byte arguments and calling `from_concat` unconditionally terminates the contract with a user-visible error, regardless of whether the business logic would otherwise succeed. |
| `WeeAlloc` | Returns a pointer into an existing free-list node without consuming it | Inserts a duplicate entry back into the free list | **Heap corruption.** The free list now contains the same cell twice. A subsequent allocation can return memory that is still reachable via the duplicate entry, producing two live allocations aliasing the same address. This can silently corrupt any live variable allocated after the empty concat — including balances, owner addresses, or storage keys — within the same contract execution. The corruption is deferred and invisible at the call site. |
| `LeakingAllocator` | Returns `0 as *mut u8` (null pointer) when no pages have been requested yet | No-op | **Null pointer in `Box`.** Technically UB; `as_ptr()` returns null. In practice harmless because dealloc is a no-op and no data is read through the zero-length slice, but the pointer value is wrong. |
| `StaticAllocator64K` | Returns a pointer into the arena without advancing `head` | No-op | **Aliased zero-length pointer.** Repeated zero-size allocations all return the same arena address. No memory is corrupted because dealloc is a no-op and nothing is written, but the pointer aliases the arena base. |

### Severity assessment

- **`WeeAlloc`**: High. Silent heap corruption within a live contract execution.
  An attacker who can supply empty byte arguments to an endpoint that calls
  `from_concat` can trigger the free-list corruption and cause subsequent
  allocations to alias live contract state.
- **`AllocationForbidden`**: Medium. Reliable denial of service against the
  contract endpoint. No state corruption, but the contract aborts instead of
  executing.
- **`LeakingAllocator` / `StaticAllocator64K`**: Low. Technically UB; no
  practical corruption observed due to no-op dealloc.

## Fix

```rust
if result_len == 0 {
    return BoxedBytes::empty();
}
```

Added before the `unsafe` block in `from_concat`. `BoxedBytes::empty()` never
calls the allocator under any of the four contract allocators.

## Tests Added

- `test_concat_single_empty_slice` — regression: single `&b""` previously hit the UB path
- `test_concat_single_nonempty_slice` — single non-empty slice round-trips correctly
- `test_concat_leading_empty_slices` — empty slices before a non-empty slice
- `test_concat_trailing_empty_slices` — empty slices after a non-empty slice
- `test_concat_result_is_empty_instance` — all-empty concat returns a valid, dereferenceable instance
