### PR TITLE
QueueMapper leak test, VM account access refactor

### DIFF
--- a/chain/vm/src/blockchain/state/account_data.rs
+++ b/chain/vm/src/blockchain/state/account_data.rs
@@ -39,6 +39,18 @@ impl AccountData {
             developer_rewards: BigUint::zero(),
         }
     }
+
+    pub fn storage_get(&self, key: &[u8]) -> Vec<u8> {
+        self.storage.get(key).cloned().unwrap_or_default()
+    }
+
+    pub fn storage_set(&mut self, key: &[u8], value: &[u8]) {
+        if value.is_empty() {
+            self.storage.remove(key);
+        } else {
+            self.storage.insert(key.to_vec(), value.to_vec());
+        }
+    }
 }
 
 impl fmt::Display for AccountData {

--- a/chain/vm/src/blockchain/state/blockchain_state.rs
+++ b/chain/vm/src/blockchain/state/blockchain_state.rs
@@ -75,16 +75,9 @@ impl BlockchainState {
             .get_mut(address)
             .unwrap_or_else(|| panic!("Account not found: {address}"));
         account.egld_balance += amount;
-        let mut storage_v_rew =
-            if let Some(old_storage_value) = account.storage.get(STORAGE_REWARD_KEY) {
-                BigUint::from_bytes_be(old_storage_value)
-            } else {
-                BigUint::zero()
-            };
+        let mut storage_v_rew = BigUint::from_bytes_be(&account.storage_get(STORAGE_REWARD_KEY));
         storage_v_rew += amount;
-        account
-            .storage
-            .insert(STORAGE_REWARD_KEY.to_vec(), storage_v_rew.to_bytes_be());
+        account.storage_set(STORAGE_REWARD_KEY, &storage_v_rew.to_bytes_be());
     }
 
     pub fn put_new_token_identifier(&mut self, token_identifier: String) {

--- a/chain/vm/src/host/vm_hooks/vh_tx_context.rs
+++ b/chain/vm/src/host/vm_hooks/vh_tx_context.rs
@@ -99,9 +99,8 @@ impl<S: InstanceState> VMHooksContext for TxVMHooksContext<S> {
     }
 
     fn storage_read_any_address(&self, address: &Address, key: &[u8]) -> Vec<u8> {
-        self.tx_context_ref.with_account_mut(address, |account| {
-            account.storage.get(key).cloned().unwrap_or_default()
-        })
+        self.tx_context_ref
+            .with_account_mut(address, |account| account.storage_get(key))
     }
 
     fn storage_write(&mut self, key: &[u8], value: &[u8]) -> Result<(), VMHooksEarlyExit> {
@@ -109,7 +108,7 @@ impl<S: InstanceState> VMHooksContext for TxVMHooksContext<S> {
         self.check_not_readonly()?;
 
         self.tx_context_ref.with_contract_account_mut(|account| {
-            account.storage.insert(key.to_vec(), value.to_vec());
+            account.storage_set(key, value);
         });
         Ok(())
     }

--- a/framework/scenario/src/api/impl_vh/vh_single_tx_api.rs
+++ b/framework/scenario/src/api/impl_vh/vh_single_tx_api.rs
@@ -92,14 +92,13 @@ impl VMHooksContext for SingleTxApiVMHooksContext {
     }
 
     fn storage_read_any_address(&self, address: &Address, key: &[u8]) -> Vec<u8> {
-        self.0.with_account_mut(address, |account| {
-            account.storage.get(key).cloned().unwrap_or_default()
-        })
+        self.0
+            .with_account_mut(address, |account| account.storage_get(key))
     }
 
     fn storage_write(&mut self, key: &[u8], value: &[u8]) -> Result<(), VMHooksEarlyExit> {
         self.0.with_account_mut(&self.0.tx_input_box.to, |account| {
-            account.storage.insert(key.to_vec(), value.to_vec());
+            account.storage_set(key, value);
         });
         Ok(())
     }

--- a/framework/scenario/src/scenario/run_vm/check_state.rs
+++ b/framework/scenario/src/scenario/run_vm/check_state.rs
@@ -78,19 +78,15 @@ fn execute(state: &BlockchainState, accounts: &CheckAccounts) {
             );
 
             if let CheckStorage::Equal(eq) = &expected_account.storage {
-                let default_value = &Vec::new();
                 for (expected_key, expected_value) in eq.storages.iter() {
-                    let actual_value = account
-                        .storage
-                        .get(&expected_key.value)
-                        .unwrap_or(default_value);
+                    let actual_value = account.storage_get(&expected_key.value);
                     assert!(
-                        expected_value.check(actual_value),
+                        expected_value.check(&actual_value),
                         "bad storage value. Address: {}. Key: {}. Want: {}. Have: {}",
                         expected_address,
                         expected_key,
                         expected_value,
-                        verbose_hex(actual_value)
+                        verbose_hex(&actual_value)
                     );
                 }
 

--- a/framework/scenario/tests/single_tx_api_test.rs
+++ b/framework/scenario/tests/single_tx_api_test.rs
@@ -17,13 +17,11 @@ fn single_tx_api_test() {
 
     // check directly in storage
     SingleTxApi::with_global_default_account(|account| {
-        let value = account.storage.get(storage_key.as_bytes()).unwrap();
-        assert_eq!(value, &vec![5u8]);
+        let value = account.storage_get(storage_key.as_bytes());
+        assert_eq!(value, vec![5u8]);
 
         // change value directly in storage
-        account
-            .storage
-            .insert(storage_key.as_bytes().to_vec(), vec![7u8]);
+        account.storage_set(storage_key.as_bytes(), &[7u8]);
     });
 
     // read again
@@ -37,11 +35,7 @@ fn single_tx_api_test() {
 
     // checking directly in storage
     SingleTxApi::with_global_default_account(|account| {
-        let value = account
-            .storage
-            .get(storage_key.as_bytes())
-            .cloned()
-            .unwrap_or_default();
+        let value = account.storage_get(storage_key.as_bytes());
         assert!(value.is_empty());
     });
 }

--- a/framework/scenario/tests/test_queue_mapper.rs
+++ b/framework/scenario/tests/test_queue_mapper.rs
@@ -100,3 +100,25 @@ fn test_queue_clear() {
     assert_eq!(queue.len(), 0);
     assert!(queue.is_empty());
 }
+
+#[test]
+fn test_queue_clear_no_info_leak() {
+    SingleTxApi::clear_global();
+
+    let mut queue = create_queue();
+    queue.push_back(1u64);
+    queue.push_back(2u64);
+    queue.push_back(3u64);
+    queue.clear();
+
+    // After clearing, the ".info" storage slot must be fully deleted (not merely
+    // reset to a default-encoded value), so no residual key should remain.
+    let info_key = b"my_queue.info".to_vec();
+    let no_residual = SingleTxApi::with_global_default_account(|account| {
+        account.storage_get(&info_key).is_empty()
+    });
+    assert!(
+        no_residual,
+        "QueueMapper::clear() left a residual '.info' storage slot"
+    );
+}


### PR DESCRIPTION
## Pull request overview

This PR tightens the scenario/VM storage access layer by introducing `AccountData::{storage_get, storage_set}` and refactoring call sites to use them, while also adding a regression test intended to ensure `QueueMapper::clear()` does not leave residual metadata in storage.

**Changes:**
- Add `AccountData::storage_get()` / `storage_set()` and switch multiple VM/scenario code paths away from direct `account.storage` map manipulation.
- Make empty writes remove the key (`storage_set(..., b"")` ⇒ `remove`) to better model “delete” semantics.
- Add a `QueueMapper::clear()` leak regression test for the `.info` slot.
