### PR TITLE
Workspace dependencies mass replace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,3 +228,7 @@ path = "framework/meta-lib"
 [workspace.dependencies.multiversx-sc-snippets]
 version = "0.66.2"
 path = "framework/snippets"
+
+[workspace.dependencies.multiversx-sc-modules]
+version = "0.66.2"
+path = "contracts/modules"

--- a/contracts/benchmarks/large-storage/Cargo.toml
+++ b/contracts/benchmarks/large-storage/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/large_storage.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/large-storage/Cargo.toml
+++ b/contracts/benchmarks/large-storage/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/large_storage.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/large-storage/meta/Cargo.toml
+++ b/contracts/benchmarks/large-storage/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/benchmarks/mappers/benchmark-common/Cargo.toml
+++ b/contracts/benchmarks/mappers/benchmark-common/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/mappers/benchmark-common/Cargo.toml
+++ b/contracts/benchmarks/mappers/benchmark-common/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/mappers/linked-list-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/linked-list-repeat/Cargo.toml
@@ -16,5 +16,4 @@ path = "../benchmark-common"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/mappers/linked-list-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/linked-list-repeat/Cargo.toml
@@ -13,8 +13,7 @@ path = "../benchmark-common"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/mappers/linked-list-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/linked-list-repeat/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/benchmarks/mappers/map-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/map-repeat/Cargo.toml
@@ -16,5 +16,4 @@ path = "../benchmark-common"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/mappers/map-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/map-repeat/Cargo.toml
@@ -13,8 +13,7 @@ path = "../benchmark-common"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/mappers/map-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/map-repeat/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/benchmarks/mappers/queue-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/queue-repeat/Cargo.toml
@@ -16,5 +16,4 @@ path = "../benchmark-common"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/mappers/queue-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/queue-repeat/Cargo.toml
@@ -13,8 +13,7 @@ path = "../benchmark-common"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/mappers/queue-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/queue-repeat/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/benchmarks/mappers/set-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/set-repeat/Cargo.toml
@@ -16,5 +16,4 @@ path = "../benchmark-common"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/mappers/set-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/set-repeat/Cargo.toml
@@ -13,8 +13,7 @@ path = "../benchmark-common"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/mappers/set-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/set-repeat/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/benchmarks/mappers/single-value-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/single-value-repeat/Cargo.toml
@@ -16,5 +16,4 @@ path = "../benchmark-common"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/mappers/single-value-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/single-value-repeat/Cargo.toml
@@ -13,8 +13,7 @@ path = "../benchmark-common"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/mappers/single-value-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/single-value-repeat/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/benchmarks/mappers/vec-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/vec-repeat/Cargo.toml
@@ -16,5 +16,4 @@ path = "../benchmark-common"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/mappers/vec-repeat/Cargo.toml
+++ b/contracts/benchmarks/mappers/vec-repeat/Cargo.toml
@@ -13,8 +13,7 @@ path = "../benchmark-common"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/mappers/vec-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/vec-repeat/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/benchmarks/send-tx-repeat/Cargo.toml
+++ b/contracts/benchmarks/send-tx-repeat/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/send_tx_repeat.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/send-tx-repeat/Cargo.toml
+++ b/contracts/benchmarks/send-tx-repeat/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/send_tx_repeat.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/send-tx-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/send-tx-repeat/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/benchmarks/str-repeat/Cargo.toml
+++ b/contracts/benchmarks/str-repeat/Cargo.toml
@@ -16,5 +16,4 @@ workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/str-repeat/Cargo.toml
+++ b/contracts/benchmarks/str-repeat/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/str_repeat.rs"
 managed-buffer-builder-cached = ["multiversx-sc/managed-buffer-builder-cached"]
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]

--- a/contracts/benchmarks/str-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/str-repeat/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/benchmarks/very-large-storage/Cargo.toml
+++ b/contracts/benchmarks/very-large-storage/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/very_large_storage.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/benchmarks/very-large-storage/Cargo.toml
+++ b/contracts/benchmarks/very-large-storage/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/very_large_storage.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/benchmarks/very-large-storage/interactor/Cargo.toml
+++ b/contracts/benchmarks/very-large-storage/interactor/Cargo.toml
@@ -16,8 +16,7 @@ path = "src/vls_interactor.rs"
 path = ".."
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/contracts/benchmarks/very-large-storage/meta/Cargo.toml
+++ b/contracts/benchmarks/very-large-storage/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/core/price-aggregator/Cargo.toml
+++ b/contracts/core/price-aggregator/Cargo.toml
@@ -19,8 +19,7 @@ edition = "2024"
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/core/price-aggregator/Cargo.toml
+++ b/contracts/core/price-aggregator/Cargo.toml
@@ -22,8 +22,7 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/core/price-aggregator/Cargo.toml
+++ b/contracts/core/price-aggregator/Cargo.toml
@@ -26,8 +26,7 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 
 [dev-dependencies]
 rand = { version = "0.10" }

--- a/contracts/core/price-aggregator/meta/Cargo.toml
+++ b/contracts/core/price-aggregator/meta/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
 version = "0.66.2"

--- a/contracts/core/price-aggregator/meta/Cargo.toml
+++ b/contracts/core/price-aggregator/meta/Cargo.toml
@@ -11,6 +11,4 @@ path = ".."
 workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/core/wegld-swap/Cargo.toml
+++ b/contracts/core/wegld-swap/Cargo.toml
@@ -23,8 +23,7 @@ path = "src/wegld.rs"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/core/wegld-swap/Cargo.toml
+++ b/contracts/core/wegld-swap/Cargo.toml
@@ -27,5 +27,4 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/core/wegld-swap/Cargo.toml
+++ b/contracts/core/wegld-swap/Cargo.toml
@@ -20,8 +20,7 @@ edition = "2024"
 path = "src/wegld.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/core/wegld-swap/meta/Cargo.toml
+++ b/contracts/core/wegld-swap/meta/Cargo.toml
@@ -14,6 +14,4 @@ path = ".."
 workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/core/wegld-swap/meta/Cargo.toml
+++ b/contracts/core/wegld-swap/meta/Cargo.toml
@@ -11,8 +11,7 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
 version = "0.66.2"

--- a/contracts/examples/bonding-curve-contract/Cargo.toml
+++ b/contracts/examples/bonding-curve-contract/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/bonding_curve_contract.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/examples/bonding-curve-contract/Cargo.toml
+++ b/contracts/examples/bonding-curve-contract/Cargo.toml
@@ -16,6 +16,5 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 

--- a/contracts/examples/bonding-curve-contract/Cargo.toml
+++ b/contracts/examples/bonding-curve-contract/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/bonding_curve_contract.rs"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/examples/bonding-curve-contract/meta/Cargo.toml
+++ b/contracts/examples/bonding-curve-contract/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/check-pause/Cargo.toml
+++ b/contracts/examples/check-pause/Cargo.toml
@@ -15,8 +15,7 @@ num-bigint = "0.4"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/examples/check-pause/Cargo.toml
+++ b/contracts/examples/check-pause/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/check_pause.rs"
 num-bigint = "0.4"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/examples/check-pause/Cargo.toml
+++ b/contracts/examples/check-pause/Cargo.toml
@@ -19,6 +19,5 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 

--- a/contracts/examples/check-pause/meta/Cargo.toml
+++ b/contracts/examples/check-pause/meta/Cargo.toml
@@ -9,6 +9,4 @@ authors = ["Alin Cruceat <alin.cruceat@multiversx.com>"]
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/crowdfunding/Cargo.toml
+++ b/contracts/examples/crowdfunding/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/crowdfunding.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/crowdfunding/Cargo.toml
+++ b/contracts/examples/crowdfunding/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/crowdfunding.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"

--- a/contracts/examples/crowdfunding/meta/Cargo.toml
+++ b/contracts/examples/crowdfunding/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/crypto-bubbles/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/crypto_bubbles.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/crypto-bubbles/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/crypto_bubbles.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/crypto-bubbles/meta/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/crypto-kitties/common/kitty/Cargo.toml
+++ b/contracts/examples/crypto-kitties/common/kitty/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../framework/base"
+workspace = true
 
 [dependencies.random]
 version = "0.0.0"

--- a/contracts/examples/crypto-kitties/common/random/Cargo.toml
+++ b/contracts/examples/crypto-kitties/common/random/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2024"
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../framework/base"
+workspace = true

--- a/contracts/examples/crypto-kitties/kitty-auction/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-auction/Cargo.toml
@@ -17,8 +17,7 @@ version = "0.0.0"
 path = "../kitty-ownership"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/crypto-kitties/kitty-auction/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-auction/Cargo.toml
@@ -20,5 +20,4 @@ path = "../kitty-ownership"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/examples/crypto-kitties/kitty-auction/meta/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-auction/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/Cargo.toml
@@ -18,8 +18,7 @@ version = "0.0.0"
 path = "../common/random"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/Cargo.toml
@@ -21,5 +21,4 @@ path = "../common/random"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/meta/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/crypto-kitties/kitty-ownership/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-ownership/Cargo.toml
@@ -24,5 +24,4 @@ path = "../kitty-genetic-alg"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/examples/crypto-kitties/kitty-ownership/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-ownership/Cargo.toml
@@ -21,8 +21,7 @@ version = "0.0.0"
 path = "../kitty-genetic-alg"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/crypto-kitties/kitty-ownership/meta/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-ownership/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/crypto-zombies/Cargo.toml
+++ b/contracts/examples/crypto-zombies/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/crypto-zombies/Cargo.toml
+++ b/contracts/examples/crypto-zombies/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/crypto-zombies/meta/Cargo.toml
+++ b/contracts/examples/crypto-zombies/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/digital-cash/Cargo.toml
+++ b/contracts/examples/digital-cash/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/digital_cash.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/digital-cash/Cargo.toml
+++ b/contracts/examples/digital-cash/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/digital_cash.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/digital-cash/meta/Cargo.toml
+++ b/contracts/examples/digital-cash/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/empty/Cargo.toml
+++ b/contracts/examples/empty/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/empty.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/empty/Cargo.toml
+++ b/contracts/examples/empty/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/empty.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 
 [dev-dependencies]
 num-bigint = "0.4"

--- a/contracts/examples/empty/meta/Cargo.toml
+++ b/contracts/examples/empty/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/esdt-transfer-with-fee/Cargo.toml
+++ b/contracts/examples/esdt-transfer-with-fee/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/esdt_transfer_with_fee.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/esdt-transfer-with-fee/Cargo.toml
+++ b/contracts/examples/esdt-transfer-with-fee/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/esdt_transfer_with_fee.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/esdt-transfer-with-fee/meta/Cargo.toml
+++ b/contracts/examples/esdt-transfer-with-fee/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/factorial/Cargo.toml
+++ b/contracts/examples/factorial/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/factorial.rs"
 compiled-sc-tests = ["multiversx-sc-scenario/compiled-sc-tests"]
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/factorial/Cargo.toml
+++ b/contracts/examples/factorial/Cargo.toml
@@ -15,6 +15,5 @@ compiled-sc-tests = ["multiversx-sc-scenario/compiled-sc-tests"]
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"

--- a/contracts/examples/factorial/meta/Cargo.toml
+++ b/contracts/examples/factorial/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/fractional-nfts/Cargo.toml
+++ b/contracts/examples/fractional-nfts/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/fractional_nfts.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/examples/fractional-nfts/Cargo.toml
+++ b/contracts/examples/fractional-nfts/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/fractional_nfts.rs"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/examples/fractional-nfts/Cargo.toml
+++ b/contracts/examples/fractional-nfts/Cargo.toml
@@ -16,5 +16,4 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/fractional-nfts/meta/Cargo.toml
+++ b/contracts/examples/fractional-nfts/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/lottery/Cargo.toml
+++ b/contracts/examples/lottery/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lottery.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/lottery/Cargo.toml
+++ b/contracts/examples/lottery/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/lottery.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/lottery/meta/Cargo.toml
+++ b/contracts/examples/lottery/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/multisig/Cargo.toml
+++ b/contracts/examples/multisig/Cargo.toml
@@ -16,6 +16,5 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"

--- a/contracts/examples/multisig/Cargo.toml
+++ b/contracts/examples/multisig/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/multisig.rs"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/examples/multisig/Cargo.toml
+++ b/contracts/examples/multisig/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/multisig.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/examples/multisig/interact/Cargo.toml
+++ b/contracts/examples/multisig/interact/Cargo.toml
@@ -31,5 +31,4 @@ version = "=0.66.2"
 path = "../../../../framework/scenario"
 
 [dependencies.multiversx-sc]
-version = "=0.66.2"
-path = "../../../../framework/base"
+workspace = true

--- a/contracts/examples/multisig/interact/Cargo.toml
+++ b/contracts/examples/multisig/interact/Cargo.toml
@@ -27,8 +27,7 @@ version = "0.66.2"
 path = "../../../../framework/snippets"
 
 [dependencies.multiversx-sc-scenario]
-version = "=0.66.2"
-path = "../../../../framework/scenario"
+workspace = true
 
 [dependencies.multiversx-sc]
 workspace = true

--- a/contracts/examples/multisig/interact/Cargo.toml
+++ b/contracts/examples/multisig/interact/Cargo.toml
@@ -23,8 +23,7 @@ version = "0.66.2"
 path = "../../../../contracts/modules"
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 [dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/examples/multisig/interact/Cargo.toml
+++ b/contracts/examples/multisig/interact/Cargo.toml
@@ -19,8 +19,7 @@ tokio = { version = "1.24" }
 path = ".."
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../../contracts/modules"
+workspace = true
 
 [dependencies.multiversx-sc-snippets]
 workspace = true

--- a/contracts/examples/multisig/meta/Cargo.toml
+++ b/contracts/examples/multisig/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/nft-minter/Cargo.toml
+++ b/contracts/examples/nft-minter/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/nft-minter/Cargo.toml
+++ b/contracts/examples/nft-minter/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/nft-minter/meta/Cargo.toml
+++ b/contracts/examples/nft-minter/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/nft-storage-prepay/Cargo.toml
+++ b/contracts/examples/nft-storage-prepay/Cargo.toml
@@ -13,5 +13,4 @@ path = "src/nft_storage_prepay.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/nft-storage-prepay/Cargo.toml
+++ b/contracts/examples/nft-storage-prepay/Cargo.toml
@@ -10,8 +10,7 @@ path = "src/nft_storage_prepay.rs"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/nft-storage-prepay/meta/Cargo.toml
+++ b/contracts/examples/nft-storage-prepay/meta/Cargo.toml
@@ -11,6 +11,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/nft-subscription/Cargo.toml
+++ b/contracts/examples/nft-subscription/Cargo.toml
@@ -16,5 +16,4 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/nft-subscription/Cargo.toml
+++ b/contracts/examples/nft-subscription/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/examples/nft-subscription/Cargo.toml
+++ b/contracts/examples/nft-subscription/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/examples/nft-subscription/meta/Cargo.toml
+++ b/contracts/examples/nft-subscription/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/order-book/factory/Cargo.toml
+++ b/contracts/examples/order-book/factory/Cargo.toml
@@ -11,6 +11,5 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true
 

--- a/contracts/examples/order-book/factory/Cargo.toml
+++ b/contracts/examples/order-book/factory/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/order-book/factory/meta/Cargo.toml
+++ b/contracts/examples/order-book/factory/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/order-book/pair/Cargo.toml
+++ b/contracts/examples/order-book/pair/Cargo.toml
@@ -11,5 +11,4 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/examples/order-book/pair/Cargo.toml
+++ b/contracts/examples/order-book/pair/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/order-book/pair/meta/Cargo.toml
+++ b/contracts/examples/order-book/pair/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/ping-pong-egld/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/ping_pong.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/ping-pong-egld/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/ping_pong.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"
 

--- a/contracts/examples/ping-pong-egld/interactor/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/interactor/Cargo.toml
@@ -25,8 +25,7 @@ serial_test = "3.2"
 path = ".."
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 [features]
 chain-simulator-tests = []

--- a/contracts/examples/ping-pong-egld/meta/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/proxy-pause/Cargo.toml
+++ b/contracts/examples/proxy-pause/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/proxy_pause.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 
 [dev-dependencies.check-pause]
 path = "../check-pause"

--- a/contracts/examples/proxy-pause/Cargo.toml
+++ b/contracts/examples/proxy-pause/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/proxy_pause.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/proxy-pause/meta/Cargo.toml
+++ b/contracts/examples/proxy-pause/meta/Cargo.toml
@@ -11,6 +11,4 @@ authors = ["you"]
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/rewards-distribution/Cargo.toml
+++ b/contracts/examples/rewards-distribution/Cargo.toml
@@ -16,5 +16,4 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/rewards-distribution/Cargo.toml
+++ b/contracts/examples/rewards-distribution/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/rewards_distribution.rs"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/examples/rewards-distribution/Cargo.toml
+++ b/contracts/examples/rewards-distribution/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/rewards_distribution.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/examples/rewards-distribution/meta/Cargo.toml
+++ b/contracts/examples/rewards-distribution/meta/Cargo.toml
@@ -11,6 +11,4 @@ authors = ["Claudiu-Marcel Bruda <claudiu.bruda@multiversx.com>"]
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/seed-nft-minter/Cargo.toml
+++ b/contracts/examples/seed-nft-minter/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/seed_nft_minter.rs"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/examples/seed-nft-minter/Cargo.toml
+++ b/contracts/examples/seed-nft-minter/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/seed_nft_minter.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/examples/seed-nft-minter/Cargo.toml
+++ b/contracts/examples/seed-nft-minter/Cargo.toml
@@ -16,5 +16,4 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/examples/seed-nft-minter/meta/Cargo.toml
+++ b/contracts/examples/seed-nft-minter/meta/Cargo.toml
@@ -11,6 +11,4 @@ authors = ["Claudiu-Marcel Bruda <claudiu.bruda@multiversx.com>"]
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/examples/token-release/Cargo.toml
+++ b/contracts/examples/token-release/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/token_release.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/examples/token-release/Cargo.toml
+++ b/contracts/examples/token-release/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/token_release.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 

--- a/contracts/examples/token-release/meta/Cargo.toml
+++ b/contracts/examples/token-release/meta/Cargo.toml
@@ -10,6 +10,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/abi-tester/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/Cargo.toml
@@ -17,8 +17,7 @@ version = "0.66.2"
 path = "../../../framework/scenario"
 
 [dev-dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../framework/meta-lib"
+workspace = true
 
 [dependencies]
 bitflags = "2.9"

--- a/contracts/feature-tests/abi-tester/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/Cargo.toml
@@ -13,8 +13,7 @@ workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 
 [dev-dependencies.multiversx-sc-meta-lib]
 workspace = true

--- a/contracts/feature-tests/abi-tester/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/abi_tester.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]

--- a/contracts/feature-tests/abi-tester/meta/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/alloc-features/Cargo.toml
+++ b/contracts/feature-tests/alloc-features/Cargo.toml
@@ -13,6 +13,5 @@ workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"

--- a/contracts/feature-tests/alloc-features/Cargo.toml
+++ b/contracts/feature-tests/alloc-features/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/alloc_features_main.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]

--- a/contracts/feature-tests/alloc-features/meta/Cargo.toml
+++ b/contracts/feature-tests/alloc-features/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/basic-features/Cargo.toml
+++ b/contracts/feature-tests/basic-features/Cargo.toml
@@ -16,14 +16,12 @@ workspace = true
 
 # BLS doesn't currently work on Windows
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental", "bls"]
-path = "../../../framework/scenario"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/feature-tests/basic-features/Cargo.toml
+++ b/contracts/feature-tests/basic-features/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/basic_features_main.rs"
 small-int-bug = ["multiversx-sc/small-int-bug"]
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 # BLS doesn't currently work on Windows
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies.multiversx-sc-scenario]

--- a/contracts/feature-tests/basic-features/Cargo.toml
+++ b/contracts/feature-tests/basic-features/Cargo.toml
@@ -24,8 +24,7 @@ workspace = true
 features = ["wasmer-experimental"]
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.esdt-system-sc-mock]
 path = "../esdt-system-sc-mock"

--- a/contracts/feature-tests/basic-features/interact/Cargo.toml
+++ b/contracts/feature-tests/basic-features/interact/Cargo.toml
@@ -26,8 +26,7 @@ serial_test = "3.2"
 path = ".."
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 [features]
 chain-simulator-tests = []

--- a/contracts/feature-tests/basic-features/meta/Cargo.toml
+++ b/contracts/feature-tests/basic-features/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/big-float-features/Cargo.toml
+++ b/contracts/feature-tests/big-float-features/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/big_float_main.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/big-float-features/Cargo.toml
+++ b/contracts/feature-tests/big-float-features/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/big_float_main.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"

--- a/contracts/feature-tests/big-float-features/meta/Cargo.toml
+++ b/contracts/feature-tests/big-float-features/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/Cargo.toml
+++ b/contracts/feature-tests/composability/Cargo.toml
@@ -36,8 +36,7 @@ path = "recursive-caller"
 path = "vault"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/Cargo.toml
+++ b/contracts/feature-tests/composability/Cargo.toml
@@ -39,6 +39,5 @@ path = "vault"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 features = ["wasmer-experimental"]

--- a/contracts/feature-tests/composability/builtin-func-features/Cargo.toml
+++ b/contracts/feature-tests/composability/builtin-func-features/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/builtin_func_features.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/builtin-func-features/Cargo.toml
+++ b/contracts/feature-tests/composability/builtin-func-features/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/builtin_func_features.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/builtin-func-features/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/builtin-func-features/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/esdt-contract-pair/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/Cargo.toml
@@ -12,8 +12,7 @@ path = "first-contract"
 path = "second-contract"
 
 [dev-dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/esdt-contract-pair/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/Cargo.toml
@@ -15,5 +15,4 @@ path = "second-contract"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../../framework/scenario"
+workspace = true
 

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/meta/Cargo.toml
@@ -11,6 +11,4 @@ path = ".."
 workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/meta/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/Cargo.toml
@@ -13,6 +13,5 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../../framework/scenario"
+workspace = true
 

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/Cargo.toml
@@ -10,8 +10,7 @@ path = "src/lib.rs"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/meta/Cargo.toml
@@ -11,6 +11,4 @@ path = ".."
 workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/meta/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/Cargo.toml
@@ -19,5 +19,4 @@ path = "child"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/Cargo.toml
@@ -16,8 +16,7 @@ path = "parent"
 path = "child"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/Cargo.toml
@@ -13,5 +13,4 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/Cargo.toml
@@ -10,8 +10,7 @@ path = "src/lib.rs"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/meta/Cargo.toml
@@ -11,6 +11,4 @@ path = ".."
 workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/meta/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../../framework/scenario"
+workspace = true
 

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/meta/Cargo.toml
@@ -11,6 +11,4 @@ path = ".."
 workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/meta/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-meta-lib]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/forwarder-blind/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-blind/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/forwarder_blind.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/forwarder-blind/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-blind/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/forwarder_blind.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/forwarder-blind/dex-interactor/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-blind/dex-interactor/Cargo.toml
@@ -20,8 +20,7 @@ version = "0.66.2"
 path = "../../../../../framework/snippets"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../../framework/base"
+workspace = true
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/contracts/feature-tests/composability/forwarder-blind/dex-interactor/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-blind/dex-interactor/Cargo.toml
@@ -16,8 +16,7 @@ path = "src/dex_interactor.rs"
 path = ".."
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../../framework/snippets"
+workspace = true
 
 [dependencies.multiversx-sc]
 workspace = true

--- a/contracts/feature-tests/composability/forwarder-blind/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-blind/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/forwarder-interactor/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-interactor/Cargo.toml
@@ -16,8 +16,7 @@ path = "src/interact.rs"
 path = "../forwarder"
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 [dependencies.multiversx-sc]
 workspace = true

--- a/contracts/feature-tests/composability/forwarder-interactor/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-interactor/Cargo.toml
@@ -20,8 +20,7 @@ version = "0.66.2"
 path = "../../../../framework/snippets"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/contracts/feature-tests/composability/forwarder-legacy/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-legacy/Cargo.toml
@@ -15,6 +15,5 @@ path = "../vault"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true
 

--- a/contracts/feature-tests/composability/forwarder-legacy/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-legacy/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/forwarder_legacy_main.rs"
 path = "../vault"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/forwarder-legacy/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-legacy/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/forwarder-raw/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-raw/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/forwarder_raw.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/forwarder-raw/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-raw/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/forwarder_raw.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/forwarder-raw/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-raw/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/forwarder/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/forwarder_main.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/forwarder/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/forwarder_main.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true
 

--- a/contracts/feature-tests/composability/forwarder/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/local-esdt-and-nft/Cargo.toml
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/Cargo.toml
@@ -13,5 +13,4 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/local-esdt-and-nft/Cargo.toml
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/Cargo.toml
@@ -10,8 +10,7 @@ path = "src/lib.rs"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/local-esdt-and-nft/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/mesh-interactor/Cargo.toml
+++ b/contracts/feature-tests/composability/mesh-interactor/Cargo.toml
@@ -16,8 +16,7 @@ tokio = { version = "1.24" }
 toml = "1.0"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-snippets]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/mesh-interactor/Cargo.toml
+++ b/contracts/feature-tests/composability/mesh-interactor/Cargo.toml
@@ -19,8 +19,7 @@ toml = "1.0"
 workspace = true
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 [dependencies.mesh-node]
 path = "../mesh-node"

--- a/contracts/feature-tests/composability/mesh-node/Cargo.toml
+++ b/contracts/feature-tests/composability/mesh-node/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/mesh_node.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-wasm-adapter]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/mesh-node/Cargo.toml
+++ b/contracts/feature-tests/composability/mesh-node/Cargo.toml
@@ -17,5 +17,4 @@ path = "../../../../framework/wasm-adapter"
 optional = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/mesh-node/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/mesh-node/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/proxy-test-first/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-first/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/proxy-test-first.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]

--- a/contracts/feature-tests/composability/proxy-test-first/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-first/Cargo.toml
@@ -13,5 +13,4 @@ workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/proxy-test-first/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-first/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/proxy-test-second/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-second/Cargo.toml
@@ -13,5 +13,4 @@ workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/proxy-test-second/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-second/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/proxy-test-second.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]

--- a/contracts/feature-tests/composability/proxy-test-second/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-second/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/recursive-caller/Cargo.toml
+++ b/contracts/feature-tests/composability/recursive-caller/Cargo.toml
@@ -15,5 +15,4 @@ path = "../vault"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/recursive-caller/Cargo.toml
+++ b/contracts/feature-tests/composability/recursive-caller/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/recursive_caller.rs"
 path = "../vault"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/recursive-caller/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/recursive-caller/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/transfer-role-features/Cargo.toml
+++ b/contracts/feature-tests/composability/transfer-role-features/Cargo.toml
@@ -15,8 +15,7 @@ path = "../vault"
 workspace = true
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../../contracts/modules"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 workspace = true

--- a/contracts/feature-tests/composability/transfer-role-features/Cargo.toml
+++ b/contracts/feature-tests/composability/transfer-role-features/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/lib.rs"
 path = "../vault"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-modules]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/transfer-role-features/Cargo.toml
+++ b/contracts/feature-tests/composability/transfer-role-features/Cargo.toml
@@ -19,5 +19,4 @@ version = "0.66.2"
 path = "../../../../contracts/modules"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/transfer-role-features/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/transfer-role-features/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/composability/vault/Cargo.toml
+++ b/contracts/feature-tests/composability/vault/Cargo.toml
@@ -10,8 +10,7 @@ path = "src/vault.rs"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/composability/vault/Cargo.toml
+++ b/contracts/feature-tests/composability/vault/Cargo.toml
@@ -13,5 +13,4 @@ path = "src/vault.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/composability/vault/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/vault/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/crowdfunding_erc20.rs"
 path = "../erc20"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/Cargo.toml
@@ -15,6 +15,5 @@ path = "../erc20"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true
 

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/Cargo.toml
@@ -17,5 +17,4 @@ workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/Cargo.toml
@@ -13,8 +13,7 @@ path = "src/lib.rs"
 path = "../erc1155"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true
 

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/erc1155/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/Cargo.toml
@@ -13,8 +13,7 @@ workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true
 
 [dev-dependencies.erc1155-user-mock]
 path="../erc1155-user-mock"

--- a/contracts/feature-tests/erc-style-contracts/erc1155/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/erc1155.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]

--- a/contracts/feature-tests/erc-style-contracts/erc1155/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/erc20/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc20/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/erc20.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/erc20/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc20/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/erc20.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/erc-style-contracts/erc20/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc20/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/erc721/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc721/Cargo.toml
@@ -10,8 +10,7 @@ path = "src/erc721.rs"
 
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/erc-style-contracts/erc721/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc721/Cargo.toml
@@ -13,5 +13,4 @@ path = "src/erc721.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/erc721/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc721/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/lottery.rs"
 path = "../erc20"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../../framework/base"
+workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/Cargo.toml
@@ -16,5 +16,4 @@ workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/esdt-system-sc-mock/Cargo.toml
+++ b/contracts/feature-tests/esdt-system-sc-mock/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/esdt_system_sc_mock.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/esdt-system-sc-mock/Cargo.toml
+++ b/contracts/feature-tests/esdt-system-sc-mock/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/esdt_system_sc_mock.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/esdt-system-sc-mock/meta/Cargo.toml
+++ b/contracts/feature-tests/esdt-system-sc-mock/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/exchange-features/Cargo.toml
+++ b/contracts/feature-tests/exchange-features/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/exchange_features.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/exchange-features/Cargo.toml
+++ b/contracts/feature-tests/exchange-features/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/exchange_features.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/exchange-features/meta/Cargo.toml
+++ b/contracts/feature-tests/exchange-features/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/formatted-message-features/Cargo.toml
+++ b/contracts/feature-tests/formatted-message-features/Cargo.toml
@@ -13,6 +13,5 @@ workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"

--- a/contracts/feature-tests/formatted-message-features/Cargo.toml
+++ b/contracts/feature-tests/formatted-message-features/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/formatted_message_features.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]

--- a/contracts/feature-tests/formatted-message-features/meta/Cargo.toml
+++ b/contracts/feature-tests/formatted-message-features/meta/Cargo.toml
@@ -11,6 +11,4 @@ authors = ["you"]
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/gas-tests/Cargo.lock
+++ b/contracts/feature-tests/gas-tests/Cargo.lock
@@ -101,21 +101,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -131,6 +131,12 @@ dependencies = [
  "rustc-demangle",
  "windows-link",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -150,7 +156,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -160,8 +166,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -172,15 +178,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -208,18 +214,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -263,7 +269,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -274,18 +280,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -305,9 +311,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -356,7 +362,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -421,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "corosensei"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c54787b605c7df106ceccf798df23da4f2e09918defad66705d1cedf3bb914f"
+checksum = "6886a0c0f263965933c438626e7179139a62b978a33aa18281cbf0cd5a975f34"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -536,7 +542,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -559,7 +565,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -570,7 +576,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -605,7 +611,7 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -627,7 +633,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -648,7 +654,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
@@ -695,13 +701,13 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36219658beb39702975c707dee7895943ca281ca46eebbc5ea395171b9c182b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "lazy_static",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -724,7 +730,7 @@ dependencies = [
  "byteorder",
  "dynasm 4.0.2",
  "fnv",
- "memmap2 0.9.10",
+ "memmap2 0.9.11",
 ]
 
 [[package]]
@@ -801,7 +807,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -872,12 +878,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -933,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
  "rustversion",
  "typenum",
@@ -956,16 +956,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1020,20 +1018,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
@@ -1074,12 +1063,6 @@ checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1142,13 +1125,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1170,9 +1152,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -1208,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -1244,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loupe"
@@ -1291,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -1315,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -1364,11 +1346,13 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "multiversx-chain-core"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
+ "base64",
  "bech32",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "blake2",
+ "ed25519-dalek",
  "hex",
  "multiversx-sc-codec",
  "serde",
@@ -1378,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "multiversx-chain-scenario-format"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bech32",
  "hex",
@@ -1391,12 +1375,11 @@ dependencies = [
 
 [[package]]
 name = "multiversx-chain-vm"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "colored",
- "ed25519-dalek",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -1462,10 +1445,10 @@ dependencies = [
 
 [[package]]
 name = "multiversx-sc"
-version = "0.65.1"
+version = "0.66.2"
 dependencies = [
- "bitflags 2.11.1",
- "generic-array 1.4.1",
+ "bitflags 2.13.0",
+ "generic-array 1.4.3",
  "multiversx-chain-core",
  "multiversx-sc-codec",
  "multiversx-sc-derive",
@@ -1478,7 +1461,7 @@ name = "multiversx-sc-codec"
 version = "0.25.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "multiversx-sc-codec-derive",
  "num-bigint",
  "num-traits",
@@ -1492,23 +1475,23 @@ dependencies = [
  "hex",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "multiversx-sc-derive"
-version = "0.65.1"
+version = "0.66.2"
 dependencies = [
  "hex",
  "proc-macro2",
  "quote",
  "radix_trie",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "multiversx-sc-meta-lib"
-version = "0.65.1"
+version = "0.66.2"
 dependencies = [
  "clap",
  "colored",
@@ -1529,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "multiversx-sc-scenario"
-version = "0.65.1"
+version = "0.66.2"
 dependencies = [
  "colored",
  "hex",
@@ -1567,7 +1550,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1718,7 +1701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1764,7 +1747,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1813,14 +1796,14 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1863,7 +1846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -1923,7 +1906,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1939,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1962,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "region"
@@ -2052,7 +2035,7 @@ checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2082,7 +2065,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2095,7 +2078,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2191,14 +2174,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2266,6 +2249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,9 +2289,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spki"
@@ -2357,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2396,7 +2385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -2437,7 +2426,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2448,7 +2437,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2525,7 +2514,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2549,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2561,9 +2550,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -2591,9 +2580,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2612,28 +2601,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2644,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2654,56 +2625,34 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.244.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.249.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69830ccbbf41c55eb585991659fb70867ef628193af3a495f09a6956f7615e59"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.249.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -3042,19 +2991,7 @@ version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
 dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3063,11 +3000,22 @@ version = "0.249.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30538cae9a794215f490b532df01c557e2e2bfac92569482554acd0992a102ea"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags 2.13.0",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -3083,22 +3031,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "249.0.0"
+version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474a321bf9ae2808e9fa23ac4ec2b27300e70985e30bcb5a38d43b76bfc901a"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.249.0",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
-version = "1.249.0"
+version = "1.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28af699d0a9c7e4e250b7b8e36167ae5215fbb4b7ae526bb4ce7b234ba0afc90"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
 dependencies = [
  "wast",
 ]
@@ -3316,100 +3264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,29 +3290,29 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/contracts/feature-tests/gas-tests/Cargo.toml
+++ b/contracts/feature-tests/gas-tests/Cargo.toml
@@ -8,10 +8,12 @@ publish = false
 path = "src/gas_tests.rs"
 
 [dependencies.multiversx-sc]
-workspace = true
+version = "0.66.2"
+path = "../../../framework/base"
 
 [dev-dependencies.multiversx-sc-scenario]
-workspace = true
+version = "0.66.2"
+path = "../../../framework/scenario"
 
 [dependencies.multiversx-chain-vm-wasmer-prod]
 path = "../../../chain/wasmer-prod"

--- a/contracts/feature-tests/gas-tests/Cargo.toml
+++ b/contracts/feature-tests/gas-tests/Cargo.toml
@@ -11,8 +11,7 @@ path = "src/gas_tests.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 
 [dependencies.multiversx-chain-vm-wasmer-prod]
 path = "../../../chain/wasmer-prod"

--- a/contracts/feature-tests/gas-tests/Cargo.toml
+++ b/contracts/feature-tests/gas-tests/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 path = "src/gas_tests.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/multi-contract-features/Cargo.toml
+++ b/contracts/feature-tests/multi-contract-features/Cargo.toml
@@ -15,5 +15,4 @@ example_feature = []
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/multi-contract-features/Cargo.toml
+++ b/contracts/feature-tests/multi-contract-features/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/multi_contract_features.rs"
 example_feature = []
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/multi-contract-features/meta/Cargo.toml
+++ b/contracts/feature-tests/multi-contract-features/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/panic-message-features/Cargo.toml
+++ b/contracts/feature-tests/panic-message-features/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/panic_features.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/panic-message-features/Cargo.toml
+++ b/contracts/feature-tests/panic-message-features/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/panic_features.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"

--- a/contracts/feature-tests/panic-message-features/meta/Cargo.toml
+++ b/contracts/feature-tests/panic-message-features/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/payable-features/Cargo.toml
+++ b/contracts/feature-tests/payable-features/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/payable_features.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/payable-features/Cargo.toml
+++ b/contracts/feature-tests/payable-features/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/payable_features.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"

--- a/contracts/feature-tests/payable-features/interactor/Cargo.toml
+++ b/contracts/feature-tests/payable-features/interactor/Cargo.toml
@@ -16,8 +16,7 @@ path = "src/payable_interactor.rs"
 path = ".."
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/contracts/feature-tests/payable-features/meta/Cargo.toml
+++ b/contracts/feature-tests/payable-features/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/rust-snippets-generator-test/Cargo.toml
+++ b/contracts/feature-tests/rust-snippets-generator-test/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/rust-snippets-generator-test/Cargo.toml
+++ b/contracts/feature-tests/rust-snippets-generator-test/Cargo.toml
@@ -12,5 +12,4 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true

--- a/contracts/feature-tests/rust-snippets-generator-test/interact-rs/Cargo.toml
+++ b/contracts/feature-tests/rust-snippets-generator-test/interact-rs/Cargo.toml
@@ -13,8 +13,7 @@ path = "src/interactor_main.rs"
 path = ".."
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 # [workspace]
 

--- a/contracts/feature-tests/rust-snippets-generator-test/meta/Cargo.toml
+++ b/contracts/feature-tests/rust-snippets-generator-test/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/rust-testing-framework-tester/Cargo.toml
+++ b/contracts/feature-tests/rust-testing-framework-tester/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2024"
 publish = false
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 features = [ "alloc" ]
 
 [dev-dependencies.adder]

--- a/contracts/feature-tests/rust-testing-framework-tester/Cargo.toml
+++ b/contracts/feature-tests/rust-testing-framework-tester/Cargo.toml
@@ -16,8 +16,7 @@ path = "../../examples/adder"
 path = "../../feature-tests/basic-features"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 
 [dev-dependencies]
 num-bigint = "0.4"

--- a/contracts/feature-tests/rust-testing-framework-tester/meta/Cargo.toml
+++ b/contracts/feature-tests/rust-testing-framework-tester/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/scenario-tester/Cargo.toml
+++ b/contracts/feature-tests/scenario-tester/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/scenario-tester/Cargo.toml
+++ b/contracts/feature-tests/scenario-tester/Cargo.toml
@@ -12,6 +12,5 @@ path = "src/lib.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental", "bls"]
-path = "../../../framework/scenario"

--- a/contracts/feature-tests/scenario-tester/meta/Cargo.toml
+++ b/contracts/feature-tests/scenario-tester/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/std-contract/Cargo.toml
+++ b/contracts/feature-tests/std-contract/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/std_contract.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/std-contract/Cargo.toml
+++ b/contracts/feature-tests/std-contract/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/std_contract.rs"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 
 [dev-dependencies]
 num-bigint = "0.4"

--- a/contracts/feature-tests/std-contract/meta/Cargo.toml
+++ b/contracts/feature-tests/std-contract/meta/Cargo.toml
@@ -8,6 +8,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/feature-tests/tiny/Cargo.toml
+++ b/contracts/feature-tests/tiny/Cargo.toml
@@ -8,6 +8,5 @@ publish = false
 path = "src/lib.rs"
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 features = ["wasmer-experimental"]

--- a/contracts/feature-tests/tiny/interactor/Cargo.toml
+++ b/contracts/feature-tests/tiny/interactor/Cargo.toml
@@ -13,8 +13,7 @@ path = "src/tiny_interactor_main.rs"
 path = "src/tiny_interactor.rs"
 
 [dependencies.multiversx-sc-snippets]
-version = "0.66.2"
-path = "../../../../framework/snippets"
+workspace = true
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/contracts/feature-tests/use-module/Cargo.toml
+++ b/contracts/feature-tests/use-module/Cargo.toml
@@ -21,5 +21,4 @@ features = ["wasmer-experimental"]
 path = "../../../framework/scenario"
 
 [dev-dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../framework/meta-lib"
+workspace = true

--- a/contracts/feature-tests/use-module/Cargo.toml
+++ b/contracts/feature-tests/use-module/Cargo.toml
@@ -13,8 +13,7 @@ version = "0.66.2"
 path = "../../../contracts/modules"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/contracts/feature-tests/use-module/Cargo.toml
+++ b/contracts/feature-tests/use-module/Cargo.toml
@@ -16,9 +16,8 @@ path = "../../../contracts/modules"
 workspace = true
 
 [dev-dependencies.multiversx-sc-scenario]
-version = "0.66.2"
+workspace = true
 features = ["wasmer-experimental"]
-path = "../../../framework/scenario"
 
 [dev-dependencies.multiversx-sc-meta-lib]
 workspace = true

--- a/contracts/feature-tests/use-module/Cargo.toml
+++ b/contracts/feature-tests/use-module/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 path = "src/use_module.rs"
 
 [dependencies.multiversx-sc-modules]
-version = "0.66.2"
-path = "../../../contracts/modules"
+workspace = true
 
 [dependencies.multiversx-sc]
 workspace = true

--- a/contracts/feature-tests/use-module/meta/Cargo.toml
+++ b/contracts/feature-tests/use-module/meta/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 path = ".."
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../../../framework/meta-lib"
-default-features = false
+workspace = true

--- a/contracts/modules/Cargo.toml
+++ b/contracts/modules/Cargo.toml
@@ -17,5 +17,4 @@ categories = ["no-std", "wasm", "cryptography::cryptocurrencies"]
 alloc = ["multiversx-sc/alloc"]
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../framework/base"
+workspace = true

--- a/data/human-readable/Cargo.toml
+++ b/data/human-readable/Cargo.toml
@@ -18,5 +18,4 @@ categories = ["cryptography::cryptocurrencies", "development-tools"]
 serde_json = { version = "1.0" }
 
 [dependencies.multiversx-sc-scenario]
-version = "=0.66.2"
-path = "../../framework/scenario"
+workspace = true

--- a/tools/cs-test-runner/Cargo.toml
+++ b/tools/cs-test-runner/Cargo.toml
@@ -10,5 +10,4 @@ name = "cs-test-runner"
 path = "src/main.rs"
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../framework/meta-lib"
+workspace = true

--- a/tools/interactor-delegation-func-calls/Cargo.toml
+++ b/tools/interactor-delegation-func-calls/Cargo.toml
@@ -24,8 +24,7 @@ version = "1.0"
 features = ["derive"]
 
 [dependencies.multiversx-sc-snippets]
-version = "=0.66.2"
-path = "../../framework/snippets"
+workspace = true
 
 [features]
 chain-simulator-tests = []

--- a/tools/interactor-governance-func-calls/Cargo.toml
+++ b/tools/interactor-governance-func-calls/Cargo.toml
@@ -24,8 +24,7 @@ version = "1.0"
 features = ["derive"]
 
 [dependencies.multiversx-sc-snippets]
-version = "=0.66.2"
-path = "../../framework/snippets"
+workspace = true
 
 [dependencies.delegation-sc-interact]
 path = "../interactor-delegation-func-calls"

--- a/tools/interactor-system-func-calls/Cargo.toml
+++ b/tools/interactor-system-func-calls/Cargo.toml
@@ -25,8 +25,7 @@ version = "1.0"
 features = ["derive"]
 
 [dependencies.multiversx-sc-snippets]
-version = "=0.66.2"
-path = "../../framework/snippets"
+workspace = true
 
 [features]
 chain-simulator-tests = []

--- a/tools/managed-mem-bench/Cargo.toml
+++ b/tools/managed-mem-bench/Cargo.toml
@@ -16,5 +16,4 @@ path = "src/bench_threading.rs"
 workspace = true
 
 [dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../framework/scenario"
+workspace = true

--- a/tools/managed-mem-bench/Cargo.toml
+++ b/tools/managed-mem-bench/Cargo.toml
@@ -13,8 +13,7 @@ name = "bench-threading"
 path = "src/bench_threading.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-scenario]
 version = "0.66.2"

--- a/tools/mxpy-snippet-generator/Cargo.toml
+++ b/tools/mxpy-snippet-generator/Cargo.toml
@@ -10,8 +10,7 @@ name = "mxpy-snippet-generator"
 path = "src/mxpy_snippet_generator.rs"
 
 [dependencies.multiversx-sc]
-version = "0.66.2"
-path = "../../framework/base"
+workspace = true
 
 [dependencies]
 bech32 = "0.11"

--- a/tools/op-test-gen/Cargo.toml
+++ b/tools/op-test-gen/Cargo.toml
@@ -17,5 +17,4 @@ num-bigint = "0.4"
 num-traits = "0.2"
 
 [dependencies.multiversx-sc-scenario]
-version = "0.66.2"
-path = "../../framework/scenario"
+workspace = true

--- a/tools/rust-debugger/format-tests/Cargo.lock
+++ b/tools/rust-debugger/format-tests/Cargo.lock
@@ -54,21 +54,27 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -84,9 +90,9 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake2"
@@ -108,18 +114,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cfg-if"
@@ -129,9 +135,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -305,7 +311,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
@@ -360,12 +366,6 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
  "rustversion",
  "typenum",
@@ -414,16 +414,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -434,20 +432,11 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
@@ -480,19 +469,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -548,23 +531,25 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "multiversx-chain-core"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
+ "base64",
  "bech32",
  "bitflags",
  "blake2",
+ "ed25519-dalek",
  "hex",
  "multiversx-sc-codec",
  "serde",
@@ -587,12 +572,11 @@ dependencies = [
 
 [[package]]
 name = "multiversx-chain-vm"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "bitflags",
  "colored",
- "ed25519-dalek",
  "hex",
  "itertools",
  "log",
@@ -617,10 +601,10 @@ dependencies = [
 
 [[package]]
 name = "multiversx-sc"
-version = "0.66.0"
+version = "0.66.2"
 dependencies = [
  "bitflags",
- "generic-array 1.4.1",
+ "generic-array 1.4.3",
  "multiversx-chain-core",
  "multiversx-sc-codec",
  "multiversx-sc-derive",
@@ -652,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "multiversx-sc-derive"
-version = "0.66.0"
+version = "0.66.2"
 dependencies = [
  "hex",
  "proc-macro2",
@@ -663,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "multiversx-sc-meta-lib"
-version = "0.66.0"
+version = "0.66.2"
 dependencies = [
  "clap",
  "colored",
@@ -684,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "multiversx-sc-scenario"
-version = "0.66.0"
+version = "0.66.2"
 dependencies = [
  "colored",
  "hex",
@@ -765,16 +749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -815,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -896,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -966,9 +940,9 @@ checksum = "69da7c8ef9e55986dcaa55dd095bbf7d321e80cc91644f25ce26a83dbe9e7f14"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spki"
@@ -1000,9 +974,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1059,9 +1033,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1071,21 +1045,15 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unwrap-infallible"
@@ -1112,65 +1080,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-encoder"
-version = "0.244.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.249.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69830ccbbf41c55eb585991659fb70867ef628193af3a495f09a6956f7615e59"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.249.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -1180,10 +1096,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30538cae9a794215f490b532df01c557e2e2bfac92569482554acd0992a102ea"
 dependencies = [
  "bitflags",
- "hashbrown 0.17.1",
+ "hashbrown",
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1199,22 +1126,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "249.0.0"
+version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474a321bf9ae2808e9fa23ac4ec2b27300e70985e30bcb5a38d43b76bfc901a"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.249.0",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
-version = "1.249.0"
+version = "1.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28af699d0a9c7e4e250b7b8e36167ae5215fbb4b7ae526bb4ce7b234ba0afc90"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
 dependencies = [
  "wast",
 ]
@@ -1250,104 +1177,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
-
-[[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/tools/rust-debugger/format-tests/Cargo.toml
+++ b/tools/rust-debugger/format-tests/Cargo.toml
@@ -9,8 +9,7 @@ name = "format-tests"
 path = "src/format_tests.rs"
 
 [dependencies.multiversx-sc]
-version = "=0.66.2"
-path = "../../../framework/base"
+workspace = true
 
 [dependencies.multiversx-sc-scenario]
 version = "=0.66.2"

--- a/tools/rust-debugger/format-tests/Cargo.toml
+++ b/tools/rust-debugger/format-tests/Cargo.toml
@@ -12,8 +12,7 @@ path = "src/format_tests.rs"
 workspace = true
 
 [dependencies.multiversx-sc-scenario]
-version = "=0.66.2"
-path = "../../../framework/scenario"
+workspace = true
 
 [dependencies.multiversx-chain-vm]
 version = "=0.23.1"

--- a/tools/rust-debugger/format-tests/Cargo.toml
+++ b/tools/rust-debugger/format-tests/Cargo.toml
@@ -9,10 +9,12 @@ name = "format-tests"
 path = "src/format_tests.rs"
 
 [dependencies.multiversx-sc]
-workspace = true
+version = "=0.66.2"
+path = "../../../framework/base"
 
 [dependencies.multiversx-sc-scenario]
-workspace = true
+version = "=0.66.2"
+path = "../../../framework/scenario"
 
 [dependencies.multiversx-chain-vm]
 version = "=0.23.1"

--- a/tools/wat-gen/Cargo.toml
+++ b/tools/wat-gen/Cargo.toml
@@ -14,5 +14,4 @@ path = "src/wat_gen_main.rs"
 wat = "1.235"
 
 [dependencies.multiversx-sc-meta-lib]
-version = "0.66.2"
-path = "../../framework/meta-lib"
+workspace = true


### PR DESCRIPTION
Using the newly supported workspace dependency feature to use the main workspace to specify framework versions and paths.