### PR TITLE
Workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,3 +221,10 @@ path = "framework/base"
 version = "0.66.2"
 path = "framework/scenario"
 
+[workspace.dependencies.multiversx-sc-meta-lib]
+version = "0.66.2"
+path = "framework/meta-lib"
+
+[workspace.dependencies.multiversx-sc-snippets]
+version = "0.66.2"
+path = "framework/snippets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,3 +212,12 @@ members = [
   # "chain/wasmer-prod", ## not included, references wasmer 2.2
   # "contracts/feature-tests/gas-tests", ## uncomment for easier development
 ]
+
+[workspace.dependencies.multiversx-sc]
+version = "0.66.2"
+path = "framework/base"
+
+[workspace.dependencies.multiversx-sc-scenario]
+version = "0.66.2"
+path = "framework/scenario"
+

--- a/contracts/examples/adder/Cargo.toml
+++ b/contracts/examples/adder/Cargo.toml
@@ -9,10 +9,8 @@ publish = false
 path = "src/adder.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"

--- a/contracts/examples/adder/interactor/Cargo.toml
+++ b/contracts/examples/adder/interactor/Cargo.toml
@@ -16,8 +16,7 @@ path = "src/basic_interactor.rs"
 path = ".."
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/contracts/examples/adder/meta/Cargo.toml
+++ b/contracts/examples/adder/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/framework/meta-lib/src/cargo_toml.rs
+++ b/framework/meta-lib/src/cargo_toml.rs
@@ -2,6 +2,7 @@ mod cargo_toml_contents;
 mod cargo_toml_deps;
 mod cargo_toml_deps_raw;
 mod version_req;
+mod workspace_dependencies;
 
 pub use cargo_toml_contents::{
     CARGO_TOML_DEPENDENCIES, CARGO_TOML_DEV_DEPENDENCIES, CargoTomlContents,
@@ -10,3 +11,4 @@ pub use cargo_toml_contents::{
 pub use cargo_toml_deps::{DependencyReference, GitCommitReference};
 pub use cargo_toml_deps_raw::DependencyRawValue;
 pub use version_req::VersionReq;
+pub use workspace_dependencies::WorkspaceDependencies;

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
@@ -159,18 +159,6 @@ impl CargoTomlContents {
         self.path.parent().unwrap_or_else(|| Path::new("."))
     }
 
-    /// Resolves a single inherited `workspace = true` dependency to a concrete dependency value.
-    ///
-    /// The workspace-relative `path` entries are rebased relative to this manifest's directory.
-    pub fn resolve_dependency_from_workspace(
-        &self,
-        workspace_dependencies: &WorkspaceDependencies,
-        crate_name: &str,
-        local_dependency: DependencyRawValue,
-    ) -> DependencyRawValue {
-        workspace_dependencies.resolve_dependency(crate_name, local_dependency, self.manifest_dir())
-    }
-
     /// Resolves inherited `workspace = true` dependencies in both `[dependencies]` and
     /// `[dev-dependencies]` using dependencies declared in the workspace root.
     pub fn resolve_workspace_dependencies(
@@ -206,21 +194,15 @@ fn resolve_workspace_dependencies_in_table(
     manifest_dir: &Path,
 ) {
     for (crate_name, value) in deps_map {
-        if !dependency_uses_workspace(value) {
+        let mut local_dep = DependencyRawValue::parse_toml_value(value);
+        if !local_dep.workspace {
             continue;
         }
-        let local_dependency = DependencyRawValue::parse_toml_value(value);
-        let resolved_dependency =
-            workspace_dependencies.resolve_dependency(&crate_name, local_dependency, manifest_dir);
-        *value = resolved_dependency.into_toml_value();
-    }
-}
 
-fn dependency_uses_workspace(value: &Value) -> bool {
-    value
-        .get("workspace")
-        .and_then(|workspace| workspace.as_bool())
-        .unwrap_or_default()
+        let workspace_dep = workspace_dependencies.resolve_dependency(&crate_name, manifest_dir);
+        local_dep.replace_workspace_dep(&workspace_dep);
+        *value = local_dep.into_toml_value();
+    }
 }
 
 impl CargoTomlContents {

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
@@ -8,11 +8,10 @@ use toml::{Value, value::Table};
 
 use crate::contract::sc_config::ContractVariantProfile;
 
-use super::DependencyRawValue;
+use super::{DependencyRawValue, WorkspaceDependencies};
 
 pub const CARGO_TOML_DEPENDENCIES: &str = "dependencies";
 pub const CARGO_TOML_DEV_DEPENDENCIES: &str = "dev-dependencies";
-pub const WORKSPACE: &str = "workspace";
 pub const PACKAGE: &str = "package";
 pub const AUTHORS: &str = "authors";
 const DEFAULT_WORKSPACE_RESOLVER: &str = "3";
@@ -155,14 +154,76 @@ impl CargoTomlContents {
             .map(DependencyRawValue::parse_toml_value)
     }
 
-    pub fn workspace_dependency_raw_value(&self, crate_name: &str) -> Option<DependencyRawValue> {
-        self.toml_value
-            .get(WORKSPACE)
-            .and_then(|workspace| workspace.get(CARGO_TOML_DEPENDENCIES))
-            .and_then(|deps| deps.get(crate_name))
-            .map(DependencyRawValue::parse_toml_value)
+    /// Returns the directory containing this manifest.
+    pub fn manifest_dir(&self) -> &Path {
+        self.path.parent().unwrap_or_else(|| Path::new("."))
     }
 
+    /// Resolves a single inherited `workspace = true` dependency to a concrete dependency value.
+    ///
+    /// The workspace-relative `path` entries are rebased relative to this manifest's directory.
+    pub fn resolve_dependency_from_workspace(
+        &self,
+        workspace_dependencies: &WorkspaceDependencies,
+        crate_name: &str,
+        local_dependency: DependencyRawValue,
+    ) -> DependencyRawValue {
+        workspace_dependencies.resolve_dependency(crate_name, local_dependency, self.manifest_dir())
+    }
+
+    /// Resolves inherited `workspace = true` dependencies in both `[dependencies]` and
+    /// `[dev-dependencies]` using dependencies declared in the workspace root.
+    pub fn resolve_workspace_dependencies(
+        &mut self,
+        workspace_dependencies: &WorkspaceDependencies,
+    ) {
+        if workspace_dependencies.is_empty() {
+            return;
+        }
+
+        let manifest_dir = self.manifest_dir().to_path_buf();
+
+        if self.has_dependencies() {
+            resolve_workspace_dependencies_in_table(
+                self.dependencies_mut(),
+                workspace_dependencies,
+                &manifest_dir,
+            );
+        }
+        if self.has_dev_dependencies() {
+            resolve_workspace_dependencies_in_table(
+                self.dev_dependencies_mut(),
+                workspace_dependencies,
+                &manifest_dir,
+            );
+        }
+    }
+}
+
+fn resolve_workspace_dependencies_in_table(
+    deps_map: &mut Table,
+    workspace_dependencies: &WorkspaceDependencies,
+    manifest_dir: &Path,
+) {
+    for (crate_name, value) in deps_map {
+        if !dependency_uses_workspace(value) {
+            continue;
+        }
+        let local_dependency = DependencyRawValue::parse_toml_value(value);
+        let resolved_dependency =
+            workspace_dependencies.resolve_dependency(&crate_name, local_dependency, manifest_dir);
+        *value = resolved_dependency.into_toml_value();
+    }
+}
+
+fn dependency_uses_workspace(value: &Value) -> bool {
+    value
+        .get("workspace")
+        .and_then(|workspace| workspace.as_bool())
+        .unwrap_or_default()
+}
+
+impl CargoTomlContents {
     pub fn insert_dependency_raw_value(&mut self, crate_name: &str, raw_value: DependencyRawValue) {
         self.dependencies_mut()
             .insert(crate_name.to_owned(), raw_value.into_toml_value());
@@ -434,7 +495,9 @@ fn remove_quotes(var: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cargo_toml::{DependencyReference, GitCommitReference, VersionReq};
+    use crate::cargo_toml::{
+        DependencyReference, GitCommitReference, VersionReq, WorkspaceDependencies,
+    };
 
     #[test]
     fn test_change_from_base_to_adapter_path() {
@@ -597,19 +660,6 @@ by-git-commit-2 = { git = "https://github.com/multiversx/repo2", rev = "e990be82
         );
         assert_eq!(raw_value.interpret(), DependencyReference::Workspace,);
 
-        let raw_value = cargo_toml
-            .workspace_dependency_raw_value("by-workspace-root")
-            .unwrap();
-        let path = Path::new("g").join("h").join("i");
-        assert_eq!(
-            raw_value,
-            DependencyRawValue {
-                version: Some("0.54.4".to_owned()),
-                path: Some(path),
-                ..Default::default()
-            },
-        );
-
         // path
         let raw_value = cargo_toml.dependency_raw_value("by-path-1").unwrap();
         let path = Path::new("a").join("b").join("c");
@@ -633,5 +683,68 @@ by-git-commit-2 = { git = "https://github.com/multiversx/repo2", rev = "e990be82
             },
         );
         assert_eq!(raw_value.interpret(), DependencyReference::Path(path),);
+    }
+
+    #[test]
+    fn test_resolve_workspace_dependencies() {
+        let mut cargo_toml = CargoTomlContents::parse_string(
+            r#"
+[dependencies.by-workspace]
+workspace = true
+features = ["std"]
+
+[dev-dependencies.by-dev-workspace]
+workspace = true
+
+[workspace.dependencies.by-workspace]
+version = "0.54.0"
+path = "framework/base"
+features = ["alloc"]
+
+[workspace.dependencies.by-dev-workspace]
+version = "0.54.1"
+path = "framework/scenario"
+"#,
+            Path::new("/repo/contracts/examples/adder/Cargo.toml"),
+        );
+        let workspace_dependencies =
+            WorkspaceDependencies::from_cargo_toml(Path::new("/repo"), &cargo_toml.clone());
+
+        cargo_toml.resolve_workspace_dependencies(&workspace_dependencies);
+
+        let path = Path::new("..")
+            .join("..")
+            .join("..")
+            .join("framework")
+            .join("base");
+        assert_eq!(
+            cargo_toml.dependency_raw_value("by-workspace").unwrap(),
+            DependencyRawValue {
+                version: Some("0.54.0".to_owned()),
+                path: Some(path),
+                features: ["alloc".to_owned(), "std".to_owned()].into(),
+                ..Default::default()
+            },
+        );
+
+        let dev_deps = cargo_toml
+            .toml_value
+            .get(CARGO_TOML_DEV_DEPENDENCIES)
+            .unwrap()
+            .as_table()
+            .unwrap();
+        let path = Path::new("..")
+            .join("..")
+            .join("..")
+            .join("framework")
+            .join("scenario");
+        assert_eq!(
+            DependencyRawValue::parse_toml_value(dev_deps.get("by-dev-workspace").unwrap()),
+            DependencyRawValue {
+                version: Some("0.54.1".to_owned()),
+                path: Some(path),
+                ..Default::default()
+            },
+        );
     }
 }

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
@@ -12,6 +12,7 @@ use super::DependencyRawValue;
 
 pub const CARGO_TOML_DEPENDENCIES: &str = "dependencies";
 pub const CARGO_TOML_DEV_DEPENDENCIES: &str = "dev-dependencies";
+pub const WORKSPACE: &str = "workspace";
 pub const PACKAGE: &str = "package";
 pub const AUTHORS: &str = "authors";
 const DEFAULT_WORKSPACE_RESOLVER: &str = "3";
@@ -151,6 +152,14 @@ impl CargoTomlContents {
     /// Interprets the dependency value and organizes values in a struct.
     pub fn dependency_raw_value(&self, crate_name: &str) -> Option<DependencyRawValue> {
         self.dependency(crate_name)
+            .map(DependencyRawValue::parse_toml_value)
+    }
+
+    pub fn workspace_dependency_raw_value(&self, crate_name: &str) -> Option<DependencyRawValue> {
+        self.toml_value
+            .get(WORKSPACE)
+            .and_then(|workspace| workspace.get(CARGO_TOML_DEPENDENCIES))
+            .and_then(|deps| deps.get(crate_name))
             .map(DependencyRawValue::parse_toml_value)
     }
 
@@ -458,8 +467,16 @@ version = "=0.54.1"
 git = "https://github.com/multiversx/repo1"
 rev = "85c31b9ce730bd5ffe41589c353d935a14baaa96"
 
+[dependencies.by-workspace]
+workspace = true
+features = ["alloc", "std"]
+
 [dependencies.by-path-1]
 path = "a/b/c"
+
+[workspace.dependencies.by-workspace-root]
+version = "0.54.4"
+path = "g/h/i"
 
 [dependencies]
 by-version-2 = "0.54.2"
@@ -566,6 +583,31 @@ by-git-commit-2 = { git = "https://github.com/multiversx/repo2", rev = "e990be82
                 git: "https://github.com/multiversx/repo2".to_owned(),
                 rev: "e990be823f26d1e7f59c71536d337b7240dc3fa2".to_owned(),
             })
+        );
+
+        // workspace
+        let raw_value = cargo_toml.dependency_raw_value("by-workspace").unwrap();
+        assert_eq!(
+            raw_value,
+            DependencyRawValue {
+                workspace: true,
+                features: ["alloc".to_owned(), "std".to_owned()].into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(raw_value.interpret(), DependencyReference::Workspace,);
+
+        let raw_value = cargo_toml
+            .workspace_dependency_raw_value("by-workspace-root")
+            .unwrap();
+        let path = Path::new("g").join("h").join("i");
+        assert_eq!(
+            raw_value,
+            DependencyRawValue {
+                version: Some("0.54.4".to_owned()),
+                path: Some(path),
+                ..Default::default()
+            },
         );
 
         // path

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
@@ -704,7 +704,7 @@ path = "framework/scenario"
             DependencyRawValue {
                 version: Some("0.54.0".to_owned()),
                 path: Some(path),
-                features: ["alloc".to_owned(), "std".to_owned()].into(),
+                features: ["std".to_owned()].into(),
                 ..Default::default()
             },
         );

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
@@ -161,30 +161,34 @@ impl CargoTomlContents {
 
     /// Resolves inherited `workspace = true` dependencies in both `[dependencies]` and
     /// `[dev-dependencies]` using dependencies declared in the workspace root.
+    /// Returns `true` if any entry was replaced.
     pub fn resolve_workspace_dependencies(
         &mut self,
         workspace_dependencies: &WorkspaceDependencies,
-    ) {
+    ) -> bool {
         if workspace_dependencies.is_empty() {
-            return;
+            return false;
         }
 
         let manifest_dir = self.manifest_dir().to_path_buf();
+        let mut changed = false;
 
         if self.has_dependencies() {
-            resolve_workspace_dependencies_in_table(
+            changed |= resolve_workspace_dependencies_in_table(
                 self.dependencies_mut(),
                 workspace_dependencies,
                 &manifest_dir,
             );
         }
         if self.has_dev_dependencies() {
-            resolve_workspace_dependencies_in_table(
+            changed |= resolve_workspace_dependencies_in_table(
                 self.dev_dependencies_mut(),
                 workspace_dependencies,
                 &manifest_dir,
             );
         }
+
+        changed
     }
 }
 
@@ -192,7 +196,8 @@ fn resolve_workspace_dependencies_in_table(
     deps_map: &mut Table,
     workspace_dependencies: &WorkspaceDependencies,
     manifest_dir: &Path,
-) {
+) -> bool {
+    let mut changed = false;
     for (crate_name, value) in deps_map {
         let mut local_dep = DependencyRawValue::parse_toml_value(value);
         if !local_dep.workspace {
@@ -202,7 +207,9 @@ fn resolve_workspace_dependencies_in_table(
         let workspace_dep = workspace_dependencies.resolve_dependency(crate_name, manifest_dir);
         local_dep.replace_workspace_dep(&workspace_dep);
         *value = local_dep.into_toml_value();
+        changed = true;
     }
+    changed
 }
 
 impl CargoTomlContents {

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_contents.rs
@@ -199,7 +199,7 @@ fn resolve_workspace_dependencies_in_table(
             continue;
         }
 
-        let workspace_dep = workspace_dependencies.resolve_dependency(&crate_name, manifest_dir);
+        let workspace_dep = workspace_dependencies.resolve_dependency(crate_name, manifest_dir);
         local_dep.replace_workspace_dep(&workspace_dep);
         *value = local_dep.into_toml_value();
     }

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_deps.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_deps.rs
@@ -29,6 +29,7 @@ pub struct GitTagReference {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DependencyReference {
     Version(VersionReq),
+    Workspace,
     GitCommit(GitCommitReference),
     GitBranch(GitBranchReference),
     GitTag(GitTagReference),
@@ -57,6 +58,10 @@ impl DependencyReference {
 impl DependencyRawValue {
     /// Interprets the raw dependency value as one of several possible formats.
     pub fn interpret(self) -> DependencyReference {
+        if self.workspace {
+            return DependencyReference::Workspace;
+        }
+
         // path is top priority
         if let Some(path) = self.path {
             return DependencyReference::Path(path);

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
@@ -1,36 +1,39 @@
 use std::{collections::BTreeSet, path::PathBuf};
 
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub struct DependencyRawValue {
-    pub version: Option<String>,
-    pub workspace: bool,
-    pub git: Option<String>,
-    pub rev: Option<String>,
-    pub branch: Option<String>,
-    pub tag: Option<String>,
-    pub path: Option<PathBuf>,
-    pub features: BTreeSet<String>,
-    pub default_features: Option<bool>,
-    pub optional: Option<bool>,
-    pub package: Option<String>,
-    pub registry: Option<String>,
+use serde::{Deserialize, Serialize};
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
-/// All dependency table keys recognized by Cargo and modeled in [`DependencyRawValue`].
-const KNOWN_DEP_KEYS: &[&str] = &[
-    "version",
-    "workspace",
-    "path",
-    "git",
-    "rev",
-    "branch",
-    "tag",
-    "features",
-    "default-features",
-    "optional",
-    "package",
-    "registry",
-];
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DependencyRawValue {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub workspace: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rev: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub features: BTreeSet<String>,
+    #[serde(rename = "default-features", skip_serializing_if = "Option::is_none")]
+    pub default_features: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optional: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry: Option<String>,
+}
 
 impl DependencyRawValue {
     pub fn from_version(version: &str) -> Self {
@@ -43,128 +46,15 @@ impl DependencyRawValue {
     pub fn parse_toml_value(toml_value: &toml::Value) -> Self {
         match toml_value {
             toml::Value::String(version) => DependencyRawValue::from_version(version),
-            toml::Value::Table(table) => {
-                for key in table.keys() {
-                    assert!(
-                        KNOWN_DEP_KEYS.contains(&key.as_str()),
-                        "unknown dependency key: {key:?}"
-                    );
-                }
-                let mut result = DependencyRawValue::default();
-                if let Some(toml::Value::String(version)) = table.get("version") {
-                    result.version = Some(version.to_owned());
-                }
-                if let Some(toml::Value::Boolean(workspace)) = table.get("workspace") {
-                    result.workspace = *workspace;
-                }
-                if let Some(toml::Value::String(path)) = table.get("path") {
-                    result.path = Some(PathBuf::from(path));
-                }
-                if let Some(toml::Value::String(git)) = table.get("git") {
-                    result.git = Some(git.to_owned());
-                }
-                if let Some(toml::Value::String(rev)) = table.get("rev") {
-                    result.rev = Some(rev.to_owned());
-                }
-                if let Some(toml::Value::String(branch)) = table.get("branch") {
-                    result.branch = Some(branch.to_owned());
-                }
-                if let Some(toml::Value::String(tag)) = table.get("tag") {
-                    result.tag = Some(tag.to_owned());
-                }
-                if let Some(toml::Value::Array(features)) = table.get("features") {
-                    result.features = features
-                        .iter()
-                        .map(|feature| feature.as_str().expect("feature is not a string"))
-                        .map(str::to_owned)
-                        .collect();
-                }
-                if let Some(toml::Value::Boolean(default_features)) =
-                    table.get("default-features")
-                {
-                    result.default_features = Some(*default_features);
-                }
-                if let Some(toml::Value::Boolean(optional)) = table.get("optional") {
-                    result.optional = Some(*optional);
-                }
-                if let Some(toml::Value::String(package)) = table.get("package") {
-                    result.package = Some(package.to_owned());
-                }
-                if let Some(toml::Value::String(registry)) = table.get("registry") {
-                    result.registry = Some(registry.to_owned());
-                }
-                result
-            }
-            _ => panic!("Unsupported dependency value"),
+            _ => toml_value
+                .clone()
+                .try_into()
+                .unwrap_or_else(|e| panic!("failed to parse dependency value: {e}")),
         }
     }
 
     pub fn into_toml_value(self) -> toml::Value {
-        let mut table = toml::map::Map::new();
-
-        if let Some(version) = self.version {
-            table.insert("version".to_string(), toml::Value::String(version));
-        }
-
-        if self.workspace {
-            table.insert("workspace".to_string(), toml::Value::Boolean(true));
-        }
-
-        if let Some(git) = self.git {
-            table.insert("git".to_string(), toml::Value::String(git));
-        }
-
-        if let Some(rev) = self.rev {
-            table.insert("rev".to_string(), toml::Value::String(rev));
-        }
-
-        if let Some(branch) = self.branch {
-            table.insert("branch".to_string(), toml::Value::String(branch));
-        }
-
-        if let Some(tag) = self.tag {
-            table.insert("tag".to_string(), toml::Value::String(tag));
-        }
-
-        if let Some(path) = self.path {
-            table.insert(
-                "path".to_string(),
-                toml::Value::String(path.to_string_lossy().into_owned()),
-            );
-        }
-
-        if !self.features.is_empty() {
-            table.insert(
-                "features".to_string(),
-                toml::Value::Array(
-                    self.features
-                        .iter()
-                        .map(|feature| toml::Value::String(feature.clone()))
-                        .collect(),
-                ),
-            );
-        }
-
-        if let Some(default_features) = self.default_features {
-            table.insert(
-                "default-features".to_string(),
-                toml::Value::Boolean(default_features),
-            );
-        }
-
-        if let Some(optional) = self.optional {
-            table.insert("optional".to_string(), toml::Value::Boolean(optional));
-        }
-
-        if let Some(package) = self.package {
-            table.insert("package".to_string(), toml::Value::String(package));
-        }
-
-        if let Some(registry) = self.registry {
-            table.insert("registry".to_string(), toml::Value::String(registry));
-        }
-
-        toml::Value::Table(table)
+        toml::Value::try_from(self).expect("failed to serialize dependency value")
     }
 
     /// Removes the `workspace = true` flag and replaces the dependency fields from `workspace_dep`.

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeSet, path::PathBuf};
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct DependencyRawValue {
     pub version: Option<String>,
+    pub workspace: bool,
     pub git: Option<String>,
     pub rev: Option<String>,
     pub branch: Option<String>,
@@ -27,6 +28,9 @@ impl DependencyRawValue {
                 if let Some(toml::Value::String(version)) = table.get("version") {
                     result.version = Some(version.to_owned());
                 }
+                if let Some(toml::Value::Boolean(workspace)) = table.get("workspace") {
+                    result.workspace = *workspace;
+                }
                 if let Some(toml::Value::String(path)) = table.get("path") {
                     result.path = Some(PathBuf::from(path));
                 }
@@ -42,6 +46,13 @@ impl DependencyRawValue {
                 if let Some(toml::Value::String(tag)) = table.get("tag") {
                     result.tag = Some(tag.to_owned());
                 }
+                if let Some(toml::Value::Array(features)) = table.get("features") {
+                    result.features = features
+                        .iter()
+                        .map(|feature| feature.as_str().expect("feature is not a string"))
+                        .map(str::to_owned)
+                        .collect();
+                }
                 result
             }
             _ => panic!("Unsupported dependency value"),
@@ -53,6 +64,10 @@ impl DependencyRawValue {
 
         if let Some(version) = self.version {
             table.insert("version".to_string(), toml::Value::String(version));
+        }
+
+        if self.workspace {
+            table.insert("workspace".to_string(), toml::Value::Boolean(true));
         }
 
         if let Some(git) = self.git {

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
@@ -109,6 +109,8 @@ impl DependencyRawValue {
     }
 
     /// Removes the `workspace = true` flag and replaces the dependency fields from `workspace_dep`.
+    ///
+    /// Doesn't touch anything other than dependency specification fields (version, git, rev, branch, tag, path). No features.
     pub fn replace_workspace_dep(&mut self, workspace_dep: &DependencyRawValue) {
         self.workspace = false;
         self.version = workspace_dep.version.clone();

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
@@ -10,7 +10,27 @@ pub struct DependencyRawValue {
     pub tag: Option<String>,
     pub path: Option<PathBuf>,
     pub features: BTreeSet<String>,
+    pub default_features: Option<bool>,
+    pub optional: Option<bool>,
+    pub package: Option<String>,
+    pub registry: Option<String>,
 }
+
+/// All dependency table keys recognized by Cargo and modeled in [`DependencyRawValue`].
+const KNOWN_DEP_KEYS: &[&str] = &[
+    "version",
+    "workspace",
+    "path",
+    "git",
+    "rev",
+    "branch",
+    "tag",
+    "features",
+    "default-features",
+    "optional",
+    "package",
+    "registry",
+];
 
 impl DependencyRawValue {
     pub fn from_version(version: &str) -> Self {
@@ -24,6 +44,12 @@ impl DependencyRawValue {
         match toml_value {
             toml::Value::String(version) => DependencyRawValue::from_version(version),
             toml::Value::Table(table) => {
+                for key in table.keys() {
+                    assert!(
+                        KNOWN_DEP_KEYS.contains(&key.as_str()),
+                        "unknown dependency key: {key:?}"
+                    );
+                }
                 let mut result = DependencyRawValue::default();
                 if let Some(toml::Value::String(version)) = table.get("version") {
                     result.version = Some(version.to_owned());
@@ -52,6 +78,20 @@ impl DependencyRawValue {
                         .map(|feature| feature.as_str().expect("feature is not a string"))
                         .map(str::to_owned)
                         .collect();
+                }
+                if let Some(toml::Value::Boolean(default_features)) =
+                    table.get("default-features")
+                {
+                    result.default_features = Some(*default_features);
+                }
+                if let Some(toml::Value::Boolean(optional)) = table.get("optional") {
+                    result.optional = Some(*optional);
+                }
+                if let Some(toml::Value::String(package)) = table.get("package") {
+                    result.package = Some(package.to_owned());
+                }
+                if let Some(toml::Value::String(registry)) = table.get("registry") {
+                    result.registry = Some(registry.to_owned());
                 }
                 result
             }
@@ -105,12 +145,33 @@ impl DependencyRawValue {
             );
         }
 
+        if let Some(default_features) = self.default_features {
+            table.insert(
+                "default-features".to_string(),
+                toml::Value::Boolean(default_features),
+            );
+        }
+
+        if let Some(optional) = self.optional {
+            table.insert("optional".to_string(), toml::Value::Boolean(optional));
+        }
+
+        if let Some(package) = self.package {
+            table.insert("package".to_string(), toml::Value::String(package));
+        }
+
+        if let Some(registry) = self.registry {
+            table.insert("registry".to_string(), toml::Value::String(registry));
+        }
+
         toml::Value::Table(table)
     }
 
     /// Removes the `workspace = true` flag and replaces the dependency fields from `workspace_dep`.
     ///
-    /// Doesn't touch anything other than dependency specification fields (version, git, rev, branch, tag, path). No features.
+    /// Copies specification fields (version, git, rev, branch, tag, path, default-features,
+    /// package, registry) from the workspace dep. Does not touch `features` or `optional`,
+    /// which are local-only attributes that the crate controls independently.
     pub fn replace_workspace_dep(&mut self, workspace_dep: &DependencyRawValue) {
         self.workspace = false;
         self.version = workspace_dep.version.clone();
@@ -119,5 +180,8 @@ impl DependencyRawValue {
         self.branch = workspace_dep.branch.clone();
         self.tag = workspace_dep.tag.clone();
         self.path = workspace_dep.path.clone();
+        self.default_features = workspace_dep.default_features;
+        self.package = workspace_dep.package.clone();
+        self.registry = workspace_dep.registry.clone();
     }
 }

--- a/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
+++ b/framework/meta-lib/src/cargo_toml/cargo_toml_deps_raw.rs
@@ -107,4 +107,15 @@ impl DependencyRawValue {
 
         toml::Value::Table(table)
     }
+
+    /// Removes the `workspace = true` flag and replaces the dependency fields from `workspace_dep`.
+    pub fn replace_workspace_dep(&mut self, workspace_dep: &DependencyRawValue) {
+        self.workspace = false;
+        self.version = workspace_dep.version.clone();
+        self.git = workspace_dep.git.clone();
+        self.rev = workspace_dep.rev.clone();
+        self.branch = workspace_dep.branch.clone();
+        self.tag = workspace_dep.tag.clone();
+        self.path = workspace_dep.path.clone();
+    }
 }

--- a/framework/meta-lib/src/cargo_toml/workspace_dependencies.rs
+++ b/framework/meta-lib/src/cargo_toml/workspace_dependencies.rs
@@ -52,16 +52,12 @@ impl WorkspaceDependencies {
     pub(crate) fn resolve_dependency(
         &self,
         crate_name: &str,
-        local_dependency: DependencyRawValue,
         relative_dir: &Path,
     ) -> DependencyRawValue {
         let mut workspace_dependency = self
             .get(crate_name)
             .unwrap_or_else(|| panic!("missing workspace dependency in Cargo.toml: {crate_name}"))
             .clone();
-        workspace_dependency
-            .features
-            .extend(local_dependency.features);
 
         if let Some(path) = &mut workspace_dependency.path {
             *path = path_relative_from_to(

--- a/framework/meta-lib/src/cargo_toml/workspace_dependencies.rs
+++ b/framework/meta-lib/src/cargo_toml/workspace_dependencies.rs
@@ -1,0 +1,157 @@
+use std::{
+    collections::BTreeMap,
+    path::{Component, Path, PathBuf},
+};
+
+use toml::value::Table;
+
+use super::{CARGO_TOML_DEPENDENCIES, CargoTomlContents, DependencyRawValue};
+
+const WORKSPACE: &str = "workspace";
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkspaceDependencies {
+    pub workspace_path: PathBuf,
+    pub dependencies: BTreeMap<String, DependencyRawValue>,
+}
+
+impl WorkspaceDependencies {
+    pub fn load_from_dir(workspace_path: impl AsRef<Path>) -> Self {
+        let workspace_path = workspace_path.as_ref();
+        let cargo_toml_contents =
+            CargoTomlContents::load_from_file(workspace_path.join("Cargo.toml"));
+
+        Self::from_cargo_toml(workspace_path, &cargo_toml_contents)
+    }
+
+    pub fn from_cargo_toml(
+        workspace_path: impl AsRef<Path>,
+        cargo_toml_contents: &CargoTomlContents,
+    ) -> Self {
+        let dependencies = Self::dependencies_table(cargo_toml_contents)
+            .map(Self::parse_dependencies_table)
+            .unwrap_or_default();
+
+        Self {
+            workspace_path: workspace_path.as_ref().to_path_buf(),
+            dependencies,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.dependencies.is_empty()
+    }
+
+    pub fn get(&self, crate_name: &str) -> Option<&DependencyRawValue> {
+        self.dependencies.get(crate_name)
+    }
+
+    /// Resolves a single dependency from workspace root to a concrete value.
+    ///
+    /// This rebases workspace-relative `path` entries to be relative to `relative_dir`.
+    pub(crate) fn resolve_dependency(
+        &self,
+        crate_name: &str,
+        local_dependency: DependencyRawValue,
+        relative_dir: &Path,
+    ) -> DependencyRawValue {
+        let mut workspace_dependency = self
+            .get(crate_name)
+            .unwrap_or_else(|| panic!("missing workspace dependency in Cargo.toml: {crate_name}"))
+            .clone();
+        workspace_dependency
+            .features
+            .extend(local_dependency.features);
+
+        if let Some(path) = &mut workspace_dependency.path {
+            *path = path_relative_from_to(
+                &absolute_path(&self.workspace_path).join(&path),
+                &absolute_path(relative_dir),
+            );
+        }
+
+        workspace_dependency
+    }
+
+    fn dependencies_table(cargo_toml_contents: &CargoTomlContents) -> Option<&Table> {
+        cargo_toml_contents
+            .toml_value
+            .get(WORKSPACE)
+            .and_then(|workspace| workspace.get(CARGO_TOML_DEPENDENCIES))
+            .and_then(|deps| deps.as_table())
+    }
+
+    fn parse_dependencies_table(deps: &Table) -> BTreeMap<String, DependencyRawValue> {
+        deps.iter()
+            .map(|(crate_name, value)| {
+                (
+                    crate_name.to_owned(),
+                    DependencyRawValue::parse_toml_value(value),
+                )
+            })
+            .collect()
+    }
+}
+
+fn absolute_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        normalize_path(path)
+    } else {
+        normalize_path(&std::env::current_dir().unwrap().join(path))
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                result.pop();
+            }
+            _ => result.push(component.as_os_str()),
+        }
+    }
+    result
+}
+
+fn path_relative_from_to(path: &Path, base: &Path) -> PathBuf {
+    let path = normalize_path(path);
+    let base = normalize_path(base);
+    let path_components: Vec<_> = path.components().collect();
+    let base_components: Vec<_> = base.components().collect();
+    let common_len = path_components
+        .iter()
+        .zip(base_components.iter())
+        .take_while(|(path_component, base_component)| path_component == base_component)
+        .count();
+
+    let mut relative_path = PathBuf::new();
+    for _ in common_len..base_components.len() {
+        relative_path.push("..");
+    }
+    for component in &path_components[common_len..] {
+        relative_path.push(component.as_os_str());
+    }
+    relative_path
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    #[test]
+    fn test_path_relative_from_to() {
+        assert_eq!(
+            super::path_relative_from_to(
+                Path::new("/repo/framework/base"),
+                Path::new("/repo/contracts/examples/adder"),
+            ),
+            Path::new("..")
+                .join("..")
+                .join("..")
+                .join("framework")
+                .join("base"),
+        );
+    }
+}

--- a/framework/meta-lib/src/cargo_toml/workspace_dependencies.rs
+++ b/framework/meta-lib/src/cargo_toml/workspace_dependencies.rs
@@ -5,6 +5,8 @@ use std::{
 
 use toml::value::Table;
 
+use crate::tools::find_workspace;
+
 use super::{CARGO_TOML_DEPENDENCIES, CargoTomlContents, DependencyRawValue};
 
 const WORKSPACE: &str = "workspace";
@@ -22,6 +24,23 @@ impl WorkspaceDependencies {
             CargoTomlContents::load_from_file(workspace_path.join("Cargo.toml"));
 
         Self::from_cargo_toml(workspace_path, &cargo_toml_contents)
+    }
+
+    /// Like [`load_from_dir`](Self::load_from_dir), but returns an empty
+    /// `WorkspaceDependencies` if no `Cargo.toml` exists at `workspace_path`
+    /// instead of panicking.
+    pub fn try_load_from_dir(workspace_path: impl AsRef<Path>) -> Option<Self> {
+        let workspace_path = workspace_path.as_ref();
+        let cargo_toml_path = workspace_path.join("Cargo.toml");
+        if !cargo_toml_path.is_file() {
+            return None;
+        }
+        Some(Self::load_from_dir(workspace_path))
+    }
+
+    pub fn find_from_dir(dir: impl AsRef<Path>) -> Option<Self> {
+        let workspace_path = find_workspace(dir.as_ref())?;
+        Self::try_load_from_dir(workspace_path)
     }
 
     pub fn from_cargo_toml(

--- a/framework/meta-lib/src/contract/meta_config.rs
+++ b/framework/meta-lib/src/contract/meta_config.rs
@@ -6,7 +6,7 @@ use std::{
 use multiversx_sc::abi::ContractAbi;
 
 use crate::{
-    cargo_toml::CargoTomlContents,
+    cargo_toml::{CargoTomlContents, DependencyRawValue},
     cli::BuildArgs,
     print_util::{print_removing_wasm_crate, print_workspace_target_dir},
     tools::{check_tools_installed, find_current_workspace},
@@ -71,11 +71,26 @@ impl MetaConfig {
         let main_cargo_toml_contents =
             CargoTomlContents::load_from_file(Path::new("..").join("Cargo.toml"));
         let crate_name = main_cargo_toml_contents.package_name();
+        let workspace_cargo_toml_contents = find_current_workspace().map(|workspace_path| {
+            (
+                workspace_path.clone(),
+                CargoTomlContents::load_from_file(workspace_path.join("Cargo.toml")),
+            )
+        });
 
         for contract in self.sc_config.contracts.iter() {
             let mut framework_dependency = main_cargo_toml_contents
                 .dependency_raw_value(FRAMEWORK_NAME_BASE)
                 .expect("missing framework dependency in Cargo.toml");
+            if framework_dependency.workspace {
+                framework_dependency = resolve_workspace_dependency(
+                    FRAMEWORK_NAME_BASE,
+                    framework_dependency,
+                    workspace_cargo_toml_contents
+                        .as_ref()
+                        .expect("missing workspace for workspace dependency"),
+                );
+            }
             if contract.settings.std {
                 framework_dependency.features.insert("std".to_owned());
             }
@@ -206,6 +221,59 @@ fn copy_to_wasm_unmanaged_ei() {
     }
 }
 
+fn resolve_workspace_dependency(
+    crate_name: &str,
+    local_dependency: DependencyRawValue,
+    (workspace_path, workspace_cargo_toml_contents): &(PathBuf, CargoTomlContents),
+) -> DependencyRawValue {
+    let mut workspace_dependency = workspace_cargo_toml_contents
+        .workspace_dependency_raw_value(crate_name)
+        .unwrap_or_else(|| panic!("missing workspace dependency in Cargo.toml: {crate_name}"));
+    workspace_dependency
+        .features
+        .extend(local_dependency.features);
+    if let Some(path) = &mut workspace_dependency.path {
+        *path = path_relative_to_current_contract(workspace_path, path);
+    }
+    workspace_dependency
+}
+
+fn path_relative_to_current_contract(
+    workspace_path: &Path,
+    workspace_dependency_path: &Path,
+) -> PathBuf {
+    let current_dir = std::env::current_dir().expect("failed to get current directory");
+    let contract_dir = current_dir
+        .join("..")
+        .canonicalize()
+        .expect("failed to resolve contract directory");
+    let absolute_dependency_path = workspace_path
+        .join(workspace_dependency_path)
+        .canonicalize()
+        .expect("failed to resolve workspace dependency path");
+
+    path_relative_from_to(&absolute_dependency_path, &contract_dir)
+}
+
+fn path_relative_from_to(path: &Path, base: &Path) -> PathBuf {
+    let path_components: Vec<_> = path.components().collect();
+    let base_components: Vec<_> = base.components().collect();
+    let common_len = path_components
+        .iter()
+        .zip(base_components.iter())
+        .take_while(|(path_component, base_component)| path_component == base_component)
+        .count();
+
+    let mut relative_path = PathBuf::new();
+    for _ in common_len..base_components.len() {
+        relative_path.push("..");
+    }
+    for component in &path_components[common_len..] {
+        relative_path.push(component.as_os_str());
+    }
+    relative_path
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -276,6 +344,21 @@ members = [\".\"]
         assert_eq!(
             generated_contents.to_string_pretty(),
             EXPECTED_CARGO_TOML_CONTENTS.to_string()
+        );
+    }
+
+    #[test]
+    fn test_path_relative_from_to() {
+        assert_eq!(
+            super::path_relative_from_to(
+                Path::new("/repo/framework/base"),
+                Path::new("/repo/contracts/examples/adder"),
+            ),
+            Path::new("..")
+                .join("..")
+                .join("..")
+                .join("framework")
+                .join("base"),
         );
     }
 }

--- a/framework/meta-lib/src/contract/meta_config.rs
+++ b/framework/meta-lib/src/contract/meta_config.rs
@@ -80,6 +80,7 @@ impl MetaConfig {
             let mut framework_dependency = main_cargo_toml_contents
                 .dependency_raw_value(FRAMEWORK_NAME_BASE)
                 .expect("missing framework dependency in Cargo.toml");
+            framework_dependency.features.clear();
             if contract.settings.std {
                 framework_dependency.features.insert("std".to_owned());
             }

--- a/framework/meta-lib/src/contract/meta_config.rs
+++ b/framework/meta-lib/src/contract/meta_config.rs
@@ -6,7 +6,7 @@ use std::{
 use multiversx_sc::abi::ContractAbi;
 
 use crate::{
-    cargo_toml::{CargoTomlContents, DependencyRawValue},
+    cargo_toml::{CargoTomlContents, WorkspaceDependencies},
     cli::BuildArgs,
     print_util::{print_removing_wasm_crate, print_workspace_target_dir},
     tools::{check_tools_installed, find_current_workspace},
@@ -68,29 +68,18 @@ impl MetaConfig {
     /// Cargo.toml files for all wasm crates are generated from the main contract Cargo.toml,
     /// by changing the package name.
     pub fn generate_cargo_toml_for_all_wasm_crates(&mut self) {
-        let main_cargo_toml_contents =
+        let mut main_cargo_toml_contents =
             CargoTomlContents::load_from_file(Path::new("..").join("Cargo.toml"));
         let crate_name = main_cargo_toml_contents.package_name();
-        let workspace_cargo_toml_contents = find_current_workspace().map(|workspace_path| {
-            (
-                workspace_path.clone(),
-                CargoTomlContents::load_from_file(workspace_path.join("Cargo.toml")),
-            )
-        });
+        if let Some(workspace_path) = find_current_workspace() {
+            let workspace_dependencies = WorkspaceDependencies::load_from_dir(workspace_path);
+            main_cargo_toml_contents.resolve_workspace_dependencies(&workspace_dependencies);
+        }
 
         for contract in self.sc_config.contracts.iter() {
             let mut framework_dependency = main_cargo_toml_contents
                 .dependency_raw_value(FRAMEWORK_NAME_BASE)
                 .expect("missing framework dependency in Cargo.toml");
-            if framework_dependency.workspace {
-                framework_dependency = resolve_workspace_dependency(
-                    FRAMEWORK_NAME_BASE,
-                    framework_dependency,
-                    workspace_cargo_toml_contents
-                        .as_ref()
-                        .expect("missing workspace for workspace dependency"),
-                );
-            }
             if contract.settings.std {
                 framework_dependency.features.insert("std".to_owned());
             }
@@ -221,59 +210,6 @@ fn copy_to_wasm_unmanaged_ei() {
     }
 }
 
-fn resolve_workspace_dependency(
-    crate_name: &str,
-    local_dependency: DependencyRawValue,
-    (workspace_path, workspace_cargo_toml_contents): &(PathBuf, CargoTomlContents),
-) -> DependencyRawValue {
-    let mut workspace_dependency = workspace_cargo_toml_contents
-        .workspace_dependency_raw_value(crate_name)
-        .unwrap_or_else(|| panic!("missing workspace dependency in Cargo.toml: {crate_name}"));
-    workspace_dependency
-        .features
-        .extend(local_dependency.features);
-    if let Some(path) = &mut workspace_dependency.path {
-        *path = path_relative_to_current_contract(workspace_path, path);
-    }
-    workspace_dependency
-}
-
-fn path_relative_to_current_contract(
-    workspace_path: &Path,
-    workspace_dependency_path: &Path,
-) -> PathBuf {
-    let current_dir = std::env::current_dir().expect("failed to get current directory");
-    let contract_dir = current_dir
-        .join("..")
-        .canonicalize()
-        .expect("failed to resolve contract directory");
-    let absolute_dependency_path = workspace_path
-        .join(workspace_dependency_path)
-        .canonicalize()
-        .expect("failed to resolve workspace dependency path");
-
-    path_relative_from_to(&absolute_dependency_path, &contract_dir)
-}
-
-fn path_relative_from_to(path: &Path, base: &Path) -> PathBuf {
-    let path_components: Vec<_> = path.components().collect();
-    let base_components: Vec<_> = base.components().collect();
-    let common_len = path_components
-        .iter()
-        .zip(base_components.iter())
-        .take_while(|(path_component, base_component)| path_component == base_component)
-        .count();
-
-    let mut relative_path = PathBuf::new();
-    for _ in common_len..base_components.len() {
-        relative_path.push("..");
-    }
-    for component in &path_components[common_len..] {
-        relative_path.push(component.as_os_str());
-    }
-    relative_path
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -344,21 +280,6 @@ members = [\".\"]
         assert_eq!(
             generated_contents.to_string_pretty(),
             EXPECTED_CARGO_TOML_CONTENTS.to_string()
-        );
-    }
-
-    #[test]
-    fn test_path_relative_from_to() {
-        assert_eq!(
-            super::path_relative_from_to(
-                Path::new("/repo/framework/base"),
-                Path::new("/repo/contracts/examples/adder"),
-            ),
-            Path::new("..")
-                .join("..")
-                .join("..")
-                .join("framework")
-                .join("base"),
         );
     }
 }

--- a/framework/meta/src/cmd/print_util.rs
+++ b/framework/meta/src/cmd/print_util.rs
@@ -43,6 +43,9 @@ pub fn print_tree_dir_metadata(dir: &RelevantDirectory, last_version: &Framework
                 print!(" {}", version_string.red());
             };
         }
+        DependencyReference::Workspace => {
+            print!(" {}", "[workspace]".green());
+        }
         DependencyReference::GitCommit(git_reference) => {
             let git_string = format!(
                 "[git: {} rev: {}]",

--- a/framework/meta/src/cmd/template/contract_creator.rs
+++ b/framework/meta/src/cmd/template/contract_creator.rs
@@ -1,4 +1,5 @@
 use crate::{cli::TemplateArgs, version::FrameworkVersion, version_history::LAST_TEMPLATE_VERSION};
+use multiversx_sc_meta_lib::cargo_toml::WorkspaceDependencies;
 
 use super::{
     ContractCreatorTarget, RepoSource, RepoVersion, TemplateAdjuster,
@@ -77,6 +78,9 @@ impl<'a> ContractCreator<'a> {
             .unwrap_or_else(|| panic!("Unknown template {template_name}"));
 
         let metadata = template_source.metadata.clone();
+        let workspace_dependencies =
+            WorkspaceDependencies::load_from_dir(repo_source.repo_path());
+        
         ContractCreator {
             repo_source,
             template_source,
@@ -86,12 +90,14 @@ impl<'a> ContractCreator<'a> {
                 target,
                 keep_paths,
                 new_author,
+                workspace_dependencies,
             },
         }
     }
 
     pub fn create_contract(&self, args_tag: FrameworkVersion) {
         self.copy_template(args_tag);
+        self.resolve_workspace_dependencies();
         self.update_dependencies();
         self.rename_template();
     }
@@ -103,6 +109,11 @@ impl<'a> ContractCreator<'a> {
 
     pub fn update_dependencies(&self) {
         self.adjuster.update_cargo_toml_files();
+    }
+
+    pub fn resolve_workspace_dependencies(&self) {
+        self.adjuster
+            .resolve_workspace_dependencies();
     }
 
     pub fn rename_template(&self) {

--- a/framework/meta/src/cmd/template/contract_creator.rs
+++ b/framework/meta/src/cmd/template/contract_creator.rs
@@ -78,9 +78,8 @@ impl<'a> ContractCreator<'a> {
             .unwrap_or_else(|| panic!("Unknown template {template_name}"));
 
         let metadata = template_source.metadata.clone();
-        let workspace_dependencies =
-            WorkspaceDependencies::load_from_dir(repo_source.repo_path());
-        
+        let workspace_dependencies = WorkspaceDependencies::load_from_dir(repo_source.repo_path());
+
         ContractCreator {
             repo_source,
             template_source,
@@ -112,8 +111,7 @@ impl<'a> ContractCreator<'a> {
     }
 
     pub fn resolve_workspace_dependencies(&self) {
-        self.adjuster
-            .resolve_workspace_dependencies();
+        self.adjuster.resolve_workspace_dependencies();
     }
 
     pub fn rename_template(&self) {

--- a/framework/meta/src/cmd/template/template_adjuster.rs
+++ b/framework/meta/src/cmd/template/template_adjuster.rs
@@ -1,9 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::{ContractCreatorTarget, template_metadata::TemplateMetadata};
 use crate::cmd::upgrade::upgrade_common::{rename_files, replace_in_files};
 use convert_case::{Case, Casing};
-use multiversx_sc_meta_lib::cargo_toml::CargoTomlContents;
+use multiversx_sc_meta_lib::cargo_toml::{CargoTomlContents, WorkspaceDependencies};
 use ruplacer::Query;
 use toml::value::Table;
 
@@ -16,8 +16,21 @@ pub struct TemplateAdjuster {
     pub target: ContractCreatorTarget,
     pub keep_paths: bool,
     pub new_author: Option<String>,
+    pub workspace_dependencies: WorkspaceDependencies,
 }
 impl TemplateAdjuster {
+    pub fn resolve_workspace_dependencies(&self) {
+        for cargo_toml_path in self.cargo_toml_paths() {
+            if !cargo_toml_path.exists() {
+                continue;
+            }
+
+            let mut toml = CargoTomlContents::load_from_file(&cargo_toml_path);
+            toml.resolve_workspace_dependencies(&self.workspace_dependencies);
+            toml.save_to_file(&cargo_toml_path);
+        }
+    }
+
     pub fn update_cargo_toml_files(&self) {
         let author_as_str = self
             .new_author
@@ -27,6 +40,23 @@ impl TemplateAdjuster {
         self.update_cargo_toml_meta();
         self.update_cargo_toml_wasm();
         self.update_cargo_toml_interact(author_as_str);
+    }
+
+    fn cargo_toml_paths(&self) -> Vec<PathBuf> {
+        let mut paths = vec![
+            self.target.contract_dir().join(CARGO_TOML),
+            self.target.contract_dir().join("meta").join(CARGO_TOML),
+            self.target.contract_dir().join("wasm").join(CARGO_TOML),
+        ];
+        if self.metadata.has_interactor {
+            paths.push(
+                self.target
+                    .contract_dir()
+                    .join("interactor")
+                    .join(CARGO_TOML),
+            );
+        }
+        paths
     }
 
     fn update_cargo_toml_root(&self, author: String) {

--- a/framework/meta/src/folder_structure/strip_path.rs
+++ b/framework/meta/src/folder_structure/strip_path.rs
@@ -1,17 +1,18 @@
 use super::{DirectoryType, FRAMEWORK_CRATE_NAMES, RelevantDirectories, RelevantDirectory};
-use multiversx_sc_meta_lib::cargo_toml::CargoTomlContents;
+use multiversx_sc_meta_lib::cargo_toml::{CargoTomlContents, WorkspaceDependencies};
 use std::path::Path;
 
 /// Recursively finds all crates under `path` that depend on a framework crate,
-/// then removes `path = "..."` from those framework dependencies in each
+/// resolves any `workspace = true` entries using `workspace_dependencies`, then
+/// removes `path = "..."` from those framework dependencies in each
 /// `Cargo.toml`. Directories named in `ignore` are skipped during traversal.
 /// For contract crates, the `meta/` subdirectory is also processed.
-pub fn strip_path(path: &Path, ignore: &[String]) {
+pub fn strip_path(path: &Path, ignore: &[String], workspace_dependencies: &WorkspaceDependencies) {
     let dirs = RelevantDirectories::find_all(path, ignore);
 
     let mut count = 0;
     for dir in dirs.iter() {
-        if strip_framework_paths(dir) {
+        if strip_framework_paths(dir, workspace_dependencies) {
             count += 1;
         }
         // `populate_directories` stops recursing into a contract crate's children,
@@ -21,7 +22,7 @@ pub fn strip_path(path: &Path, ignore: &[String]) {
                 path: dir.meta_path(),
                 ..dir.clone()
             };
-            if strip_framework_paths(&meta_dir) {
+            if strip_framework_paths(&meta_dir, workspace_dependencies) {
                 count += 1;
             }
         }
@@ -30,19 +31,27 @@ pub fn strip_path(path: &Path, ignore: &[String]) {
     println!("Done. Stripped path from {count} Cargo.toml file(s).");
 }
 
-/// Removes `path = "..."` from framework dependencies in a directory's Cargo.toml.
+/// Resolves `workspace = true` entries, then removes `path = "..."` from
+/// framework dependencies in a directory's Cargo.toml.
 /// Returns `true` if the file was modified.
-fn strip_framework_paths(dir: &RelevantDirectory) -> bool {
+fn strip_framework_paths(
+    dir: &RelevantDirectory,
+    workspace_dependencies: &WorkspaceDependencies,
+) -> bool {
     let cargo_toml_path = dir.path.join("Cargo.toml");
     if !cargo_toml_path.is_file() {
         return false;
     }
 
     let mut cargo_toml = CargoTomlContents::load_from_file(&cargo_toml_path);
+    cargo_toml.resolve_workspace_dependencies(workspace_dependencies);
     let changed = cargo_toml.strip_dependency_paths(FRAMEWORK_CRATE_NAMES);
 
     if changed {
         println!("Stripped: {}", cargo_toml_path.display());
+        cargo_toml.save_to_file(&cargo_toml_path);
+    } else if !workspace_dependencies.is_empty() {
+        // Still save if workspace deps were resolved even if no path stripping occurred.
         cargo_toml.save_to_file(&cargo_toml_path);
     }
 

--- a/framework/meta/src/folder_structure/strip_path.rs
+++ b/framework/meta/src/folder_structure/strip_path.rs
@@ -44,16 +44,15 @@ fn strip_framework_paths(
     }
 
     let mut cargo_toml = CargoTomlContents::load_from_file(&cargo_toml_path);
-    cargo_toml.resolve_workspace_dependencies(workspace_dependencies);
-    let changed = cargo_toml.strip_dependency_paths(FRAMEWORK_CRATE_NAMES);
+    let ws_changed = cargo_toml.resolve_workspace_dependencies(workspace_dependencies);
+    let paths_stripped = cargo_toml.strip_dependency_paths(FRAMEWORK_CRATE_NAMES);
 
-    if changed {
+    if paths_stripped {
         println!("Stripped: {}", cargo_toml_path.display());
-        cargo_toml.save_to_file(&cargo_toml_path);
-    } else if !workspace_dependencies.is_empty() {
-        // Still save if workspace deps were resolved even if no path stripping occurred.
+    }
+    if ws_changed || paths_stripped {
         cargo_toml.save_to_file(&cargo_toml_path);
     }
 
-    changed
+    paths_stripped
 }

--- a/framework/meta/src/lib.rs
+++ b/framework/meta/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cmd;
 pub mod folder_structure;
 
 pub use multiversx_sc_meta_lib::abi_json;
+pub use multiversx_sc_meta_lib::cargo_toml;
 pub use multiversx_sc_meta_lib::ei;
 pub use multiversx_sc_meta_lib::ei_check_json;
 pub use multiversx_sc_meta_lib::version;

--- a/framework/meta/tests/repro_build_test.rs
+++ b/framework/meta/tests/repro_build_test.rs
@@ -20,6 +20,7 @@ use multiversx_sc_meta::{
     folder_structure::{setup_workspace, strip_path},
 };
 use multiversx_sc_meta_lib::{
+    cargo_toml::WorkspaceDependencies,
     cli::{BuildArgs, ContractCliAction},
     tools::find_current_workspace,
 };
@@ -267,7 +268,11 @@ fn setup_build_dir(workspace: &Path, build_dir: &Path, contracts: &[&str]) {
         fs::remove_dir_all(&adder_interactor).unwrap();
     }
 
-    strip_path(build_dir, &["target".to_string()]);
+    strip_path(
+        build_dir,
+        &["target".to_string()],
+        &WorkspaceDependencies::load_from_dir(workspace),
+    );
 
     for contract in contracts {
         setup_workspace(

--- a/tools/strip-path/src/main.rs
+++ b/tools/strip-path/src/main.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 fn main() {
     let root = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
     let workspace_dependencies =
-        WorkspaceDependencies::find_from_dir(&root).expect("failed to find workspace");
+        WorkspaceDependencies::find_from_dir(&root).unwrap_or_default();
     strip_path(
         Path::new(&root),
         &["target".to_string()],

--- a/tools/strip-path/src/main.rs
+++ b/tools/strip-path/src/main.rs
@@ -1,7 +1,14 @@
+use multiversx_sc_meta::cargo_toml::WorkspaceDependencies;
 use multiversx_sc_meta::folder_structure::strip_path;
 use std::path::Path;
 
 fn main() {
     let root = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
-    strip_path(Path::new(&root), &["target".to_string()]);
+    let workspace_dependencies =
+        WorkspaceDependencies::find_from_dir(&root).expect("failed to find workspace");
+    strip_path(
+        Path::new(&root),
+        &["target".to_string()],
+        &workspace_dependencies,
+    );
 }

--- a/tools/strip-path/src/main.rs
+++ b/tools/strip-path/src/main.rs
@@ -4,8 +4,7 @@ use std::path::Path;
 
 fn main() {
     let root = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
-    let workspace_dependencies =
-        WorkspaceDependencies::find_from_dir(&root).unwrap_or_default();
+    let workspace_dependencies = WorkspaceDependencies::find_from_dir(&root).unwrap_or_default();
     strip_path(
         Path::new(&root),
         &["target".to_string()],


### PR DESCRIPTION
## Pull request overview

Adds first-class support for Cargo workspace-inherited dependencies (`workspace = true`) across the meta tooling, so manifests can be normalized/resolved before path-stripping and template generation.

**Changes:**
- Introduces `WorkspaceDependencies` in `meta-lib` and adds manifest resolution logic for `workspace = true` dependencies.
- Updates `strip_path` (and its CLI/test callers) to resolve workspace dependencies before stripping framework `path = ...` entries.
- Migrates the `adder` example crates to `workspace = true` dependencies and adds `[workspace.dependencies]` entries to the workspace root `Cargo.toml`.
