### PR TITLE
CodeMetadata - stricter constructor/convertors

### DIFF
--- a/chain/core/src/types/flags.rs
+++ b/chain/core/src/types/flags.rs
@@ -5,7 +5,7 @@ mod esdt_token_type;
 mod return_code;
 mod token_type;
 
-pub use code_metadata::CodeMetadata;
+pub use code_metadata::{CodeMetadata, CodeMetadataError};
 pub use esdt_local_role::EsdtLocalRole;
 pub use esdt_local_role_flags::EsdtLocalRoleFlags;
 pub use esdt_token_type::EsdtTokenType;

--- a/chain/core/src/types/flags/code_metadata.rs
+++ b/chain/core/src/types/flags/code_metadata.rs
@@ -107,52 +107,67 @@ impl CodeMetadata {
         *self & CodeMetadata::GUARDED != CodeMetadata::EMPTY
     }
 
+    /// Serialises the metadata to its 2-byte big-endian wire representation.
+    ///
+    /// The returned array is the canonical on-chain encoding: first byte carries
+    /// `UPGRADEABLE`, `READABLE`, and `GUARDED`; second byte carries `PAYABLE` and `PAYABLE_BY_SC`.
     #[inline]
     pub fn to_byte_array(&self) -> [u8; 2] {
         self.bits().to_be_bytes()
     }
 
+    /// Serialises the metadata to a 2-byte big-endian `Vec`.
+    ///
+    /// Convenience wrapper around [`to_byte_array`](Self::to_byte_array) for call sites
+    /// that need an owned buffer.
     pub fn to_vec(&self) -> Vec<u8> {
         self.to_byte_array().to_vec()
     }
 
-    pub fn for_each_string_token<F: FnMut(&'static str)>(&self, mut f: F) {
+    /// Calls `f` once for each token that makes up the human-readable display of these flags.
+    ///
+    /// Tokens are the flag name strings (`"Upgradeable"`, `"Readable"`, `"Guarded"`,
+    /// `"Payable"`, `"PayableBySC"`) and the `"|"` separator between them.
+    /// If no flags are set, `f` is called once with `"Default"`.
+    ///
+    /// The flag order matches the canonical display order used in scenario JSON files.
+    pub fn write_display_tokens<F: FnMut(&'static str)>(&self, mut write: F) {
         let mut nothing_printed: bool = true;
         if self.is_upgradeable() {
-            f(UPGRADEABLE_STRING);
+            write(UPGRADEABLE_STRING);
             nothing_printed = false;
         }
         if self.is_readable() {
             if !nothing_printed {
-                f("|");
+                write("|");
             }
-            f(READABLE_STRING);
+            write(READABLE_STRING);
             nothing_printed = false;
         }
         if self.is_guarded() {
             if !nothing_printed {
-                f("|");
+                write("|");
             }
-            f(GUARDED_STRING);
+            write(GUARDED_STRING);
             nothing_printed = false;
         }
         if self.is_payable() {
             if !nothing_printed {
-                f("|");
+                write("|");
             }
-            f(PAYABLE_STRING);
+            write(PAYABLE_STRING);
             nothing_printed = false;
         }
         if self.is_payable_by_sc() {
             if !nothing_printed {
-                f("|");
+                write("|");
             }
-            f(PAYABLE_BY_SC_STRING);
+            write(PAYABLE_BY_SC_STRING);
             nothing_printed = false;
         }
 
         if nothing_printed {
-            f(DEFAULT_STRING);
+            write(DEFAULT_STRING);
         }
     }
 

--- a/chain/core/src/types/flags/code_metadata.rs
+++ b/chain/core/src/types/flags/code_metadata.rs
@@ -98,32 +98,68 @@ impl CodeMetadata {
             f(DEFAULT_STRING);
         }
     }
-}
 
-impl From<[u8; 2]> for CodeMetadata {
-    #[inline]
-    fn from(arr: [u8; 2]) -> Self {
-        CodeMetadata::from(u16::from_be_bytes(arr))
-    }
-}
-
-impl From<u16> for CodeMetadata {
-    #[inline]
-    fn from(value: u16) -> Self {
+    /// Parses code metadata from a 2-byte slice, mirroring the MultiversX protocol implementation.
+    ///
+    /// If the slice is not exactly 2 bytes, returns [`CodeMetadata::DEFAULT`] (all flags cleared).
+    /// Unknown or reserved bits are silently ignored; only the bits corresponding to known flags
+    /// are extracted.
+    ///
+    /// This intentionally lenient behaviour matches the on-chain Go implementation
+    /// (`CodeMetadataFromBytes`). Prefer [`TryFrom<&[u8]>`] in tooling and off-chain code
+    /// where strict validation is desirable.
+    pub fn from_bytes_or_default(bytes: &[u8]) -> Self {
+        if bytes.len() != 2 {
+            return CodeMetadata::DEFAULT;
+        }
+        let value = u16::from_be_bytes([bytes[0], bytes[1]]);
         CodeMetadata::from_bits_truncate(value)
     }
 }
 
-impl From<&[u8]> for CodeMetadata {
-    fn from(slice: &[u8]) -> Self {
-        let arr: [u8; 2] = slice.try_into().unwrap_or_default();
-        CodeMetadata::from(arr)
+/// Error type returned when converting raw bytes or integers into [`CodeMetadata`] fails.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum CodeMetadataError {
+    /// The input slice was not exactly 2 bytes long.
+    InvalidLength,
+    /// The bit pattern contains bits that do not correspond to any known flag.
+    InvalidBits(u16),
+}
+
+impl TryFrom<u16> for CodeMetadata {
+    type Error = CodeMetadataError;
+
+    #[inline]
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        CodeMetadata::from_bits(value).ok_or(CodeMetadataError::InvalidBits(value))
     }
 }
 
-impl From<&Vec<u8>> for CodeMetadata {
-    fn from(v: &Vec<u8>) -> Self {
-        CodeMetadata::from(v.as_slice())
+impl TryFrom<[u8; 2]> for CodeMetadata {
+    type Error = CodeMetadataError;
+
+    #[inline]
+    fn try_from(arr: [u8; 2]) -> Result<Self, Self::Error> {
+        CodeMetadata::try_from(u16::from_be_bytes(arr))
+    }
+}
+
+impl TryFrom<&[u8]> for CodeMetadata {
+    type Error = CodeMetadataError;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        let arr: [u8; 2] = slice
+            .try_into()
+            .map_err(|_| CodeMetadataError::InvalidLength)?;
+        CodeMetadata::try_from(arr)
+    }
+}
+
+impl TryFrom<&Vec<u8>> for CodeMetadata {
+    type Error = CodeMetadataError;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self, Self::Error> {
+        CodeMetadata::try_from(v.as_slice())
     }
 }
 
@@ -155,7 +191,8 @@ impl NestedDecode for CodeMetadata {
         I: NestedDecodeInput,
         H: DecodeErrorHandler,
     {
-        Ok(CodeMetadata::from(u16::dep_decode_or_handle_err(input, h)?))
+        let value = u16::dep_decode_or_handle_err(input, h)?;
+        CodeMetadata::try_from(value).map_err(|_| h.handle_error(DecodeError::INVALID_VALUE))
     }
 }
 
@@ -219,16 +256,60 @@ mod tests {
         assert!(CodeMetadata::READABLE.is_readable());
     }
 
+    #[test]
+    fn test_try_from_slice_exact_length() {
+        assert!(
+            CodeMetadata::try_from(&[1u8, 0u8][..])
+                .unwrap()
+                .is_upgradeable()
+        );
+        assert!(
+            CodeMetadata::try_from(&[0u8, 2u8][..])
+                .unwrap()
+                .is_payable()
+        );
+        assert!(
+            !CodeMetadata::try_from(&[0u8, 0u8][..])
+                .unwrap()
+                .is_upgradeable()
+        );
+    }
+
+    #[test]
+    fn test_try_from_slice_wrong_length() {
+        assert_eq!(
+            CodeMetadata::try_from(&[1u8][..]),
+            Err(CodeMetadataError::InvalidLength)
+        );
+        assert_eq!(
+            CodeMetadata::try_from(&[][..]),
+            Err(CodeMetadataError::InvalidLength)
+        );
+        assert_eq!(
+            CodeMetadata::try_from(&[1u8, 0u8, 0u8][..]),
+            Err(CodeMetadataError::InvalidLength)
+        );
+    }
+
+    #[test]
+    fn test_try_from_invalid_bits() {
+        // 0x0001 has no defined flag in the second byte at bit 0
+        assert_eq!(
+            CodeMetadata::try_from(0x0001u16),
+            Err(CodeMetadataError::InvalidBits(0x0001))
+        );
+    }
+
     /// Translated from vm-wasm.
     #[test]
-    fn test_from_array() {
-        assert!(CodeMetadata::from([1, 0]).is_upgradeable());
-        assert!(!CodeMetadata::from([1, 0]).is_readable());
-        assert!(CodeMetadata::from([0, 2]).is_payable());
-        assert!(CodeMetadata::from([4, 0]).is_readable());
-        assert!(!CodeMetadata::from([4, 0]).is_upgradeable());
-        assert!(!CodeMetadata::from([0, 0]).is_upgradeable());
-        assert!(!CodeMetadata::from([0, 0]).is_payable());
-        assert!(!CodeMetadata::from([0, 0]).is_readable());
+    fn test_try_from_array() {
+        assert!(CodeMetadata::try_from([1u8, 0u8]).unwrap().is_upgradeable());
+        assert!(!CodeMetadata::try_from([1u8, 0u8]).unwrap().is_readable());
+        assert!(CodeMetadata::try_from([0u8, 2u8]).unwrap().is_payable());
+        assert!(CodeMetadata::try_from([4u8, 0u8]).unwrap().is_readable());
+        assert!(!CodeMetadata::try_from([4u8, 0u8]).unwrap().is_upgradeable());
+        assert!(!CodeMetadata::try_from([0u8, 0u8]).unwrap().is_upgradeable());
+        assert!(!CodeMetadata::try_from([0u8, 0u8]).unwrap().is_payable());
+        assert!(!CodeMetadata::try_from([0u8, 0u8]).unwrap().is_readable());
     }
 }

--- a/chain/core/src/types/flags/code_metadata.rs
+++ b/chain/core/src/types/flags/code_metadata.rs
@@ -11,11 +11,42 @@ const PAYABLE_BY_SC_STRING: &str = "PayableBySC";
 const DEFAULT_STRING: &str = "Default";
 
 bitflags! {
-    /// Flags representing the smart contract's allowed actions after deploy.
-    #[derive(Default, PartialEq, Debug, Clone, Copy)]
+    /// Bit-flags that govern a smart contract's permissions after deployment.
+    ///
+    /// Each flag corresponds to a protocol-level capability:
+    /// - [`UPGRADEABLE`](CodeMetadata::UPGRADEABLE) — the contract may be upgraded by its owner.
+    /// - [`READABLE`](CodeMetadata::READABLE) — other contracts may read this contract's storage.
+    /// - [`GUARDED`](CodeMetadata::GUARDED) — transactions require a second guardian signature.
+    /// - [`PAYABLE`](CodeMetadata::PAYABLE) — the contract accepts direct EGLD/ESDT transfers.
+    /// - [`PAYABLE_BY_SC`](CodeMetadata::PAYABLE_BY_SC) — the contract accepts transfers from other contracts only.
+    ///
+    /// # Wire format
+    ///
+    /// Metadata is serialised as exactly **2 big-endian bytes**. The first byte carries
+    /// `UPGRADEABLE` (bit 0), `READABLE` (bit 2), and `GUARDED` (bit 3); the second byte carries
+    /// `PAYABLE` (bit 1) and `PAYABLE_BY_SC` (bit 2).
+    ///
+    /// # Parsing
+    ///
+    /// - Use [`TryFrom<&[u8]>`] / [`TryFrom<u16>`] in **tooling and off-chain code** — these
+    ///   return [`CodeMetadataError`] on wrong-length input or unknown bits, enabling fail-closed
+    ///   validation.
+    /// - Use [`from_bytes_or_default`](CodeMetadata::from_bytes_or_default) in the **Rust VM** —
+    ///   this mirrors the lenient Go protocol implementation: wrong-length input yields
+    ///   [`EMPTY`](CodeMetadata::EMPTY) and unknown bits are silently truncated.
+    ///
+    /// # Default value
+    ///
+    /// [`Default::default()`] returns `UPGRADEABLE | READABLE | PAYABLE | PAYABLE_BY_SC`,
+    /// which is the permissive set used as a fallback in **scenario tests** when a deployed
+    /// contract's metadata field is left unset. This is intentionally *not* the zero value;
+    /// use [`EMPTY`](CodeMetadata::EMPTY) explicitly when you need all flags cleared.
+    #[derive(PartialEq, Debug, Clone, Copy)]
     pub struct CodeMetadata: u16 {
-        /// No flags set. The contract is not upgradeable, not readable, and not payable.
-        const DEFAULT = 0;
+        /// No flags set. The contract is not upgradeable, not readable, and not payable, has no guardian.
+        ///
+        /// Warning! This is not the default value, see CodeMetadata::default() for that.
+        const EMPTY = 0;
 
         /// The contract can be upgraded in the future.
         const UPGRADEABLE = 0b0000_0001_0000_0000; // LSB of first byte
@@ -40,31 +71,40 @@ bitflags! {
     }
 }
 
+impl Default for CodeMetadata {
+    fn default() -> Self {
+        CodeMetadata::UPGRADEABLE
+            | CodeMetadata::READABLE
+            | CodeMetadata::PAYABLE
+            | CodeMetadata::PAYABLE_BY_SC
+    }
+}
+
 impl CodeMetadata {
     /// Returns `true` if the contract is allowed to be upgraded.
     pub fn is_upgradeable(&self) -> bool {
-        *self & CodeMetadata::UPGRADEABLE != CodeMetadata::DEFAULT
+        *self & CodeMetadata::UPGRADEABLE != CodeMetadata::EMPTY
     }
 
     /// Returns `true` if the contract can receive funds without an endpoint call.
     pub fn is_payable(&self) -> bool {
-        *self & CodeMetadata::PAYABLE != CodeMetadata::DEFAULT
+        *self & CodeMetadata::PAYABLE != CodeMetadata::EMPTY
     }
 
     /// Returns `true` if the contract can receive funds from other smart contracts
     /// without an endpoint call. Direct user transfers are rejected.
     pub fn is_payable_by_sc(&self) -> bool {
-        *self & CodeMetadata::PAYABLE_BY_SC != CodeMetadata::DEFAULT
+        *self & CodeMetadata::PAYABLE_BY_SC != CodeMetadata::EMPTY
     }
 
     /// Returns `true` if the contract's storage can be read by other contracts.
     pub fn is_readable(&self) -> bool {
-        *self & CodeMetadata::READABLE != CodeMetadata::DEFAULT
+        *self & CodeMetadata::READABLE != CodeMetadata::EMPTY
     }
 
     /// Returns `true` if the contract is guarded.
     pub fn is_guarded(&self) -> bool {
-        *self & CodeMetadata::GUARDED != CodeMetadata::DEFAULT
+        *self & CodeMetadata::GUARDED != CodeMetadata::EMPTY
     }
 
     #[inline]
@@ -118,7 +158,7 @@ impl CodeMetadata {
 
     /// Parses code metadata from a 2-byte slice, mirroring the MultiversX protocol implementation.
     ///
-    /// If the slice is not exactly 2 bytes, returns [`CodeMetadata::DEFAULT`] (all flags cleared).
+    /// If the slice is not exactly 2 bytes, returns [`CodeMetadata::EMPTY`] (all flags cleared).
     /// Unknown or reserved bits are silently ignored; only the bits corresponding to known flags
     /// are extracted.
     ///
@@ -127,7 +167,7 @@ impl CodeMetadata {
     /// where strict validation is desirable.
     pub fn from_bytes_or_default(bytes: &[u8]) -> Self {
         if bytes.len() != 2 {
-            return CodeMetadata::DEFAULT;
+            return CodeMetadata::EMPTY;
         }
         let value = u16::from_be_bytes([bytes[0], bytes[1]]);
         CodeMetadata::from_bits_truncate(value)
@@ -228,10 +268,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_default() {
-        assert!(!CodeMetadata::DEFAULT.is_upgradeable());
-        assert!(!CodeMetadata::DEFAULT.is_payable());
-        assert!(!CodeMetadata::DEFAULT.is_readable());
+    fn test_empty() {
+        assert!(!CodeMetadata::EMPTY.is_upgradeable());
+        assert!(!CodeMetadata::EMPTY.is_payable());
+        assert!(!CodeMetadata::EMPTY.is_payable_by_sc());
+        assert!(!CodeMetadata::EMPTY.is_readable());
+        assert!(!CodeMetadata::EMPTY.is_guarded());
     }
 
     #[test]

--- a/chain/core/src/types/flags/code_metadata.rs
+++ b/chain/core/src/types/flags/code_metadata.rs
@@ -5,6 +5,7 @@ use bitflags::bitflags;
 
 const UPGRADEABLE_STRING: &str = "Upgradeable";
 const READABLE_STRING: &str = "Readable";
+const GUARDED_STRING: &str = "Guarded";
 const PAYABLE_STRING: &str = "Payable";
 const PAYABLE_BY_SC_STRING: &str = "PayableBySC";
 const DEFAULT_STRING: &str = "Default";
@@ -21,6 +22,10 @@ bitflags! {
 
         /// The contract's storage can be read by other contracts.
         const READABLE = 0b0000_0100_0000_0000; // 3rd LSB of first byte
+
+        /// The contract is guarded: transactions must carry a second signature
+        /// from a guardian account in order to be executed.
+        const GUARDED = 0b0000_1000_0000_0000; // 4th LSB of first byte
 
         /// The contract can receive funds without having any endpoint called,
         /// just like user accounts.
@@ -57,6 +62,11 @@ impl CodeMetadata {
         *self & CodeMetadata::READABLE != CodeMetadata::DEFAULT
     }
 
+    /// Returns `true` if the contract is guarded.
+    pub fn is_guarded(&self) -> bool {
+        *self & CodeMetadata::GUARDED != CodeMetadata::DEFAULT
+    }
+
     #[inline]
     pub fn to_byte_array(&self) -> [u8; 2] {
         self.bits().to_be_bytes()
@@ -77,6 +87,13 @@ impl CodeMetadata {
                 f("|");
             }
             f(READABLE_STRING);
+            nothing_printed = false;
+        }
+        if self.is_guarded() {
+            if !nothing_printed {
+                f("|");
+            }
+            f(GUARDED_STRING);
             nothing_printed = false;
         }
         if self.is_payable() {
@@ -222,38 +239,40 @@ mod tests {
         let all = CodeMetadata::UPGRADEABLE
             | CodeMetadata::PAYABLE
             | CodeMetadata::PAYABLE_BY_SC
-            | CodeMetadata::READABLE;
+            | CodeMetadata::READABLE
+            | CodeMetadata::GUARDED;
         assert!(all.is_upgradeable());
         assert!(all.is_payable());
         assert!(all.is_payable_by_sc());
         assert!(all.is_readable());
+        assert!(all.is_guarded());
 
-        assert_eq!(all.bits(), 0x0506);
+        assert_eq!(all.bits(), 0x0d06);
 
         assert_eq!(CodeMetadata::from_bits_truncate(0xffff), all);
     }
 
     #[test]
     fn test_each() {
-        assert!(CodeMetadata::UPGRADEABLE.is_upgradeable());
-        assert!(!CodeMetadata::PAYABLE.is_upgradeable());
-        assert!(!CodeMetadata::PAYABLE_BY_SC.is_upgradeable());
-        assert!(!CodeMetadata::READABLE.is_upgradeable());
+        type CodeMetadataChecker = fn(&CodeMetadata) -> bool;
+        let flags_and_checkers: &[(CodeMetadata, CodeMetadataChecker)] = &[
+            (CodeMetadata::UPGRADEABLE, CodeMetadata::is_upgradeable),
+            (CodeMetadata::READABLE, CodeMetadata::is_readable),
+            (CodeMetadata::GUARDED, CodeMetadata::is_guarded),
+            (CodeMetadata::PAYABLE, CodeMetadata::is_payable),
+            (CodeMetadata::PAYABLE_BY_SC, CodeMetadata::is_payable_by_sc),
+        ];
 
-        assert!(!CodeMetadata::UPGRADEABLE.is_payable());
-        assert!(CodeMetadata::PAYABLE.is_payable());
-        assert!(!CodeMetadata::PAYABLE_BY_SC.is_payable());
-        assert!(!CodeMetadata::READABLE.is_payable());
-
-        assert!(!CodeMetadata::UPGRADEABLE.is_payable_by_sc());
-        assert!(!CodeMetadata::PAYABLE.is_payable_by_sc());
-        assert!(CodeMetadata::PAYABLE_BY_SC.is_payable_by_sc());
-        assert!(!CodeMetadata::READABLE.is_payable_by_sc());
-
-        assert!(!CodeMetadata::UPGRADEABLE.is_readable());
-        assert!(!CodeMetadata::PAYABLE.is_readable());
-        assert!(!CodeMetadata::PAYABLE_BY_SC.is_readable());
-        assert!(CodeMetadata::READABLE.is_readable());
+        // checking that checkers match, and are orthogonal (each checker only returns true for its own flag)
+        for (flag, checker) in flags_and_checkers {
+            for (other_flag, _) in flags_and_checkers {
+                assert_eq!(
+                    checker(other_flag),
+                    flag == other_flag,
+                    "{checker:?} returned unexpected result for flag {other_flag:?}",
+                );
+            }
+        }
     }
 
     #[test]
@@ -305,11 +324,17 @@ mod tests {
     fn test_try_from_array() {
         assert!(CodeMetadata::try_from([1u8, 0u8]).unwrap().is_upgradeable());
         assert!(!CodeMetadata::try_from([1u8, 0u8]).unwrap().is_readable());
+        assert!(!CodeMetadata::try_from([1u8, 0u8]).unwrap().is_guarded());
         assert!(CodeMetadata::try_from([0u8, 2u8]).unwrap().is_payable());
         assert!(CodeMetadata::try_from([4u8, 0u8]).unwrap().is_readable());
         assert!(!CodeMetadata::try_from([4u8, 0u8]).unwrap().is_upgradeable());
+        assert!(!CodeMetadata::try_from([4u8, 0u8]).unwrap().is_guarded());
+        assert!(CodeMetadata::try_from([8u8, 0u8]).unwrap().is_guarded());
+        assert!(!CodeMetadata::try_from([8u8, 0u8]).unwrap().is_upgradeable());
+        assert!(!CodeMetadata::try_from([8u8, 0u8]).unwrap().is_readable());
         assert!(!CodeMetadata::try_from([0u8, 0u8]).unwrap().is_upgradeable());
         assert!(!CodeMetadata::try_from([0u8, 0u8]).unwrap().is_payable());
         assert!(!CodeMetadata::try_from([0u8, 0u8]).unwrap().is_readable());
+        assert!(!CodeMetadata::try_from([0u8, 0u8]).unwrap().is_guarded());
     }
 }

--- a/chain/vm/src/blockchain/state/account_data.rs
+++ b/chain/vm/src/blockchain/state/account_data.rs
@@ -4,7 +4,7 @@ use num_traits::Zero;
 use super::AccountEsdt;
 use crate::{
     display_util::key_hex,
-    types::{Address, VMCodeMetadata},
+    types::{Address, CodeMetadata},
 };
 use std::{collections::HashMap, fmt, fmt::Write};
 
@@ -19,7 +19,7 @@ pub struct AccountData {
     pub storage: AccountStorage,
     pub username: Vec<u8>,
     pub contract_path: Option<Vec<u8>>,
-    pub code_metadata: VMCodeMetadata,
+    pub code_metadata: CodeMetadata,
     pub contract_owner: Option<Address>,
     pub developer_rewards: BigUint,
 }
@@ -34,7 +34,7 @@ impl AccountData {
             storage: AccountStorage::default(),
             username: vec![],
             contract_path: None,
-            code_metadata: VMCodeMetadata::empty(),
+            code_metadata: CodeMetadata::empty(),
             contract_owner: None,
             developer_rewards: BigUint::zero(),
         }

--- a/chain/vm/src/builtin_functions/general/upgrade_contract.rs
+++ b/chain/vm/src/builtin_functions/general/upgrade_contract.rs
@@ -3,7 +3,7 @@ use crate::{
     host::context::{BlockchainUpdate, CallType, TxCache, TxFunctionName, TxInput, TxResult},
     host::execution,
     host::runtime::{RuntimeInstanceCallLambda, RuntimeRef},
-    types::VMCodeMetadata,
+    types::CodeMetadata,
 };
 
 use super::super::builtin_func_trait::BuiltinFunction;
@@ -33,7 +33,7 @@ impl BuiltinFunction for UpgradeContract {
         }
 
         let new_code = tx_input.args[0].clone();
-        let code_metadata = VMCodeMetadata::from_bytes_or_default(&tx_input.args[1]);
+        let code_metadata = CodeMetadata::from_bytes_or_default(&tx_input.args[1]);
 
         let args = if tx_input.args.len() > 2 {
             tx_input.args[2..].to_vec()

--- a/chain/vm/src/builtin_functions/general/upgrade_contract.rs
+++ b/chain/vm/src/builtin_functions/general/upgrade_contract.rs
@@ -33,7 +33,7 @@ impl BuiltinFunction for UpgradeContract {
         }
 
         let new_code = tx_input.args[0].clone();
-        let code_metadata = VMCodeMetadata::from(&tx_input.args[1]);
+        let code_metadata = VMCodeMetadata::from_bytes_or_default(&tx_input.args[1]);
 
         let args = if tx_input.args.len() > 2 {
             tx_input.args[2..].to_vec()

--- a/chain/vm/src/host/context/managed_type_container/tx_managed_buffer.rs
+++ b/chain/vm/src/host/context/managed_type_container/tx_managed_buffer.rs
@@ -35,8 +35,7 @@ impl ManagedTypeContainer {
     }
 
     pub fn mb_to_code_metadata(&self, handle: RawHandle) -> VMCodeMetadata {
-        let bytes: [u8; 2] = self.mb_get(handle).try_into().unwrap();
-        VMCodeMetadata::from(bytes)
+        VMCodeMetadata::from_bytes_or_default(self.mb_get(handle))
     }
 
     pub fn mb_get_slice(

--- a/chain/vm/src/host/context/managed_type_container/tx_managed_buffer.rs
+++ b/chain/vm/src/host/context/managed_type_container/tx_managed_buffer.rs
@@ -1,6 +1,6 @@
 use crate::{
     host::context::{TxFunctionName, TxTokenTransfer},
-    types::{Address, RawHandle, VMCodeMetadata},
+    types::{Address, CodeMetadata, RawHandle},
 };
 
 use super::ManagedTypeContainer;
@@ -34,8 +34,8 @@ impl ManagedTypeContainer {
         TxFunctionName::from(self.mb_get(handle))
     }
 
-    pub fn mb_to_code_metadata(&self, handle: RawHandle) -> VMCodeMetadata {
-        VMCodeMetadata::from_bytes_or_default(self.mb_get(handle))
+    pub fn mb_to_code_metadata(&self, handle: RawHandle) -> CodeMetadata {
+        CodeMetadata::from_bytes_or_default(self.mb_get(handle))
     }
 
     pub fn mb_get_slice(

--- a/chain/vm/src/host/context/tx_context.rs
+++ b/chain/vm/src/host/context/tx_context.rs
@@ -4,7 +4,7 @@ use crate::{
         state::{AccountData, AccountEsdt, BlockchainState},
     },
     host::runtime::RuntimeRef,
-    types::{Address, VMCodeMetadata},
+    types::{Address, CodeMetadata},
 };
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -53,7 +53,7 @@ impl TxContext {
             esdt: AccountEsdt::default(),
             username: Vec::new(),
             contract_path: None,
-            code_metadata: VMCodeMetadata::empty(),
+            code_metadata: CodeMetadata::empty(),
             contract_owner: None,
             developer_rewards: BigUint::zero(),
         });
@@ -154,7 +154,7 @@ impl TxContext {
         &self,
         new_address: &Address,
         contract_path: Vec<u8>,
-        code_metadata: VMCodeMetadata,
+        code_metadata: CodeMetadata,
         contract_owner: Address,
     ) {
         assert!(

--- a/chain/vm/src/host/execution/exec_call.rs
+++ b/chain/vm/src/host/execution/exec_call.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         runtime::{RuntimeInstanceCallLambda, RuntimeInstanceCallLambdaDefault, RuntimeRef},
     },
-    types::VMCodeMetadata,
+    types::CodeMetadata,
 };
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -210,7 +210,7 @@ fn insert_ghost_account(
         username: Vec::new(),
         storage: HashMap::new(),
         contract_path: None,
-        code_metadata: VMCodeMetadata::empty(),
+        code_metadata: CodeMetadata::empty(),
         contract_owner: None,
         developer_rewards: BigUint::zero(),
     });

--- a/chain/vm/src/host/execution/exec_create.rs
+++ b/chain/vm/src/host/execution/exec_create.rs
@@ -2,14 +2,14 @@ use crate::{
     blockchain::state::BlockchainStateRef,
     host::context::{BlockchainUpdate, TxCache, TxContext, TxInput, TxResult},
     host::runtime::{RuntimeInstanceCallLambda, RuntimeRef},
-    types::{Address, VMCodeMetadata},
+    types::{Address, CodeMetadata},
 };
 
 /// Executes deploy transaction and commits changes back to the underlying blockchain state.
 pub fn commit_deploy<F>(
     tx_input: TxInput,
     contract_path: &[u8],
-    code_metadata: VMCodeMetadata,
+    code_metadata: CodeMetadata,
     state: &mut BlockchainStateRef,
     runtime: &RuntimeRef,
     f: F,
@@ -47,7 +47,7 @@ where
 pub fn execute_deploy<F>(
     mut tx_input: TxInput,
     contract_path: Vec<u8>,
-    code_metadata: VMCodeMetadata,
+    code_metadata: CodeMetadata,
     tx_cache: TxCache,
     runtime: &RuntimeRef,
     f: F,

--- a/chain/vm/src/host/vm_hooks/vh_context.rs
+++ b/chain/vm/src/host/vm_hooks/vh_context.rs
@@ -8,7 +8,7 @@ use crate::{
         BackTransfers, ManagedTypeContainer, TxErrorTrace, TxFunctionName, TxInput, TxLog, TxResult,
     },
     schedule::GasSchedule,
-    types::{Address, H256, VMCodeMetadata},
+    types::{Address, CodeMetadata, H256},
 };
 
 /// Abstracts away the borrowing of a managed types structure.
@@ -119,7 +119,7 @@ pub trait VMHooksContext: Debug {
         &mut self,
         egld_value: num_bigint::BigUint,
         contract_code: Vec<u8>,
-        code_metadata: VMCodeMetadata,
+        code_metadata: CodeMetadata,
         args: Vec<Vec<u8>>,
     ) -> Result<(Address, Vec<Vec<u8>>), VMHooksEarlyExit>;
 

--- a/chain/vm/src/host/vm_hooks/vh_handler/vh_send.rs
+++ b/chain/vm/src/host/vm_hooks/vh_handler/vh_send.rs
@@ -7,7 +7,7 @@ use crate::{
         context::{AsyncCallTxData, Promise, TxFunctionName, TxTokenTransfer},
         vm_hooks::{VMHooksContext, vh_early_exit::early_exit_vm_error},
     },
-    types::{Address, RawHandle, VMCodeMetadata, top_encode_big_uint, top_encode_u64},
+    types::{Address, CodeMetadata, RawHandle, top_encode_big_uint, top_encode_u64},
     vm_err_msg,
 };
 use multiversx_chain_core::types::ReturnCode;
@@ -114,7 +114,7 @@ impl<C: VMHooksContext> VMHooksHandler<C> {
         to: Address,
         egld_value: num_bigint::BigUint,
         contract_code: Vec<u8>,
-        code_metadata: VMCodeMetadata,
+        code_metadata: CodeMetadata,
         args: Vec<Vec<u8>>,
     ) -> Result<(), VMHooksEarlyExit> {
         let mut arguments = vec![contract_code, code_metadata.to_vec()];

--- a/chain/vm/src/host/vm_hooks/vh_tx_context.rs
+++ b/chain/vm/src/host/vm_hooks/vh_tx_context.rs
@@ -16,7 +16,7 @@ use crate::{
         TxContextRef, TxFunctionName, TxInput, TxResult, async_call_tx_input,
     },
     host::execution,
-    types::{Address, VMCodeMetadata},
+    types::{Address, CodeMetadata},
     vm_err_msg,
 };
 
@@ -209,7 +209,7 @@ impl<S: InstanceState> VMHooksContext for TxVMHooksContext<S> {
         &mut self,
         egld_value: num_bigint::BigUint,
         contract_code: Vec<u8>,
-        code_metadata: VMCodeMetadata,
+        code_metadata: CodeMetadata,
         args: Vec<Vec<u8>>,
     ) -> Result<(Address, Vec<Vec<u8>>), VMHooksEarlyExit> {
         let contract_address = self.current_address();

--- a/chain/vm/src/types.rs
+++ b/chain/vm/src/types.rs
@@ -1,5 +1,5 @@
 pub use crate::chain_core::types::Address;
-pub use crate::chain_core::types::CodeMetadata as VMCodeMetadata;
+pub use crate::chain_core::types::CodeMetadata;
 pub use crate::chain_core::types::EsdtLocalRole;
 pub use crate::chain_core::types::EsdtLocalRoleFlags;
 pub use crate::chain_core::types::H256;

--- a/contracts/examples/multisig/tests/multisig_blackbox_test.rs
+++ b/contracts/examples/multisig/tests/multisig_blackbox_test.rs
@@ -530,7 +530,7 @@ fn blackbox_deploy_and_upgrade_from_source() {
     let action_id = state.propose_sc_deploy_from_source(
         0u64,
         ADDER_ADDRESS,
-        CodeMetadata::all(),
+        CodeMetadata::default(),
         MultiValueVec::from([top_encode_to_vec_u8_or_panic(&5u64)]),
     );
     state.sign(action_id);
@@ -576,7 +576,7 @@ fn blackbox_deploy_and_upgrade_from_source() {
         ADDER_ADDRESS,
         0u64,
         factorial_address,
-        CodeMetadata::all(),
+        CodeMetadata::default(),
         MultiValueVec::new(),
     );
     state.sign(action_id);

--- a/contracts/examples/multisig/tests/multisig_whitebox_test.rs
+++ b/contracts/examples/multisig/tests/multisig_whitebox_test.rs
@@ -626,7 +626,7 @@ fn whitebox_deploy_and_upgrade_from_source() {
         ActionRaw::SCDeployFromSource {
             amount: 0u64.into(),
             source: ADDER_ADDRESS.to_address(),
-            code_metadata: CodeMetadata::all(),
+            code_metadata: CodeMetadata::default(),
             arguments: vec![BoxedBytes::from(&[5u8][..])],
         },
         None,
@@ -683,7 +683,7 @@ fn whitebox_deploy_and_upgrade_from_source() {
         ActionRaw::SCUpgradeFromSource {
             source: FACTORIAL_ADDRESS.to_address(),
             amount: 0u64.into(),
-            code_metadata: CodeMetadata::all(),
+            code_metadata: CodeMetadata::default(),
             arguments: Vec::new(),
             sc_address: ADDER_ADDRESS.to_address(),
         },

--- a/contracts/examples/order-book/factory/src/lib.rs
+++ b/contracts/examples/order-book/factory/src/lib.rs
@@ -33,7 +33,7 @@ pub trait Factory {
             .raw_deploy()
             .arguments_raw(arguments)
             .from_source(source)
-            .code_metadata(CodeMetadata::DEFAULT)
+            .code_metadata(CodeMetadata::EMPTY)
             .returns(ReturnsNewManagedAddress)
             .sync_call();
 

--- a/contracts/feature-tests/composability/forwarder-legacy/src/fwd_deploy_legacy.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/src/fwd_deploy_legacy.rs
@@ -38,7 +38,7 @@ pub trait DeployContractModule {
     ) -> (ManagedAddress, OptionalValue<ManagedBuffer>) {
         self.vault_proxy()
             .init(opt_arg)
-            .deploy_contract(code, CodeMetadata::DEFAULT)
+            .deploy_contract(code, CodeMetadata::EMPTY)
     }
 
     #[endpoint]
@@ -49,7 +49,7 @@ pub trait DeployContractModule {
     ) -> MultiValue2<ManagedAddress, OptionalValue<ManagedBuffer>> {
         self.vault_proxy()
             .init(opt_arg)
-            .deploy_from_source(&source_address, CodeMetadata::DEFAULT)
+            .deploy_from_source(&source_address, CodeMetadata::EMPTY)
             .into()
     }
 }

--- a/contracts/feature-tests/composability/forwarder/src/fwd_deploy.rs
+++ b/contracts/feature-tests/composability/forwarder/src/fwd_deploy.rs
@@ -53,7 +53,7 @@ pub trait DeployContractModule {
         self.tx()
             .typed(vault_proxy::VaultProxy)
             .init(opt_arg)
-            .code_metadata(CodeMetadata::DEFAULT)
+            .code_metadata(CodeMetadata::EMPTY)
             .from_source(source_address)
             .returns(ReturnsNewManagedAddress)
             .returns(ReturnsResult)

--- a/contracts/feature-tests/composability/mesh-interactor/src/call_tree_deploy.rs
+++ b/contracts/feature-tests/composability/mesh-interactor/src/call_tree_deploy.rs
@@ -44,7 +44,7 @@ impl ComposabilityInteract {
             let code_metadata = if contract.payable.unwrap_or(false) {
                 CodeMetadata::PAYABLE
             } else {
-                CodeMetadata::DEFAULT
+                CodeMetadata::EMPTY
             };
             buffer.push_tx(|tx| {
                 tx.from(wallet)

--- a/framework/base/src/contract_base/wrappers/blockchain_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/blockchain_wrapper.rs
@@ -165,7 +165,7 @@ where
             ManagedRefMut::<'static, A, ManagedBuffer<A>>::wrap_handle(mbuf_temp_1)
                 .load_to_byte_array(&mut buffer);
         }
-        CodeMetadata::from(buffer)
+        CodeMetadata::from_bytes_or_default(&buffer)
     }
 
     pub fn get_code_hash(&self, address: &ManagedAddress<A>) -> ManagedBuffer<A> {

--- a/framework/base/src/formatter/formatter_impl_vm_core.rs
+++ b/framework/base/src/formatter/formatter_impl_vm_core.rs
@@ -4,7 +4,7 @@ use super::{FormatByteReceiver, SCBinary, SCDisplay, SCLowerHex, hex_util};
 
 impl SCDisplay for CodeMetadata {
     fn fmt<F: FormatByteReceiver>(&self, f: &mut F) {
-        self.for_each_string_token(|token| f.append_bytes(token.as_bytes()))
+        self.write_display_tokens(|token| f.append_bytes(token.as_bytes()))
     }
 }
 

--- a/framework/base/src/types/interaction/tx_data/upgrade_call.rs
+++ b/framework/base/src/types/interaction/tx_data/upgrade_call.rs
@@ -23,7 +23,7 @@ where
     fn default() -> UpgradeCall<Env, ()> {
         UpgradeCall {
             code_source: (),
-            code_metadata: CodeMetadata::DEFAULT,
+            code_metadata: CodeMetadata::EMPTY,
             arg_buffer: ManagedArgBuffer::new(),
         }
     }

--- a/framework/base/tests/formatter_test.rs
+++ b/framework/base/tests/formatter_test.rs
@@ -140,7 +140,7 @@ fn test_display_code_metadata() {
             | CodeMetadata::PAYABLE_BY_SC,
         "Upgradeable|Readable|Payable|PayableBySC",
     );
-    check_code_metadata_display(CodeMetadata::DEFAULT, "Default");
+    check_code_metadata_display(CodeMetadata::EMPTY, "Default");
 }
 
 fn check_lower_hex_eq<T: SCLowerHex>(item: T, expected: &str) {

--- a/framework/meta/src/cmd/tx/parse_code_metadata.rs
+++ b/framework/meta/src/cmd/tx/parse_code_metadata.rs
@@ -5,7 +5,7 @@ use crate::cli::cli_args_tx::MetadataArgs;
 /// Build a [`CodeMetadata`] bitfield from the CLI [`MetadataArgs`] flags.
 /// Defaults match standard contract conventions: upgradeable + readable, not payable.
 pub fn parse_code_metadata(meta: &MetadataArgs) -> CodeMetadata {
-    let mut flags = CodeMetadata::DEFAULT;
+    let mut flags = CodeMetadata::EMPTY;
     if !meta.metadata_not_upgradeable {
         flags |= CodeMetadata::UPGRADEABLE;
     }

--- a/framework/scenario/src/api/impl_vh/vh_single_tx_api.rs
+++ b/framework/scenario/src/api/impl_vh/vh_single_tx_api.rs
@@ -12,7 +12,7 @@ use multiversx_chain_vm::{
         vm_hooks::VMHooksContext,
     },
     schedule::GasSchedule,
-    types::{Address, VMCodeMetadata},
+    types::{Address, CodeMetadata},
 };
 
 use crate::executor::debug::ContractDebugInstanceState;
@@ -153,7 +153,7 @@ impl VMHooksContext for SingleTxApiVMHooksContext {
         &mut self,
         _egld_value: num_bigint::BigUint,
         _contract_code: Vec<u8>,
-        _code_metadata: VMCodeMetadata,
+        _code_metadata: CodeMetadata,
         _args: Vec<Vec<u8>>,
     ) -> Result<(Address, Vec<Vec<u8>>), VMHooksEarlyExit> {
         panic!("cannot launch contract calls in the SingleTxApi")

--- a/framework/scenario/src/api/impl_vh/vh_static_api.rs
+++ b/framework/scenario/src/api/impl_vh/vh_static_api.rs
@@ -9,7 +9,7 @@ use multiversx_chain_vm::{
         vm_hooks::VMHooksContext,
     },
     schedule::GasSchedule,
-    types::{Address, VMCodeMetadata},
+    types::{Address, CodeMetadata},
 };
 
 use crate::executor::debug::ContractDebugInstanceState;
@@ -132,7 +132,7 @@ impl VMHooksContext for StaticApiVMHooksContext {
         &mut self,
         _egld_value: num_bigint::BigUint,
         _contract_code: Vec<u8>,
-        _code_metadata: VMCodeMetadata,
+        _code_metadata: CodeMetadata,
         _args: Vec<Vec<u8>>,
     ) -> Result<(Address, Vec<Vec<u8>>), VMHooksEarlyExit> {
         panic!("cannot launch contract calls in the StaticApi")

--- a/framework/scenario/src/scenario/model/transaction/tx_deploy.rs
+++ b/framework/scenario/src/scenario/model/transaction/tx_deploy.rs
@@ -25,7 +25,7 @@ impl Default for TxDeploy {
         Self {
             from: Default::default(),
             egld_value: Default::default(),
-            code_metadata: CodeMetadata::all(),
+            code_metadata: CodeMetadata::default(),
             contract_code: Default::default(),
             arguments: Default::default(),
             gas_limit: U64Value::from(DEFAULT_GAS_EXPR),

--- a/framework/scenario/src/scenario/run_vm/sc_deploy.rs
+++ b/framework/scenario/src/scenario/run_vm/sc_deploy.rs
@@ -2,13 +2,10 @@ use crate::{
     multiversx_sc::types::heap::Address, scenario::model::ScDeployStep, scenario_model::TxResponse,
 };
 
-use multiversx_chain_vm::{
-    host::{
-        context::{TxFunctionName, TxInput, TxResult},
-        execution,
-        runtime::{RuntimeInstanceCallLambda, RuntimeInstanceCallLambdaDefault},
-    },
-    types::VMCodeMetadata,
+use multiversx_chain_vm::host::{
+    context::{TxFunctionName, TxInput, TxResult},
+    execution,
+    runtime::{RuntimeInstanceCallLambda, RuntimeInstanceCallLambdaDefault},
 };
 
 use super::{ScenarioVMRunner, check_tx_output, tx_input_util::generate_tx_hash};

--- a/framework/scenario/src/scenario/run_vm/sc_deploy.rs
+++ b/framework/scenario/src/scenario/run_vm/sc_deploy.rs
@@ -42,7 +42,7 @@ impl ScenarioVMRunner {
         let (new_address, tx_result) = execution::commit_deploy(
             tx_input,
             contract_code,
-            VMCodeMetadata::from(sc_deploy_step.tx.code_metadata.bits()),
+            sc_deploy_step.tx.code_metadata,
             &mut self.blockchain_mock.state,
             &runtime,
             f,

--- a/framework/scenario/src/scenario/run_vm/set_state.rs
+++ b/framework/scenario/src/scenario/run_vm/set_state.rs
@@ -5,14 +5,14 @@ use multiversx_chain_vm::{
         AccountData, AccountEsdt, BlockInfo as CrateBlockInfo, BlockchainState, EsdtData,
         EsdtInstance, EsdtInstanceMetadata, EsdtInstances, EsdtRoles,
     },
-    types::VMCodeMetadata,
+    types::CodeMetadata,
 };
 use multiversx_sc::types::{TimestampMillis, TimestampSeconds};
 
 use super::ScenarioVMRunner;
 
 /// Refers to the default of the "setState" scenario step.
-pub const DEFAULT_CODE_METADATA: VMCodeMetadata = VMCodeMetadata::all();
+pub const DEFAULT_CODE_METADATA: CodeMetadata = CodeMetadata::all();
 
 impl ScenarioVMRunner {
     pub fn perform_set_state(&mut self, set_state_step: &SetStateStep) {
@@ -62,7 +62,7 @@ fn execute(state: &mut BlockchainState, set_state_step: &SetStateStep) {
                 .code_metadata
                 .as_ref()
                 .map(|bytes_value| {
-                    VMCodeMetadata::try_from(&bytes_value.value).expect("invalid CodeMetadata")
+                    CodeMetadata::try_from(&bytes_value.value).expect("invalid CodeMetadata")
                 })
                 .unwrap_or(DEFAULT_CODE_METADATA),
             contract_owner: account

--- a/framework/scenario/src/scenario/run_vm/set_state.rs
+++ b/framework/scenario/src/scenario/run_vm/set_state.rs
@@ -61,7 +61,9 @@ fn execute(state: &mut BlockchainState, set_state_step: &SetStateStep) {
             code_metadata: account
                 .code_metadata
                 .as_ref()
-                .map(|bytes_value| VMCodeMetadata::from(&bytes_value.value))
+                .map(|bytes_value| {
+                    VMCodeMetadata::try_from(&bytes_value.value).expect("invalid CodeMetadata")
+                })
                 .unwrap_or(DEFAULT_CODE_METADATA),
             contract_owner: account
                 .owner

--- a/framework/scenario/src/scenario/run_vm/set_state.rs
+++ b/framework/scenario/src/scenario/run_vm/set_state.rs
@@ -11,9 +11,6 @@ use multiversx_sc::types::{TimestampMillis, TimestampSeconds};
 
 use super::ScenarioVMRunner;
 
-/// Refers to the default of the "setState" scenario step.
-pub const DEFAULT_CODE_METADATA: CodeMetadata = CodeMetadata::all();
-
 impl ScenarioVMRunner {
     pub fn perform_set_state(&mut self, set_state_step: &SetStateStep) {
         execute(&mut self.blockchain_mock.state, set_state_step);
@@ -64,7 +61,7 @@ fn execute(state: &mut BlockchainState, set_state_step: &SetStateStep) {
                 .map(|bytes_value| {
                     CodeMetadata::try_from(&bytes_value.value).expect("invalid CodeMetadata")
                 })
-                .unwrap_or(DEFAULT_CODE_METADATA),
+                .unwrap_or_default(),
             contract_owner: account
                 .owner
                 .as_ref()


### PR DESCRIPTION
## Pull request overview

This PR tightens and clarifies `CodeMetadata` handling across the VM and scenario framework by removing the `VMCodeMetadata` alias, adding stricter conversions (with an explicit error type), and introducing a new `GUARDED` flag.

**Changes:**
- Replace `VMCodeMetadata` with `CodeMetadata` across scenario + VM host APIs and execution paths.
- Add `CodeMetadataError`, strict `TryFrom` conversions, and a lenient `from_bytes_or_default` helper for protocol-mirroring parsing.
- Introduce the `GUARDED` code metadata flag and extend formatting/tests accordingly.
