### PR TITLE
codec - trait default implementation cleanup

### DIFF
--- a/data/codec/src/single/nested_de.rs
+++ b/data/codec/src/single/nested_de.rs
@@ -17,13 +17,7 @@ pub trait NestedDecode: Sized {
     fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> Result<Self, H::HandledErr>
     where
         I: NestedDecodeInput,
-        H: DecodeErrorHandler,
-    {
-        match Self::dep_decode(input) {
-            Ok(v) => Ok(v),
-            Err(e) => Err(h.handle_error(e)),
-        }
-    }
+        H: DecodeErrorHandler;
 
     /// Allows the framework to do monomorphisation of special cases where the data is of type `u8`.
     ///

--- a/data/codec/src/single/nested_en.rs
+++ b/data/codec/src/single/nested_en.rs
@@ -18,13 +18,7 @@ pub trait NestedEncode: Sized {
     fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, h: H) -> Result<(), H::HandledErr>
     where
         O: NestedEncodeOutput,
-        H: EncodeErrorHandler,
-    {
-        match self.dep_encode(dest) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(h.handle_error(e)),
-        }
-    }
+        H: EncodeErrorHandler;
 
     /// Allows the framework to do monomorphisation of special cases where the data is of type `u8`.
     ///

--- a/data/codec/src/single/top_de.rs
+++ b/data/codec/src/single/top_de.rs
@@ -33,13 +33,7 @@ pub trait TopDecode: Sized {
     fn top_decode_or_handle_err<I, H>(input: I, h: H) -> Result<Self, H::HandledErr>
     where
         I: TopDecodeInput,
-        H: DecodeErrorHandler,
-    {
-        match Self::top_decode(input) {
-            Ok(v) => Ok(v),
-            Err(e) => Err(h.handle_error(e)),
-        }
-    }
+        H: DecodeErrorHandler;
 
     /// Allows types to provide optimized implementations for their boxed version.
     /// Especially designed for byte arrays that can be transmuted directly from the input sometimes.

--- a/data/codec/src/single/top_en.rs
+++ b/data/codec/src/single/top_en.rs
@@ -20,13 +20,7 @@ pub trait TopEncode: Sized {
     fn top_encode_or_handle_err<O, H>(&self, output: O, h: H) -> Result<(), H::HandledErr>
     where
         O: TopEncodeOutput,
-        H: EncodeErrorHandler,
-    {
-        match self.top_encode(output) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(h.handle_error(e)),
-        }
-    }
+        H: EncodeErrorHandler;
 }
 
 pub fn top_encode_from_nested<T, O, H>(obj: &T, output: O, h: H) -> Result<(), H::HandledErr>

--- a/framework/scenario/src/scenario/model/value/bytes_value.rs
+++ b/framework/scenario/src/scenario/model/value/bytes_value.rs
@@ -1,5 +1,5 @@
 use multiversx_sc::{
-    codec::{EncodeError, TopEncode, TopEncodeOutput},
+    codec::{EncodeErrorHandler, TopEncode, TopEncodeOutput},
     types::{AnnotatedValue, ManagedBuffer, TxCodeValue, TxEnv},
 };
 
@@ -163,11 +163,12 @@ impl fmt::Display for BytesValue {
 }
 
 impl TopEncode for BytesValue {
-    fn top_encode<O>(&self, output: O) -> Result<(), EncodeError>
+    fn top_encode_or_handle_err<O, H>(&self, output: O, h: H) -> Result<(), H::HandledErr>
     where
         O: TopEncodeOutput,
+        H: EncodeErrorHandler,
     {
-        self.value.top_encode(output)
+        self.value.top_encode_or_handle_err(output, h)
     }
 }
 


### PR DESCRIPTION
## Pull request overview

This PR refactors the codec traits’ default implementations by removing the default bodies of the `*_or_handle_err` methods (making them required) and instead providing defaults for the simpler `top_encode`/`top_decode`/`dep_encode`/`dep_decode` methods that delegate to the handler-based variants. It also updates one scenario value type to implement the new required method.

**Changes:**
- Make `TopEncode::top_encode_or_handle_err`, `TopDecode::top_decode_or_handle_err`, `NestedEncode::dep_encode_or_handle_err`, and `NestedDecode::dep_decode_or_handle_err` required trait methods by removing their default implementations.
- Provide/keep default implementations for `top_encode`/`top_decode`/`dep_encode`/`dep_decode` that call the handler-based variants with `DefaultErrorHandler`.
- Update `BytesValue` to implement `TopEncode::top_encode_or_handle_err` and adjust imports accordingly.
