### PR TITLE
EsdtLocalRole flag fix, docs, tests

### DIFF
--- a/chain/core/src/types/flags/esdt_local_role.rs
+++ b/chain/core/src/types/flags/esdt_local_role.rs
@@ -49,11 +49,13 @@ pub enum EsdtLocalRole {
 }
 
 impl EsdtLocalRole {
-    /// Returns the numeric role ID used for `ManagedVecItem` encoding and VM-hook role flags.
+    /// Returns the 1-based ordinal role ID used for `ManagedVecItem` payload encoding.
     ///
-    /// Values mirror the Go VM's `Role*` iota constants (`RoleMint = 1 << 0` …
-    /// `RoleSetNewURI = 1 << 10`). `Transfer` (12) has no counterpart in the
-    /// current Go VM. This is the inverse of `From<u16>`.
+    /// This is a sequential index (1..=12), **not** a bitflag value. The
+    /// corresponding bitflag in [`EsdtLocalRoleFlags`] is `1 << (id - 1)`, which
+    /// aligns with the Go VM's `Role*` iota ordering in
+    /// `vmhost/vmhooks/eei_helpers.go`. `Transfer` (12) has no counterpart in
+    /// the current Go VM iota. This is the inverse of `From<u16>`.
     pub fn as_u16(&self) -> u16 {
         match self {
             Self::None => 0,

--- a/chain/core/src/types/flags/esdt_local_role.rs
+++ b/chain/core/src/types/flags/esdt_local_role.rs
@@ -18,6 +18,19 @@ const ESDT_ROLE_MODIFY_CREATOR: &str = "ESDTRoleModifyCreator";
 const ESDT_ROLE_NFT_RECREATE: &str = "ESDTRoleNFTRecreate";
 const ESDT_ROLE_TRANSFER: &str = "ESDTTransferRole";
 
+/// An ESDT local role that can be granted to or revoked from an account for a specific token.
+///
+/// Each role has two canonical representations:
+/// - A **byte-string name** (e.g. `"ESDTRoleLocalMint"`) used in on-chain role
+///   assignment, decoded via `From<&[u8]>`.
+/// - A **numeric ID** (`u16`) used for `ManagedVecItem` payload encoding,
+///   accessed via [`as_u16`][EsdtLocalRole::as_u16] and decoded via `From<u16>`.
+///
+/// The numeric IDs and bit-flag positions correspond to the `Role*` iota constants
+/// in `vmhost/vmhooks/eei_helpers.go` of `mx-chain-vm-go`.
+///
+/// The declaration order matches the Go VM `iota` ordering so that the codec
+/// discriminant (declaration index) aligns with [`as_u16`][EsdtLocalRole::as_u16].
 #[derive(TopDecode, TopEncode, NestedDecode, NestedEncode, Clone, PartialEq, Eq, Debug, Copy)]
 pub enum EsdtLocalRole {
     None,
@@ -29,13 +42,18 @@ pub enum EsdtLocalRole {
     NftUpdateAttributes,
     NftAddUri,
     NftRecreate,
-    ModifyRoyalties,
     ModifyCreator,
+    ModifyRoyalties,
     SetNewUri,
     Transfer,
 }
 
 impl EsdtLocalRole {
+    /// Returns the numeric role ID used for `ManagedVecItem` encoding and VM-hook role flags.
+    ///
+    /// Values mirror the Go VM's `Role*` iota constants (`RoleMint = 1 << 0` …
+    /// `RoleSetNewURI = 1 << 10`). `Transfer` (12) has no counterpart in the
+    /// current Go VM. This is the inverse of `From<u16>`.
     pub fn as_u16(&self) -> u16 {
         match self {
             Self::None => 0,
@@ -54,10 +72,17 @@ impl EsdtLocalRole {
         }
     }
 
+    /// Returns the canonical byte-string name of this role (e.g. `b"ESDTRoleLocalMint"`).
+    ///
+    /// This is the format used in on-chain ESDT role grant/revoke operations.
     pub fn as_role_name(&self) -> &'static [u8] {
         self.name().as_bytes()
     }
 
+    /// Returns the canonical string name of this role (e.g. `"ESDTRoleLocalMint"`).
+    ///
+    /// This is the format used in on-chain ESDT role grant/revoke operations and
+    /// corresponds to the role-name constants in the Go VM.
     pub fn name(&self) -> &'static str {
         match self {
             Self::None => ESDT_ROLE_NONE,
@@ -76,6 +101,9 @@ impl EsdtLocalRole {
         }
     }
 
+    /// Converts this role to its corresponding bit-flag in [`EsdtLocalRoleFlags`].
+    ///
+    /// The bit position matches the Go VM's `Role*` iota constant for the same role.
     pub fn to_flag(&self) -> EsdtLocalRoleFlags {
         match self {
             Self::None => EsdtLocalRoleFlags::NONE,
@@ -106,19 +134,24 @@ const ALL_ROLES: [EsdtLocalRole; 12] = [
     EsdtLocalRole::NftUpdateAttributes,
     EsdtLocalRole::NftAddUri,
     EsdtLocalRole::NftRecreate,
-    EsdtLocalRole::ModifyRoyalties,
     EsdtLocalRole::ModifyCreator,
+    EsdtLocalRole::ModifyRoyalties,
     EsdtLocalRole::SetNewUri,
     EsdtLocalRole::Transfer,
 ];
 
 impl EsdtLocalRole {
+    /// Iterates over all non-`None` roles in canonical numeric-ID order.
     pub fn iter_all() -> core::slice::Iter<'static, EsdtLocalRole> {
         ALL_ROLES.iter()
     }
 }
 
 impl From<u16> for EsdtLocalRole {
+    /// Decodes a numeric role ID into an [`EsdtLocalRole`].
+    ///
+    /// This is the inverse of [`EsdtLocalRole::as_u16`]. Unknown values map to
+    /// [`EsdtLocalRole::None`].
     #[inline]
     fn from(value: u16) -> Self {
         match value {
@@ -130,8 +163,8 @@ impl From<u16> for EsdtLocalRole {
             6 => Self::NftUpdateAttributes,
             7 => Self::NftAddUri,
             8 => Self::NftRecreate,
-            9 => Self::ModifyRoyalties,
-            10 => Self::ModifyCreator,
+            9 => Self::ModifyCreator,
+            10 => Self::ModifyRoyalties,
             11 => Self::SetNewUri,
             12 => Self::Transfer,
             _ => Self::None,
@@ -140,6 +173,11 @@ impl From<u16> for EsdtLocalRole {
 }
 
 impl<'a> From<&'a [u8]> for EsdtLocalRole {
+    /// Decodes an ESDT role from its canonical byte-string name
+    /// (e.g. `b"ESDTRoleLocalMint"`).
+    ///
+    /// This is the primary decoding path for on-chain ESDT role data. Unknown
+    /// byte strings map to [`EsdtLocalRole::None`].
     #[inline]
     fn from(byte_slice: &'a [u8]) -> Self {
         if byte_slice == ESDT_ROLE_LOCAL_MINT.as_bytes() {

--- a/chain/core/src/types/flags/esdt_local_role_flags.rs
+++ b/chain/core/src/types/flags/esdt_local_role_flags.rs
@@ -2,7 +2,29 @@ use super::EsdtLocalRole;
 use bitflags::bitflags;
 
 bitflags! {
-    #[derive(PartialEq, Clone, Copy)]
+    /// Bit-flag representation of ESDT local roles.
+    ///
+    /// Each flag corresponds to a `Role*` constant defined in the Go VM at
+    /// `vmhost/vmhooks/eei_helpers.go` (`mx-chain-vm-go`), where the same
+    /// values are produced via `1 << iota` starting from `RoleMint = 1`.
+    ///
+    /// Correspondence table (Rust flag → Go constant → bit):
+    ///
+    /// | Rust flag              | Go constant             | Bit |
+    /// |------------------------|--------------------------|----|
+    /// | `MINT`                 | `RoleMint`               |  0 |
+    /// | `BURN`                 | `RoleBurn`               |  1 |
+    /// | `NFT_CREATE`           | `RoleNFTCreate`          |  2 |
+    /// | `NFT_ADD_QUANTITY`     | `RoleNFTAddQuantity`     |  3 |
+    /// | `NFT_BURN`             | `RoleNFTBurn`            |  4 |
+    /// | `NFT_UPDATE_ATTRIBUTES`| `RoleNFTUpdateAttributes`|  5 |
+    /// | `NFT_ADD_URI`          | `RoleNFTAddURI`          |  6 |
+    /// | `NFT_RECREATE`         | `RoleNFTRecreate`        |  7 |
+    /// | `MODIFY_CREATOR`       | `RoleModifyCreator`      |  8 |
+    /// | `MODIFY_ROYALTIES`     | `RoleModifyRoyalties`    |  9 |
+    /// | `SET_NEW_URI`          | `RoleSetNewURI`          | 10 |
+    /// | `TRANSFER`             | *(not yet in Go VM)*     | 11 |
+    #[derive(PartialEq, Clone, Copy, Debug)]
     pub struct EsdtLocalRoleFlags: u64 {
         const NONE                  = 0b00000000_00000000;
         const MINT                  = 0b00000000_00000001;
@@ -22,10 +44,14 @@ bitflags! {
 }
 
 impl EsdtLocalRoleFlags {
+    /// Returns `true` if this flag set contains the bit corresponding to `role`.
     pub fn has_role(&self, role: &EsdtLocalRole) -> bool {
         *self & role.to_flag() != EsdtLocalRoleFlags::NONE
     }
 
+    /// Iterates over all [`EsdtLocalRole`] variants whose bit is set in this flag set.
+    ///
+    /// Roles are yielded in canonical numeric-ID order (see [`EsdtLocalRole::iter_all`]).
     pub fn iter_roles(&self) -> impl Iterator<Item = &EsdtLocalRole> {
         EsdtLocalRole::iter_all().filter(move |role| self.has_role(role))
     }

--- a/chain/core/tests/esdt_local_role_test.rs
+++ b/chain/core/tests/esdt_local_role_test.rs
@@ -1,7 +1,7 @@
 use multiversx_chain_core::types::{EsdtLocalRole, EsdtLocalRoleFlags};
 
 /// Every non-None role paired with its expected numeric ID, canonical name,
-/// and expected flag bit.  This is the single source of truth for all
+/// and expected flag bit. This is the single source of truth for all
 /// round-trip checks below.
 #[rustfmt::skip]
 const ROLE_TABLE: &[(EsdtLocalRole, u16, &str, EsdtLocalRoleFlags)] = &[

--- a/chain/core/tests/esdt_local_role_test.rs
+++ b/chain/core/tests/esdt_local_role_test.rs
@@ -1,0 +1,148 @@
+use multiversx_chain_core::types::{EsdtLocalRole, EsdtLocalRoleFlags};
+
+/// Every non-None role paired with its expected numeric ID, canonical name,
+/// and expected flag bit.  This is the single source of truth for all
+/// round-trip checks below.
+#[rustfmt::skip]
+const ROLE_TABLE: &[(EsdtLocalRole, u16, &str, EsdtLocalRoleFlags)] = &[
+    (EsdtLocalRole::Mint,                1,  "ESDTRoleLocalMint",          EsdtLocalRoleFlags::MINT),
+    (EsdtLocalRole::Burn,                2,  "ESDTRoleLocalBurn",          EsdtLocalRoleFlags::BURN),
+    (EsdtLocalRole::NftCreate,           3,  "ESDTRoleNFTCreate",          EsdtLocalRoleFlags::NFT_CREATE),
+    (EsdtLocalRole::NftAddQuantity,      4,  "ESDTRoleNFTAddQuantity",     EsdtLocalRoleFlags::NFT_ADD_QUANTITY),
+    (EsdtLocalRole::NftBurn,             5,  "ESDTRoleNFTBurn",            EsdtLocalRoleFlags::NFT_BURN),
+    (EsdtLocalRole::NftUpdateAttributes, 6,  "ESDTRoleNFTUpdateAttributes",EsdtLocalRoleFlags::NFT_UPDATE_ATTRIBUTES),
+    (EsdtLocalRole::NftAddUri,           7,  "ESDTRoleNFTAddURI",          EsdtLocalRoleFlags::NFT_ADD_URI),
+    (EsdtLocalRole::NftRecreate,         8,  "ESDTRoleNFTRecreate",        EsdtLocalRoleFlags::NFT_RECREATE),
+    (EsdtLocalRole::ModifyCreator,       9,  "ESDTRoleModifyCreator",      EsdtLocalRoleFlags::MODIFY_CREATOR),
+    (EsdtLocalRole::ModifyRoyalties,     10, "ESDTRoleModifyRoyalties",    EsdtLocalRoleFlags::MODIFY_ROYALTIES),
+    (EsdtLocalRole::SetNewUri,           11, "ESDTRoleSetNewURI",          EsdtLocalRoleFlags::SET_NEW_URI),
+    (EsdtLocalRole::Transfer,            12, "ESDTTransferRole",           EsdtLocalRoleFlags::TRANSFER),
+];
+
+#[test]
+fn test_none_role() {
+    assert_eq!(EsdtLocalRole::None.as_u16(), 0);
+    assert_eq!(EsdtLocalRole::None.name(), "");
+    assert_eq!(EsdtLocalRole::None.as_role_name(), b"");
+    assert_eq!(EsdtLocalRole::None.to_flag(), EsdtLocalRoleFlags::NONE);
+}
+
+#[test]
+fn test_as_u16() {
+    for (role, id, _, _) in ROLE_TABLE {
+        assert_eq!(role.as_u16(), *id, "{role:?}.as_u16()");
+    }
+}
+
+#[test]
+fn test_from_u16_round_trip() {
+    for (role, id, _, _) in ROLE_TABLE {
+        assert_eq!(EsdtLocalRole::from(*id), *role, "from({})", id);
+    }
+}
+
+#[test]
+fn test_from_u16_unknown_returns_none() {
+    assert_eq!(EsdtLocalRole::from(0u16), EsdtLocalRole::None);
+    assert_eq!(EsdtLocalRole::from(13u16), EsdtLocalRole::None);
+    assert_eq!(EsdtLocalRole::from(u16::MAX), EsdtLocalRole::None);
+}
+
+/// `as_u16` and `From<u16>` must be exact inverses for every defined role.
+#[test]
+fn test_u16_round_trip_both_directions() {
+    for (role, _, _, _) in ROLE_TABLE {
+        let id = role.as_u16();
+        assert_eq!(&EsdtLocalRole::from(id), role, "round-trip for {role:?}");
+    }
+}
+
+#[test]
+fn test_name_and_as_role_name() {
+    for (role, _, name, _) in ROLE_TABLE {
+        assert_eq!(role.name(), *name, "{role:?}.name()");
+        assert_eq!(
+            role.as_role_name(),
+            name.as_bytes(),
+            "{role:?}.as_role_name()"
+        );
+    }
+}
+
+#[test]
+fn test_from_byte_slice_round_trip() {
+    for (role, _, name, _) in ROLE_TABLE {
+        let decoded = EsdtLocalRole::from(name.as_bytes());
+        assert_eq!(decoded, *role, "from(b\"{name}\")");
+    }
+}
+
+#[test]
+fn test_from_byte_slice_unknown_returns_none() {
+    assert_eq!(EsdtLocalRole::from(b"".as_ref()), EsdtLocalRole::None);
+    assert_eq!(
+        EsdtLocalRole::from(b"unknown".as_ref()),
+        EsdtLocalRole::None
+    );
+    // Ensure a near-match (extra char) does not decode as a valid role.
+    assert_eq!(
+        EsdtLocalRole::from(b"ESDTRoleLocalMintX".as_ref()),
+        EsdtLocalRole::None,
+    );
+}
+
+/// `name()` and `From<&[u8]>` must be exact inverses for every defined role.
+#[test]
+fn test_byte_slice_round_trip_both_directions() {
+    for (role, _, _, _) in ROLE_TABLE {
+        let name = role.name();
+        assert_eq!(
+            &EsdtLocalRole::from(name.as_bytes()),
+            role,
+            "round-trip for {role:?}",
+        );
+    }
+}
+
+#[test]
+fn test_to_flag() {
+    for (role, _, _, flag) in ROLE_TABLE {
+        assert_eq!(role.to_flag(), *flag, "{role:?}.to_flag()");
+    }
+    assert_eq!(EsdtLocalRole::None.to_flag(), EsdtLocalRoleFlags::NONE);
+}
+
+/// `ModifyCreator` (9) and `ModifyRoyalties` (10) are the historically
+/// swapped pair — verify both directions explicitly.
+#[test]
+fn test_modify_creator_and_modify_royalties_not_swapped() {
+    assert_eq!(EsdtLocalRole::ModifyCreator.as_u16(), 9);
+    assert_eq!(EsdtLocalRole::ModifyRoyalties.as_u16(), 10);
+    assert_eq!(EsdtLocalRole::from(9u16), EsdtLocalRole::ModifyCreator);
+    assert_eq!(EsdtLocalRole::from(10u16), EsdtLocalRole::ModifyRoyalties);
+    assert_eq!(
+        EsdtLocalRole::from(b"ESDTRoleModifyCreator".as_ref()),
+        EsdtLocalRole::ModifyCreator,
+    );
+    assert_eq!(
+        EsdtLocalRole::from(b"ESDTRoleModifyRoyalties".as_ref()),
+        EsdtLocalRole::ModifyRoyalties,
+    );
+    assert_eq!(
+        EsdtLocalRole::ModifyCreator.to_flag(),
+        EsdtLocalRoleFlags::MODIFY_CREATOR,
+    );
+    assert_eq!(
+        EsdtLocalRole::ModifyRoyalties.to_flag(),
+        EsdtLocalRoleFlags::MODIFY_ROYALTIES,
+    );
+}
+
+#[test]
+fn test_iter_all_order_and_completeness() {
+    let roles: Vec<EsdtLocalRole> = EsdtLocalRole::iter_all().copied().collect();
+    assert_eq!(roles.len(), ROLE_TABLE.len());
+    for (idx, (expected_role, _, _, _)) in ROLE_TABLE.iter().enumerate() {
+        assert_eq!(roles[idx], *expected_role, "iter_all position {idx}");
+    }
+}


### PR DESCRIPTION
## Pull request overview

This PR fixes the historically swapped `ModifyCreator`/`ModifyRoyalties` mapping for `EsdtLocalRole` numeric IDs/flags, and strengthens the contract around role encoding/decoding by adding documentation and comprehensive round-trip tests.

**Changes:**
- Reordered `EsdtLocalRole` variants and updated `From<u16>` mapping so IDs 9/10 correctly map to `ModifyCreator`/`ModifyRoyalties`.
- Expanded Rustdoc for `EsdtLocalRole` and `EsdtLocalRoleFlags` to clarify canonical representations and Go VM correspondence.
- Added an integration test suite to validate `as_u16`, name/byte decoding, flag conversion, and `iter_all()` ordering.
