### PR TITLE
ManagedVec slice + DebugApi issue fix

### DIFF
--- a/framework/base/src/types/interaction/managed_arg_buffer.rs
+++ b/framework/base/src/types/interaction/managed_arg_buffer.rs
@@ -1,6 +1,6 @@
 use crate::{
     abi::{TypeAbi, TypeAbiFrom, TypeName},
-    api::{ErrorApi, ManagedTypeApi, ManagedTypeApiImpl, use_raw_handle},
+    api::{ErrorApi, ManagedTypeApi, use_raw_handle},
     codec::{
         DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
         NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeMultiOutput,
@@ -342,7 +342,7 @@ where
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/multi_value/egld_or_esdt_token_payment_multi_value.rs
+++ b/framework/base/src/types/managed/multi_value/egld_or_esdt_token_payment_multi_value.rs
@@ -1,6 +1,5 @@
 use crate::{
     abi::TypeAbiFrom,
-    api::ManagedTypeApiImpl,
     codec::{
         DecodeErrorHandler, EncodeErrorHandler, MultiValueConstLength, TopDecodeMulti,
         TopDecodeMultiInput, TopEncodeMulti, TopEncodeMultiOutput, multi_types::MultiValue3,
@@ -53,7 +52,7 @@ impl<M: ManagedTypeApi> ManagedVecItem for EgldOrEsdtTokenPaymentMultiValue<M> {
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/multi_value/esdt_token_payment_multi_value.rs
+++ b/framework/base/src/types/managed/multi_value/esdt_token_payment_multi_value.rs
@@ -1,6 +1,5 @@
 use crate::{
     abi::TypeAbiFrom,
-    api::ManagedTypeApiImpl,
     codec::{
         DecodeErrorHandler, EncodeErrorHandler, MultiValueConstLength, TopDecodeMulti,
         TopDecodeMultiInput, TopEncodeMulti, TopEncodeMultiOutput, multi_types::MultiValue3,
@@ -59,7 +58,7 @@ impl<M: ManagedTypeApi> ManagedVecItem for EsdtTokenPaymentMultiValue<M> {
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/multi_value/multi_value_managed_vec_counted.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_managed_vec_counted.rs
@@ -2,7 +2,7 @@ use core::borrow::Borrow;
 
 use crate::{
     abi::{TypeAbi, TypeAbiFrom, TypeDescriptionContainer, TypeName},
-    api::{ManagedTypeApi, ManagedTypeApiImpl},
+    api::ManagedTypeApi,
     codec::{
         DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput,
         TopEncodeMulti, TopEncodeMultiOutput,
@@ -113,7 +113,7 @@ where
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/multi_value/payment_multi_value.rs
+++ b/framework/base/src/types/managed/multi_value/payment_multi_value.rs
@@ -1,6 +1,5 @@
 use crate::{
     abi::TypeAbiFrom,
-    api::ManagedTypeApiImpl,
     codec::{
         DecodeErrorHandler, EncodeErrorHandler, MultiValueConstLength, TopDecodeMulti,
         TopDecodeMultiInput, TopEncodeMulti, TopEncodeMultiOutput, multi_types::MultiValue3,
@@ -53,7 +52,7 @@ impl<M: ManagedTypeApi> ManagedVecItem for PaymentMultiValue<M> {
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/wrapped/decimal/managed_decimal.rs
+++ b/framework/base/src/types/managed/wrapped/decimal/managed_decimal.rs
@@ -7,7 +7,7 @@ use multiversx_sc_codec::{
 
 use crate::{
     abi::{TypeAbi, TypeAbiFrom, TypeName},
-    api::{ManagedTypeApi, ManagedTypeApiImpl, quick_signal_error},
+    api::{ManagedTypeApi, quick_signal_error},
     err_msg,
     formatter::{FormatBuffer, FormatByteReceiver, SCDisplay},
     typenum::{U4, U8, Unsigned},
@@ -327,7 +327,7 @@ impl<M: ManagedTypeApi> ManagedVecItem for ManagedDecimal<M, NumDecimals> {
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 
@@ -353,7 +353,7 @@ impl<M: ManagedTypeApi, DECIMALS: Unsigned> ManagedVecItem
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/wrapped/decimal/managed_decimal_signed.rs
+++ b/framework/base/src/types/managed/wrapped/decimal/managed_decimal_signed.rs
@@ -2,7 +2,7 @@ use crate::{
     abi::{TypeAbi, TypeAbiFrom, TypeName},
     api::{
         BigFloatApiImpl, BigIntApiImpl, HandleConstraints, ManagedBufferApiImpl, ManagedTypeApi,
-        ManagedTypeApiImpl, const_handles, use_raw_handle,
+        const_handles, use_raw_handle,
     },
     err_msg,
     formatter::{FormatBuffer, FormatByteReceiver, SCDisplay},
@@ -273,7 +273,7 @@ impl<M: ManagedTypeApi> ManagedVecItem for ManagedDecimalSigned<M, NumDecimals> 
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 
@@ -299,7 +299,7 @@ impl<M: ManagedTypeApi, DECIMALS: Unsigned> ManagedVecItem
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/wrapped/managed_option.rs
+++ b/framework/base/src/types/managed/wrapped/managed_option.rs
@@ -4,7 +4,7 @@ use generic_array::typenum::U4;
 
 use crate::{
     abi::TypeAbiFrom,
-    api::{HandleConstraints, ManagedTypeApiImpl},
+    api::HandleConstraints,
     codec::{
         DecodeErrorHandler, EncodeErrorHandler, NestedDecode, NestedDecodeInput, NestedEncode,
         NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode, TopEncodeOutput,
@@ -223,7 +223,7 @@ where
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/wrapped/managed_vec.rs
+++ b/framework/base/src/types/managed/wrapped/managed_vec.rs
@@ -350,9 +350,10 @@ where
     ///
     /// # Safety
     ///
-    /// Only safe when `T::requires_drop() == false` (e.g. all non-`StaticApi` backends).
-    /// In all other cases, both the original vec and the returned slice will hold aliased
-    /// handle integers, and both will attempt to free those handles on drop — causing a
+    /// Only safe when `T::requires_drop() == false` (i.e. `T` stores no VM-level handles —
+    /// plain integers, fixed-size POD structs, etc.). When `T::requires_drop() == true`,
+    /// copying raw bytes aliases the handle integers stored in the payload; both the original
+    /// vec and the returned vec will attempt to free the same VM objects on drop, causing a
     /// double-free. Use the safe [`clone_range`] method instead.
     unsafe fn slice_no_copy_unchecked(&self, start_index: usize, end_index: usize) -> Option<Self> {
         let byte_start = start_index * T::payload_size();

--- a/framework/base/src/types/managed/wrapped/managed_vec.rs
+++ b/framework/base/src/types/managed/wrapped/managed_vec.rs
@@ -694,6 +694,10 @@ where
     T: ManagedVecItem + Clone,
 {
     fn clone(&self) -> Self {
+        if !T::requires_drop() {
+            return ManagedVec::new_from_raw_buffer(self.buffer.clone());
+        }
+
         let mut result = ManagedVec::new();
         for item in self.into_iter() {
             result.push(item.borrow().clone())

--- a/framework/base/src/types/managed/wrapped/managed_vec.rs
+++ b/framework/base/src/types/managed/wrapped/managed_vec.rs
@@ -1,7 +1,7 @@
 use super::{EncodedManagedVecItem, ManagedVecItemPayload};
 use crate::{
     abi::{TypeAbi, TypeAbiFrom, TypeDescriptionContainer, TypeName},
-    api::{ErrorApiImpl, InvalidSliceError, ManagedTypeApi},
+    api::{ErrorApiImpl, InvalidSliceError, ManagedTypeApi, ManagedTypeApiImpl},
     codec::{
         DecodeErrorHandler, EncodeErrorHandler, IntoMultiValue, NestedDecode, NestedDecodeInput,
         NestedEncode, NestedEncodeOutput, TopDecode, TopDecodeInput, TopEncode,
@@ -675,7 +675,7 @@ where
             let (dedup, tail) = slice.split_at_mut(next_write);
             // Drop the duplicate items moved into the tail, so their handles are freed
             // before the buffer is truncated to the dedup length.
-            if T::requires_drop() {
+            if T::requires_drop() && M::managed_type_impl().requires_managed_type_drop() {
                 for tail_item in tail.iter() {
                     unsafe {
                         let item = T::read_from_payload(&tail_item.encoded);
@@ -780,7 +780,7 @@ where
 {
     unsafe fn drop_items(&mut self) {
         unsafe {
-            if T::requires_drop() {
+            if T::requires_drop() && M::managed_type_impl().requires_managed_type_drop() {
                 let iter = ManagedVecPayloadIterator::<M, T::PAYLOAD>::new(self.get_handle());
                 for payload in iter {
                     let item = T::read_from_payload(&payload);

--- a/framework/base/src/types/managed/wrapped/managed_vec.rs
+++ b/framework/base/src/types/managed/wrapped/managed_vec.rs
@@ -292,13 +292,26 @@ where
         Ok(old_item)
     }
 
-    /// Returns a new `ManagedVec`, containing the [start_index, end_index) range of elements.
-    /// Returns `None` if any index is out of range.
+    /// Returns a new `ManagedVec` containing the elements in the half-open range
+    /// `[start_index, end_index)`. Returns `None` if the range is invalid
+    /// (`start_index > end_index` or `end_index > self.len()`).
     ///
-    /// Note: for managed types that require handle-level drop (e.g. under `StaticApi`),
-    /// this performs a deep copy of each item so that both the original and the slice
-    /// hold independently owned handles.
-    pub fn slice(&self, start_index: usize, end_index: usize) -> Option<Self>
+    /// ## Cloning strategy
+    ///
+    /// The implementation chooses between two paths based on whether `T` owns
+    /// VM-level resources (i.e. `T::requires_drop()`):
+    ///
+    /// - **Copy-like types** (`T::requires_drop() == false`, e.g. `u32`, `u64`,
+    ///   fixed-size structs of plain integers): the relevant slice of the underlying
+    ///   managed buffer is copied in a single VM call. No per-item work is done.
+    ///
+    /// - **Handle-owning types** (`T::requires_drop() == true`, e.g. `BigUint`,
+    ///   `ManagedBuffer`, or any struct containing them): copying raw bytes would
+    ///   alias the integer handles stored in the payload, causing both the original
+    ///   vec and the returned vec to attempt freeing the same VM object on drop
+    ///   (double-free). Instead each item in the range is cloned individually,
+    ///   allocating a fresh independent VM object for every element.
+    pub fn clone_range(&self, start_index: usize, end_index: usize) -> Option<Self>
     where
         T: Clone,
     {
@@ -323,6 +336,15 @@ where
         }
     }
 
+    /// Deprecated alias for [`clone_range`].
+    #[deprecated(since = "0.66.2", note = "Please use method `clone_range` instead.")]
+    pub fn slice(&self, start_index: usize, end_index: usize) -> Option<Self>
+    where
+        T: Clone,
+    {
+        self.clone_range(start_index, end_index)
+    }
+
     /// Returns a new `ManagedVec`, containing the [start_index, end_index) range of elements.
     /// Returns `None` if any index is out of range.
     ///
@@ -331,7 +353,7 @@ where
     /// Only safe when `T::requires_drop() == false` (e.g. all non-`StaticApi` backends).
     /// In all other cases, both the original vec and the returned slice will hold aliased
     /// handle integers, and both will attempt to free those handles on drop — causing a
-    /// double-free. Use the safe [`slice`] method instead.
+    /// double-free. Use the safe [`clone_range`] method instead.
     unsafe fn slice_no_copy_unchecked(&self, start_index: usize, end_index: usize) -> Option<Self> {
         let byte_start = start_index * T::payload_size();
         let byte_end = end_index * T::payload_size();

--- a/framework/base/src/types/managed/wrapped/managed_vec_item.rs
+++ b/framework/base/src/types/managed/wrapped/managed_vec_item.rs
@@ -11,7 +11,7 @@ use multiversx_chain_core::types::{
 use multiversx_sc_codec::multi_types::{MultiValue2, MultiValue3};
 
 use crate::{
-    api::{HandleConstraints, ManagedTypeApi, ManagedTypeApiImpl, use_raw_handle},
+    api::{HandleConstraints, ManagedTypeApi, use_raw_handle},
     types::{
         BigInt, BigUint, EllipticCurve, EsdtTokenIdentifier, ManagedAddress, ManagedBuffer,
         ManagedByteArray, ManagedRef, ManagedType, ManagedVec, NonZeroBigUint, TokenId,
@@ -304,7 +304,7 @@ macro_rules! impl_managed_type {
             }
 
             fn requires_drop() -> bool {
-                M::managed_type_impl().requires_managed_type_drop()
+                true
             }
         }
     };
@@ -346,7 +346,7 @@ where
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 
@@ -377,7 +377,7 @@ where
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/wrapped/token/egld_or_esdt_token_payment.rs
+++ b/framework/base/src/types/managed/wrapped/token/egld_or_esdt_token_payment.rs
@@ -3,7 +3,7 @@ use multiversx_sc_codec::IntoMultiValue;
 
 use crate::{
     abi::TypeAbiFrom,
-    api::{ManagedTypeApi, ManagedTypeApiImpl},
+    api::ManagedTypeApi,
     types::{
         BigUint, EgldOrEsdtTokenIdentifier, EgldOrEsdtTokenPaymentMultiValue,
         EgldOrEsdtTokenPaymentRefs, EsdtTokenPayment, EsdtTokenPaymentRefs, ManagedVecItem,
@@ -180,6 +180,6 @@ impl<M: ManagedTypeApi> ManagedVecItem for EgldOrEsdtTokenPayment<M> {
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }

--- a/framework/base/src/types/managed/wrapped/token/esdt_token_payment.rs
+++ b/framework/base/src/types/managed/wrapped/token/esdt_token_payment.rs
@@ -1,7 +1,7 @@
 use generic_array::typenum::U16;
 
 use crate::{
-    api::{ManagedTypeApi, ManagedTypeApiImpl},
+    api::ManagedTypeApi,
     types::{
         BigUint, EsdtTokenIdentifier, EsdtTokenPaymentMultiValue, EsdtTokenType, ManagedType,
         ManagedVec, ManagedVecItem, ManagedVecItemPayloadBuffer, Payment, PaymentVec, Ref,
@@ -265,7 +265,7 @@ impl<M: ManagedTypeApi> ManagedVecItem for EsdtTokenPayment<M> {
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }
 

--- a/framework/base/src/types/managed/wrapped/token/fungible_payment.rs
+++ b/framework/base/src/types/managed/wrapped/token/fungible_payment.rs
@@ -2,7 +2,7 @@ use generic_array::typenum::U8;
 
 use crate::{
     abi::{TypeAbi, TypeAbiFrom, TypeName},
-    api::{ManagedTypeApi, ManagedTypeApiImpl},
+    api::ManagedTypeApi,
     codec::{
         self,
         derive::{NestedDecode, NestedEncode, TopDecode, TopEncode},
@@ -80,6 +80,6 @@ impl<M: ManagedTypeApi> ManagedVecItem for FungiblePayment<M> {
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }

--- a/framework/base/src/types/managed/wrapped/token/payment.rs
+++ b/framework/base/src/types/managed/wrapped/token/payment.rs
@@ -3,7 +3,7 @@ use multiversx_sc_codec::IntoMultiValue;
 
 use crate::{
     abi::{TypeAbi, TypeAbiFrom, TypeName},
-    api::{ErrorApiImpl, ManagedTypeApi, ManagedTypeApiImpl},
+    api::{ErrorApiImpl, ManagedTypeApi},
     codec::{
         self, NestedDecode, TopDecode,
         derive::{NestedEncode, TopEncode},
@@ -354,6 +354,6 @@ impl<M: ManagedTypeApi> ManagedVecItem for Payment<M> {
     }
 
     fn requires_drop() -> bool {
-        M::managed_type_impl().requires_managed_type_drop()
+        true
     }
 }

--- a/framework/scenario/tests/managed_vec_test.rs
+++ b/framework/scenario/tests/managed_vec_test.rs
@@ -556,6 +556,48 @@ fn test_append_vec() {
 }
 
 #[test]
+fn test_clone_u32_non_drop_path() {
+    assert!(!<u32 as multiversx_sc::types::ManagedVecItem>::requires_drop());
+
+    let mut original = ManagedVec::<StaticApi, u32>::new();
+    original.push(10u32);
+    original.push(20u32);
+    original.push(30u32);
+
+    let mut cloned = original.clone();
+    assert_eq!(cloned, original);
+
+    let old = cloned.set(1, 99u32).unwrap();
+    assert_eq!(old, 20u32);
+
+    // Mutating the clone must not affect the source.
+    assert_eq!(cloned.get(1), 99u32);
+    assert_eq!(original.get(1), 20u32);
+}
+
+#[test]
+fn test_clone_biguint_drop_path() {
+    assert!(<BigUint<StaticApi> as multiversx_sc::types::ManagedVecItem>::requires_drop());
+
+    let mut original = ManagedVec::<StaticApi, BigUint<StaticApi>>::new();
+    original.push(BigUint::from(10u64));
+    original.push(BigUint::from(20u64));
+    original.push(BigUint::from(30u64));
+
+    let mut cloned = original.clone();
+    assert_eq!(cloned, original);
+
+    {
+        let mut first = cloned.get_mut(0);
+        *first += 100u64;
+    }
+
+    // Clone changes are independent from source for managed, drop-requiring types too.
+    assert_eq!(*cloned.get(0), BigUint::from(110u64));
+    assert_eq!(*original.get(0), BigUint::from(10u64));
+}
+
+#[test]
 fn test_overwrite_with_single_item() {
     let mut vec = Vec::new();
     for i in 20u64..=30u64 {

--- a/framework/scenario/tests/managed_vec_test.rs
+++ b/framework/scenario/tests/managed_vec_test.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use multiversx_sc::types::{BigUint, ManagedBuffer, ManagedRef, ManagedVec};
-use multiversx_sc_scenario::api::StaticApi;
+use multiversx_sc_scenario::api::{DebugApi, StaticApi};
 
 #[test]
 fn test_managed_vec_iter_rev() {
@@ -782,6 +782,36 @@ fn test_slice_biguint() {
 
     // out of range
     assert!(vec.slice(3, 10).is_none());
+}
+
+#[test]
+fn test_slice_biguint_debug_api() {
+    // Keep this test on the DebugApi stack, where managed-type dropping semantics
+    // differ from StaticApi and previously exposed slice aliasing issues.
+    DebugApi::dummy();
+
+    let mut vec = ManagedVec::<DebugApi, BigUint<DebugApi>>::new();
+    for i in 1u64..=5u64 {
+        vec.push(BigUint::from(i));
+    }
+
+    let mut sliced = vec.slice(1, 4).unwrap();
+    assert_eq!(sliced.len(), 3);
+    assert_eq!(*sliced.get(0), BigUint::from(2u64));
+    assert_eq!(*sliced.get(1), BigUint::from(3u64));
+    assert_eq!(*sliced.get(2), BigUint::from(4u64));
+
+    // Mutating the slice must not mutate the source collection.
+    {
+        let mut first_sliced = sliced.get_mut(0);
+        *first_sliced += &BigUint::from(100u64);
+    }
+    assert_eq!(*sliced.get(0), BigUint::from(102u64));
+
+    // Original is intact after slicing and after mutating the slice.
+    assert_eq!(vec.len(), 5);
+    assert_eq!(*vec.get(0), BigUint::from(1u64));
+    assert_eq!(*vec.get(1), BigUint::from(2u64));
 }
 
 #[test]

--- a/framework/scenario/tests/managed_vec_test.rs
+++ b/framework/scenario/tests/managed_vec_test.rs
@@ -784,7 +784,7 @@ fn test_slice_u32() {
         vec.push(i);
     }
 
-    let sliced = vec.slice(1, 4).unwrap();
+    let sliced = vec.clone_range(1, 4).unwrap();
     assert_eq!(sliced.len(), 3);
     assert_eq!(sliced.get(0), 2u32);
     assert_eq!(sliced.get(1), 3u32);
@@ -794,14 +794,14 @@ fn test_slice_u32() {
     assert_eq!(vec.len(), 5);
 
     // empty slice (start == end)
-    let empty = vec.slice(2, 2).unwrap();
+    let empty = vec.clone_range(2, 2).unwrap();
     assert!(empty.is_empty());
 
     // out of range
-    assert!(vec.slice(3, 10).is_none());
+    assert!(vec.clone_range(3, 10).is_none());
 
     // full slice
-    let full = vec.slice(0, 5).unwrap();
+    let full = vec.clone_range(0, 5).unwrap();
     assert_eq!(full.len(), 5);
 }
 
@@ -812,7 +812,7 @@ fn test_slice_biguint() {
         vec.push(BigUint::from(i));
     }
 
-    let sliced = vec.slice(1, 4).unwrap();
+    let sliced = vec.clone_range(1, 4).unwrap();
     assert_eq!(sliced.len(), 3);
     assert_eq!(*sliced.get(0), BigUint::from(2u64));
     assert_eq!(*sliced.get(1), BigUint::from(3u64));
@@ -823,7 +823,7 @@ fn test_slice_biguint() {
     assert_eq!(*vec.get(0), BigUint::from(1u64));
 
     // out of range
-    assert!(vec.slice(3, 10).is_none());
+    assert!(vec.clone_range(3, 10).is_none());
 }
 
 #[test]
@@ -837,7 +837,7 @@ fn test_slice_biguint_debug_api() {
         vec.push(BigUint::from(i));
     }
 
-    let mut sliced = vec.slice(1, 4).unwrap();
+    let mut sliced = vec.clone_range(1, 4).unwrap();
     assert_eq!(sliced.len(), 3);
     assert_eq!(*sliced.get(0), BigUint::from(2u64));
     assert_eq!(*sliced.get(1), BigUint::from(3u64));
@@ -864,27 +864,27 @@ fn test_slice_out_of_bounds_u32() {
     }
 
     // end > len
-    assert!(vec.slice(0, 6).is_none());
-    assert!(vec.slice(3, 6).is_none());
+    assert!(vec.clone_range(0, 6).is_none());
+    assert!(vec.clone_range(3, 6).is_none());
 
     // start > end
-    assert!(vec.slice(3, 2).is_none());
-    assert!(vec.slice(5, 1).is_none());
+    assert!(vec.clone_range(3, 2).is_none());
+    assert!(vec.clone_range(5, 1).is_none());
 
     // start == end == len is a valid empty slice, not out of bounds
-    assert!(vec.slice(5, 5).is_some());
-    assert!(vec.slice(5, 5).unwrap().is_empty());
+    assert!(vec.clone_range(5, 5).is_some());
+    assert!(vec.clone_range(5, 5).unwrap().is_empty());
 
     // start > len
-    assert!(vec.slice(6, 6).is_none());
+    assert!(vec.clone_range(6, 6).is_none());
 
     // empty vec
     let empty = ManagedVec::<StaticApi, u32>::new();
-    assert!(empty.slice(0, 1).is_none());
-    assert!(empty.slice(1, 0).is_none());
+    assert!(empty.clone_range(0, 1).is_none());
+    assert!(empty.clone_range(1, 0).is_none());
     // empty slice from empty vec is valid
-    assert!(empty.slice(0, 0).is_some());
-    assert!(empty.slice(0, 0).unwrap().is_empty());
+    assert!(empty.clone_range(0, 0).is_some());
+    assert!(empty.clone_range(0, 0).unwrap().is_empty());
 }
 
 #[test]
@@ -895,27 +895,27 @@ fn test_slice_out_of_bounds_biguint() {
     }
 
     // end > len
-    assert!(vec.slice(0, 6).is_none());
-    assert!(vec.slice(3, 6).is_none());
+    assert!(vec.clone_range(0, 6).is_none());
+    assert!(vec.clone_range(3, 6).is_none());
 
     // start > end
-    assert!(vec.slice(3, 2).is_none());
-    assert!(vec.slice(5, 1).is_none());
+    assert!(vec.clone_range(3, 2).is_none());
+    assert!(vec.clone_range(5, 1).is_none());
 
     // start == end == len is a valid empty slice, not out of bounds
-    assert!(vec.slice(5, 5).is_some());
-    assert!(vec.slice(5, 5).unwrap().is_empty());
+    assert!(vec.clone_range(5, 5).is_some());
+    assert!(vec.clone_range(5, 5).unwrap().is_empty());
 
     // start > len
-    assert!(vec.slice(6, 6).is_none());
+    assert!(vec.clone_range(6, 6).is_none());
 
     // empty vec
     let empty = ManagedVec::<StaticApi, BigUint<StaticApi>>::new();
-    assert!(empty.slice(0, 1).is_none());
-    assert!(empty.slice(1, 0).is_none());
+    assert!(empty.clone_range(0, 1).is_none());
+    assert!(empty.clone_range(1, 0).is_none());
     // empty slice from empty vec is valid
-    assert!(empty.slice(0, 0).is_some());
-    assert!(empty.slice(0, 0).unwrap().is_empty());
+    assert!(empty.clone_range(0, 0).is_some());
+    assert!(empty.clone_range(0, 0).unwrap().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Pull request overview

This PR fixes `ManagedVec` range-slicing semantics to avoid handle aliasing (notably under `DebugApi`), and clarifies/adjusts the “drop required” signaling used to choose safe cloning paths for managed (handle-owning) items.

**Changes:**
- Introduces `ManagedVec::clone_range()` as the safe range-clone API and deprecates `slice()` as an alias.
- Updates `ManagedVec` clone/drop logic to distinguish “handle-owning” item types from “backend actually performs drops”.
- Adds regression tests (including a `DebugApi` case) to ensure slices/clones don’t alias and mutations don’t leak back to the source.
