### PR TITLE
Token id validation fix + refactor + tests

### DIFF
--- a/chain/core/src/token_identifier_util.rs
+++ b/chain/core/src/token_identifier_util.rs
@@ -19,7 +19,6 @@ pub fn validate_token_identifier(token_id_slice: &[u8]) -> bool {
         return false;
     }
 
-    let lowercase_letter_range = b'a'..=b'z';
     let uppercase_letter_range = b'A'..=b'Z';
     let number_range = b'0'..=b'9';
 
@@ -40,13 +39,14 @@ pub fn validate_token_identifier(token_id_slice: &[u8]) -> bool {
         return false;
     }
 
-    // random chars are alphanumeric lowercase
+    // random chars are lowercase hex digits (the suffix is hex-encoded, so only [0-9a-f] is valid)
+    let hex_letter_range = b'a'..=b'f';
     let random_chars = &token_id_slice[(length - ADDITIONAL_RANDOM_CHARS_LENGTH)..];
     for rand_char in random_chars {
-        let is_lowercase_letter = lowercase_letter_range.contains(rand_char);
+        let is_hex_letter = hex_letter_range.contains(rand_char);
         let is_number = number_range.contains(rand_char);
 
-        if !is_lowercase_letter && !is_number {
+        if !is_hex_letter && !is_number {
             return false;
         }
     }

--- a/chain/core/src/token_identifier_util.rs
+++ b/chain/core/src/token_identifier_util.rs
@@ -1,3 +1,16 @@
+/// Error type returned by token identifier validation functions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenIdValidationError {
+    /// Token identifier length is outside the allowed range.
+    InvalidLength,
+    /// Ticker contains a character that is not uppercase alphanumeric.
+    InvalidTickerChar,
+    /// The dash separator is missing or not at the expected position.
+    MissingOrMisplacedDash,
+    /// The random suffix contains a character outside `[0-9a-f]`.
+    InvalidRandomChar,
+}
+
 const TICKER_MIN_LENGTH: usize = 3;
 const TICKER_MAX_LENGTH: usize = 10;
 const ADDITIONAL_RANDOM_CHARS_LENGTH: usize = 6;
@@ -8,52 +21,170 @@ pub const IDENTIFIER_MAX_LENGTH: usize = TICKER_MAX_LENGTH + ADDITIONAL_RANDOM_C
 
 const DASH_CHARACTER: u8 = b'-';
 
-/// There is a VM implementation of this very function.
-/// This implementation is used for debugging mode and backwards compatibility.
-/// Using the VM implementation instead of this one saves ~0.6 kB of contract code.
-pub fn validate_token_identifier(token_id_slice: &[u8]) -> bool {
-    let length = token_id_slice.len();
-
-    #[allow(clippy::manual_range_contains)]
-    if length < IDENTIFIER_MIN_LENGTH || length > IDENTIFIER_MAX_LENGTH {
-        return false;
-    }
-
+/// Validates the ticker portion of a token identifier (uppercase alphanumeric).
+///
+/// Expects `ticker` to be the slice before the dash.
+fn validate_ticker(ticker: &[u8]) -> Result<(), TokenIdValidationError> {
     let uppercase_letter_range = b'A'..=b'Z';
     let number_range = b'0'..=b'9';
 
-    // ticker must be all uppercase alphanumeric
-    let ticker_len = get_token_ticker_len(length);
-    let ticker = &token_id_slice[..ticker_len];
     for ticker_char in ticker {
         let is_uppercase_letter = uppercase_letter_range.contains(ticker_char);
         let is_number = number_range.contains(ticker_char);
 
         if !is_uppercase_letter && !is_number {
-            return false;
+            return Err(TokenIdValidationError::InvalidTickerChar);
         }
     }
 
-    let dash_position = ticker_len;
-    if token_id_slice[dash_position] != DASH_CHARACTER {
-        return false;
-    }
+    Ok(())
+}
 
-    // random chars are lowercase hex digits (the suffix is hex-encoded, so only [0-9a-f] is valid)
+/// Validates the random suffix of a token identifier (lowercase hex digits `[0-9a-f]`).
+///
+/// The suffix is hex-encoded from 3 bytes, so only `[0-9a-f]{6}` is valid.
+fn validate_random_chars(random_chars: &[u8]) -> Result<(), TokenIdValidationError> {
     let hex_letter_range = b'a'..=b'f';
-    let random_chars = &token_id_slice[(length - ADDITIONAL_RANDOM_CHARS_LENGTH)..];
+    let number_range = b'0'..=b'9';
+
     for rand_char in random_chars {
         let is_hex_letter = hex_letter_range.contains(rand_char);
         let is_number = number_range.contains(rand_char);
 
         if !is_hex_letter && !is_number {
-            return false;
+            return Err(TokenIdValidationError::InvalidRandomChar);
         }
     }
 
-    true
+    Ok(())
+}
+
+/// There is a VM implementation of this very function.
+/// This implementation is used for debugging mode and backwards compatibility.
+/// Using the VM implementation instead of this one saves ~0.6 kB of contract code.
+pub fn validate_token_identifier(token_id_slice: &[u8]) -> Result<(), TokenIdValidationError> {
+    let length = token_id_slice.len();
+
+    #[allow(clippy::manual_range_contains)]
+    if length < IDENTIFIER_MIN_LENGTH || length > IDENTIFIER_MAX_LENGTH {
+        return Err(TokenIdValidationError::InvalidLength);
+    }
+
+    // The dash must be at the fixed position separating the ticker from the 6-char suffix.
+    let dash_pos = get_token_ticker_len(length);
+    if token_id_slice[dash_pos] != DASH_CHARACTER {
+        return Err(TokenIdValidationError::MissingOrMisplacedDash);
+    }
+
+    validate_ticker(&token_id_slice[..dash_pos])?;
+
+    validate_random_chars(&token_id_slice[(dash_pos + 1)..])
 }
 
 pub fn get_token_ticker_len(token_id_len: usize) -> usize {
     token_id_len - ADDITIONAL_RANDOM_CHARS_LENGTH - 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TokenIdValidationError, validate_token_identifier};
+
+    fn valid(token_id: &str) {
+        assert_eq!(validate_token_identifier(token_id.as_bytes()), Ok(()));
+    }
+
+    fn invalid(token_id: &str, expected_err: TokenIdValidationError) {
+        assert_eq!(
+            validate_token_identifier(token_id.as_bytes()),
+            Err(expected_err)
+        );
+    }
+
+    #[test]
+    fn test_valid_identifiers() {
+        valid("ALC-6258d2");
+        valid("ALC123-6258d2");
+        valid("12345-6258d2");
+        // max-length ticker (10 chars)
+        valid("EGLDRIDEFL-08d8ef");
+        // number at end of max-length ticker
+        valid("EGLDRIDEF2-08d8ef");
+    }
+
+    #[test]
+    fn test_invalid_length() {
+        // total too short: ticker 0 chars
+        invalid("-6258d2", TokenIdValidationError::InvalidLength);
+        // total too short: ticker 2 chars
+        invalid("AL-6258d2", TokenIdValidationError::InvalidLength);
+        // total too short: no dash, 9 chars
+        invalid("ALC6258d2", TokenIdValidationError::InvalidLength);
+        // total too long: ticker 11 chars
+        invalid("ALCCCCCCCCC-6258d2", TokenIdValidationError::InvalidLength);
+        // total too long: suffix 7 chars
+        invalid("EGLDRIDEFL-08d8eff", TokenIdValidationError::InvalidLength);
+    }
+
+    #[test]
+    fn test_missing_or_misplaced_dash() {
+        // no dash at expected position (valid length, but no dash at pos 3)
+        invalid("ABCX6258d2", TokenIdValidationError::MissingOrMisplacedDash);
+        // dash too early (valid length 10, dash at pos 2, expected at pos 3)
+        invalid("AL-C6258d2", TokenIdValidationError::MissingOrMisplacedDash);
+        // dash too early (valid length 12, dash at pos 3, expected at pos 5)
+        invalid(
+            "ALC-6258d2ff",
+            TokenIdValidationError::MissingOrMisplacedDash,
+        );
+        // dash too late (valid length 16, dash at pos 10, expected at pos 9)
+        invalid(
+            "EGLDRIDEFL-08d8e",
+            TokenIdValidationError::MissingOrMisplacedDash,
+        );
+    }
+
+    #[test]
+    fn test_invalid_ticker_char() {
+        // all lowercase ticker
+        invalid("alc-6258d2", TokenIdValidationError::InvalidTickerChar);
+        // lowercase char in ticker
+        invalid(
+            "EGLDRIDEFl-08d8ef",
+            TokenIdValidationError::InvalidTickerChar,
+        );
+        // special char in ticker
+        invalid(
+            "EGLDRIDEF*-08d8ef",
+            TokenIdValidationError::InvalidTickerChar,
+        );
+        // extra dash inside the ticker (dash at expected pos, but ticker contains a dash)
+        // "AL-C-6258d2" (11 chars): dash_pos=4, ticker="AL-C" → InvalidTickerChar
+        invalid("AL-C-6258d2", TokenIdValidationError::InvalidTickerChar);
+        // "ALC--6258d2" (11 chars): dash_pos=4, ticker="ALC-" → InvalidTickerChar
+        invalid("ALC--6258d2", TokenIdValidationError::InvalidTickerChar);
+        // identifier starting with a dash: dash_pos=3, ticker="-LC" → InvalidTickerChar
+        invalid("-LC-6258d2", TokenIdValidationError::InvalidTickerChar);
+    }
+
+    #[test]
+    fn test_invalid_random_char() {
+        // uppercase char in random part
+        invalid("ALC-6258D2", TokenIdValidationError::InvalidRandomChar);
+        invalid(
+            "EGLDRIDEFL-08d8eF",
+            TokenIdValidationError::InvalidRandomChar,
+        );
+        // special char in random part
+        invalid(
+            "EGLDRIDEFL-08d*ef",
+            TokenIdValidationError::InvalidRandomChar,
+        );
+        // non-hex lowercase letters (g-z) in random part
+        invalid("ABC-ghijkl", TokenIdValidationError::InvalidRandomChar);
+        invalid("ALC-6258g2", TokenIdValidationError::InvalidRandomChar);
+        invalid("ALC-zzzzzz", TokenIdValidationError::InvalidRandomChar);
+        // dash in the random part (dash at expected pos, suffix contains a dash)
+        // "ALC-625-d2" (10 chars): dash_pos=3, ticker="ALC" ✓, suffix="625-d2" → InvalidRandomChar
+        invalid("ALC-625-d2", TokenIdValidationError::InvalidRandomChar);
+    }
 }

--- a/chain/vm/src/host/vm_hooks/vh_handler/vh_blockchain.rs
+++ b/chain/vm/src/host/vm_hooks/vh_handler/vh_blockchain.rs
@@ -554,7 +554,10 @@ impl<C: VMHooksContext> VMHooksHandler<C> {
 
         let m_types = self.context.m_types_lock();
         let token_id = m_types.mb_get(token_id_handle);
-        Ok(multiversx_chain_core::token_identifier_util::validate_token_identifier(token_id))
+        Ok(
+            multiversx_chain_core::token_identifier_util::validate_token_identifier(token_id)
+                .is_ok(),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/framework/scenario/tests/token_id_test.rs
+++ b/framework/scenario/tests/token_id_test.rs
@@ -79,6 +79,12 @@ fn test_is_valid_esdt_identifier() {
     // valid ticker only numbers
     assert!(TokenId::<StaticApi>::from("12345-6258d2").is_valid_esdt_identifier());
 
+    // valid identifier with max-length ticker (10 chars)
+    assert!(TokenId::<StaticApi>::from("EGLDRIDEFL-08d8ef").is_valid_esdt_identifier());
+
+    // valid identifier with number at end of max-length ticker
+    assert!(TokenId::<StaticApi>::from("EGLDRIDEF2-08d8ef").is_valid_esdt_identifier());
+
     // missing dash
     assert!(!TokenId::<StaticApi>::from("ALC6258d2").is_valid_esdt_identifier());
 
@@ -88,11 +94,34 @@ fn test_is_valid_esdt_identifier() {
     // lowercase ticker
     assert!(!TokenId::<StaticApi>::from("alc-6258d2").is_valid_esdt_identifier());
 
+    // lowercase char in ticker
+    assert!(!TokenId::<StaticApi>::from("EGLDRIDEFl-08d8ef").is_valid_esdt_identifier());
+
+    // special char in ticker
+    assert!(!TokenId::<StaticApi>::from("EGLDRIDEF*-08d8ef").is_valid_esdt_identifier());
+
     // uppercase random chars
     assert!(!TokenId::<StaticApi>::from("ALC-6258D2").is_valid_esdt_identifier());
 
+    // uppercase char in random part
+    assert!(!TokenId::<StaticApi>::from("EGLDRIDEFL-08d8eF").is_valid_esdt_identifier());
+
+    // special char in random part
+    assert!(!TokenId::<StaticApi>::from("EGLDRIDEFL-08d*ef").is_valid_esdt_identifier());
+
+    // non-hex lowercase letter in random part (g-z are not valid hex digits)
+    assert!(!TokenId::<StaticApi>::from("ABC-ghijkl").is_valid_esdt_identifier());
+    assert!(!TokenId::<StaticApi>::from("ALC-6258g2").is_valid_esdt_identifier());
+    assert!(!TokenId::<StaticApi>::from("ALC-zzzzzz").is_valid_esdt_identifier());
+
     // too many random chars
     assert!(!TokenId::<StaticApi>::from("ALC-6258d2ff").is_valid_esdt_identifier());
+
+    // too many random chars (7)
+    assert!(!TokenId::<StaticApi>::from("EGLDRIDEFL-08d8eff").is_valid_esdt_identifier());
+
+    // too few random chars (5)
+    assert!(!TokenId::<StaticApi>::from("EGLDRIDEFL-08d8e").is_valid_esdt_identifier());
 
     // ticker too short
     assert!(!TokenId::<StaticApi>::from("AL-6258d2").is_valid_esdt_identifier());


### PR DESCRIPTION
## Pull request overview

This PR tightens ESDT token identifier validation to enforce a lowercase-hex random suffix, refactors the validation logic in `multiversx-chain-core`, and expands test coverage for edge cases (max ticker length, invalid chars, and invalid random suffix content).

**Changes:**
- Refactor `validate_token_identifier` into smaller helpers and return structured validation errors.
- Update the VM hook implementation to adapt to the new validation return type.
- Add/extend tests covering max-length tickers and stricter random-suffix validation (hex-only).
